### PR TITLE
Memory usage improvements

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -19,7 +19,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_parrot.adapter import Parrot, Config, mark_only_adapter_as_trainable, adapter_state_from_state_dict
 from lit_parrot.tokenizer import Tokenizer
-from lit_parrot.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger
+from lit_parrot.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
 from lit_parrot.speed_monitor import SpeedMonitor, measure_flops, estimate_flops
 from scripts.prepare_alpaca import generate_prompt
 
@@ -164,7 +164,8 @@ def train(
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids, max_seq_length=max_seq_length)
-            loss = loss_fn(logits, targets)
+            # shift the targets such that output n predicts token n+1
+            loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:])
             fabric.backward(loss / gradient_accumulation_iters)
 
         if not is_accumulating:
@@ -215,7 +216,7 @@ def validate(
     for k in range(eval_iters):
         input_ids, targets = get_batch(fabric, val_data, max_seq_length)
         logits = model(input_ids)
-        loss = loss_fn(logits, targets)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
         losses[k] = loss.item()
     val_loss = losses.mean()
 
@@ -236,14 +237,6 @@ def validate(
 
     model.train()
     return val_loss.item()
-
-
-def loss_fn(logits, targets):
-    # shift the targets such that output n predicts token n+1
-    logits = logits[..., :-1, :].contiguous()
-    targets = targets[..., 1:].contiguous()
-    loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
-    return loss
 
 
 def get_batch(fabric: L.Fabric, data: np.ndarray, max_seq_length: int):

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -97,10 +97,13 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
 
     mark_only_adapter_as_trainable(model)
 
-    num_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
+    num_params = sum(p.numel() for p in trainable_params)
     fabric.print(f"Number of trainable parameters: {num_params}")
+    num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+    fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:
@@ -204,7 +207,7 @@ def train(
 
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+    fabric: L.Fabric, model: Parrot, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -228,6 +231,8 @@ def validate(
     )
     output = tokenizer.decode(output)
     fabric.print(output)
+
+    model.reset_cache()
 
     model.train()
     return val_loss.item()

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -103,7 +103,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -103,7 +103,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -24,7 +24,7 @@ from lit_parrot.adapter_v2 import (
     adapter_v2_state_from_state_dict,
 )
 from lit_parrot.tokenizer import Tokenizer
-from lit_parrot.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger
+from lit_parrot.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
 from lit_parrot.speed_monitor import SpeedMonitor, measure_flops, estimate_flops
 from scripts.prepare_alpaca import generate_prompt
 
@@ -170,7 +170,7 @@ def train(
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids, max_seq_length=max_seq_length)
-            loss = loss_fn(logits, targets)
+            loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:])
             fabric.backward(loss / gradient_accumulation_iters)
 
         if not is_accumulating:
@@ -221,7 +221,7 @@ def validate(
     for k in range(eval_iters):
         input_ids, targets = get_batch(fabric, val_data, max_seq_length)
         logits = model(input_ids)
-        loss = loss_fn(logits, targets)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
         losses[k] = loss.item()
     val_loss = losses.mean()
 
@@ -242,14 +242,6 @@ def validate(
 
     model.train()
     return val_loss.item()
-
-
-def loss_fn(logits, targets):
-    # shift the targets such that output n predicts token n+1
-    logits = logits[..., :-1, :].contiguous()
-    targets = targets[..., 1:].contiguous()
-    loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
-    return loss
 
 
 def get_batch(fabric: L.Fabric, data: np.ndarray, max_seq_length: int):

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -109,7 +109,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -109,7 +109,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -98,10 +98,14 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
         model.load_state_dict(checkpoint, strict=False)
 
     mark_only_lora_as_trainable(model)
-    num_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    fabric.print(f"Number of trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
+    num_params = sum(p.numel() for p in trainable_params)
+    fabric.print(f"Number of trainable parameters: {num_params}")
+    num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+    fabric.print(f"Number of non trainable parameters: {num_params}")
+
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:
@@ -204,7 +208,7 @@ def train(
 
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
+    fabric: L.Fabric, model: Parrot, val_data: np.ndarray, tokenizer: Tokenizer, max_seq_length: int
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -228,6 +232,8 @@ def validate(
     )
     output = tokenizer.decode(output)
     fabric.print(output)
+
+    model.reset_cache()
 
     model.train()
     return val_loss.item()

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -105,7 +105,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -105,7 +105,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
     fabric.print(f"Number of non trainable parameters: {num_params}")
 
-    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay, foreach=False)
+    optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)
 
     with open(data_dir / "config.json") as data_config_path:

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -119,7 +119,7 @@ def main(
     tokens_generated = y.size(0) - prompt_length
     fabric.print(f"\n\nTime for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr)
     if fabric.device.type == "cuda":
-        fabric.print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
+        fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -122,7 +122,7 @@ def main(
     tokens_generated = y.size(0) - prompt_length
     fabric.print(f"\n\nTime for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr)
     if fabric.device.type == "cuda":
-        fabric.print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
+        fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/generate/base.py
+++ b/generate/base.py
@@ -184,7 +184,7 @@ def main(
             f"Time for inference {i + 1}: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr
         )
     if fabric.device.type == "cuda":
-        fabric.print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
+        fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -127,7 +127,7 @@ def main(
     tokens_generated = y.size(0) - prompt_length
     fabric.print(f"\n\nTime for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr)
     if fabric.device.type == "cuda":
-        fabric.print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
+        fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/lit_parrot/utils.py
+++ b/lit_parrot/utils.py
@@ -438,9 +438,8 @@ def chunked_cross_entropy(logits: torch.Tensor, targets: torch.Tensor, chunk_siz
     # the memory spike's magnitude
     logit_chunks = torch.split(logits, chunk_size)
     target_chunks = torch.split(targets, chunk_size)
-    return torch.cat(
-        [
-            torch.nn.functional.cross_entropy(logit_chunk, target_chunk, ignore_index=-1, reduction="none")
-            for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
-        ]
-    ).mean()
+    loss_chunks = [
+        torch.nn.functional.cross_entropy(logit_chunk, target_chunk, ignore_index=-1, reduction="none")
+        for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
+    ]
+    return torch.cat(loss_chunks).mean()

--- a/lit_parrot/utils.py
+++ b/lit_parrot/utils.py
@@ -428,9 +428,8 @@ def step_csv_logger(*args: Any, **kwargs: Any) -> CSVLogger:
 
 
 def chunked_cross_entropy(logits: torch.Tensor, targets: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
-    # FIXME: contiguous?
-    logits = logits.view(-1, logits.size(-1))
-    targets = targets.view(-1)
+    logits = logits.reshape(-1, logits.size(-1))
+    targets = targets.reshape(-1)
     if chunk_size == 0:
         return torch.nn.functional.cross_entropy(logits, targets, ignore_index=-1)
     # with large max_sequence_lengths, the beginning of `backward` allocates a large memory chunk which can dominate

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -92,7 +92,9 @@ def main(fabric: L.Fabric) -> None:
     num_total_params = sum(p.numel() for p in model.parameters())
     fabric.print(f"Total parameters {num_total_params}")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay, betas=(beta1, beta2))
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=learning_rate, weight_decay=weight_decay, betas=(beta1, beta2), foreach=False
+    )
     model, optimizer = fabric.setup(model, optimizer)
 
     train_time = time.time()

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -18,8 +18,7 @@ sys.path.append(str(wd))
 from lit_parrot import Config
 from lit_parrot.model import Parrot, Block
 from lit_parrot.speed_monitor import SpeedMonitor, measure_flops, estimate_flops
-from lit_parrot.utils import step_csv_logger
-
+from lit_parrot.utils import step_csv_logger, chunked_cross_entropy
 
 model_name = "pythia-70m"
 name = "openwebtext"
@@ -141,9 +140,7 @@ def train(
         is_accumulating = (iter_num + 1) % gradient_accumulation_steps != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
-            loss = torch.nn.functional.cross_entropy(
-                logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1
-            )
+            loss = chunked_cross_entropy(logits, targets, chunk_size=0)
             fabric.backward(loss / gradient_accumulation_steps)
 
         if not is_accumulating:
@@ -194,7 +191,7 @@ def validate(fabric: L.Fabric, model: torch.nn.Module, val_data: np.ndarray) -> 
     for k in range(eval_iters):
         input_ids, targets = get_batch(fabric, val_data, model.config.block_size)
         logits = model(input_ids)
-        loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
         losses[k] = loss.item()
     out = losses.mean()
 

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -18,7 +18,7 @@ sys.path.append(str(wd))
 
 from lit_parrot.model import Block, Parrot, Config
 from lit_parrot.packed_dataset import PackedDataset, CombinedDataset
-from lit_parrot.utils import step_csv_logger
+from lit_parrot.utils import step_csv_logger, chunked_cross_entropy
 from lit_parrot.speed_monitor import SpeedMonitor, estimate_flops, measure_flops
 
 model_name = "pythia-70m"
@@ -176,9 +176,7 @@ def train(
         is_accumulating = (iter_num + 1) % gradient_accumulation_steps != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
-            loss = torch.nn.functional.cross_entropy(
-                logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1
-            )
+            loss = chunked_cross_entropy(logits, targets, chunk_size=0)
             fabric.backward(loss / gradient_accumulation_steps)
 
         if not is_accumulating:
@@ -230,7 +228,7 @@ def validate(fabric: L.Fabric, model: torch.nn.Module, val_dataloader: DataLoade
         input_ids = val_data[:, 0 : model.config.block_size].contiguous()
         targets = val_data[:, 1 : model.config.block_size + 1].contiguous()
         logits = model(input_ids)
-        loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
         losses[k] = loss.item()
     out = losses.mean()
 

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -122,7 +122,9 @@ def main(fabric: L.Fabric, train_data_dir: Path, val_data_dir: Optional[Path]) -
     num_total_params = sum(p.numel() for p in model.parameters())
     fabric.print(f"Total parameters {num_total_params}")
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay, betas=(beta1, beta2))
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=learning_rate, weight_decay=weight_decay, betas=(beta1, beta2), foreach=False
+    )
     model, optimizer = fabric.setup(model, optimizer)
 
     train_time = time.time()

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -361,7 +361,7 @@ def main(
     t = time.perf_counter() - t0
 
     print(f"\n\nTime for quantization: {t:.02f} sec total", file=sys.stderr)
-    print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
+    print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB", file=sys.stderr)
 
     torch.save(model.state_dict(), output_path)
 


### PR DESCRIPTION
See posted comments for in-depth explanations.

Memory usage was gathered with

```python
    with torch.profiler.profile(record_shapes=True, profile_memory=True, with_stack=True) as p:
        # the training loop
        ...

    from torch.cuda._memory_viz import profile_plot
    with open('memory.html', 'w') as f:
        f.write(profile_plot(p))
```

and setting

```diff
-    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else max_seq_length
+    max_len = max_seq_length
```

With the changes in this PR, running `python finetune/adapter.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 16-true` with `max_seq_length=1079` goes from 23.10 to 22.82 GB maximum memory allocated.

Huge thanks to @robieta for helping debug the `backward` memory spike