### PR TITLE
Filter downloaded files

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -20,7 +20,13 @@ def download_from_hub(repo_id: Optional[str] = None) -> None:
 
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id, local_dir=f"checkpoints/{repo_id}", local_dir_use_symlinks=False, resume_download=True)
+    snapshot_download(
+        repo_id,
+        local_dir=f"checkpoints/{repo_id}",
+        local_dir_use_symlinks=False,
+        resume_download=True,
+        allow_patterns=["*.bin*", "tokenizer*"],
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A user got confused by a README included in one of the checkpoints. We should only download what we need.