### PR TITLE
Support LoRA for all Linear layers

### DIFF
--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -76,12 +76,7 @@ def setup(
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 
-def main(
-    fabric: L.Fabric,
-    data_dir: Path,
-    checkpoint_dir: Path,
-    out_dir: Path,
-):
+def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     check_valid_checkpoint_dir(checkpoint_dir)
 
     speed_monitor = SpeedMonitor(fabric, window_size=50, time_unit="seconds")

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -39,6 +39,12 @@ weight_decay = 0.01
 lora_r = 8
 lora_alpha = 16
 lora_dropout = 0.05
+lora_query = True
+lora_key = False
+lora_value = True
+lora_projection = False
+lora_mlp = False
+lora_head = False
 warmup_steps = 100
 
 hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str)) and not k.startswith("_")}
@@ -50,12 +56,6 @@ def setup(
     out_dir: Path = Path("out/lora/alpaca"),
     precision: Optional[str] = None,
     tpu: bool = False,
-    query_lora: bool = True,
-    key_lora: bool = False,
-    value_lora: bool = True,
-    projection_lora: bool = False,
-    mlp_lora: bool = False,
-    head_lora: bool = False,
 ):
     if precision is None:
         precision = "32-true" if tpu else "bf16-mixed"
@@ -73,7 +73,7 @@ def setup(
     logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
-    fabric.launch(main, data_dir, checkpoint_dir, out_dir, query_lora, key_lora, value_lora, projection_lora, mlp_lora, head_lora)
+    fabric.launch(main, data_dir, checkpoint_dir, out_dir)
 
 
 def main(
@@ -81,12 +81,6 @@ def main(
     data_dir: Path,
     checkpoint_dir: Path,
     out_dir: Path,
-    query_lora: bool,
-    key_lora: bool,
-    value_lora: bool,
-    projection_lora: bool,
-    mlp_lora: bool,
-    head_lora: bool,
 ):
     check_valid_checkpoint_dir(checkpoint_dir)
 
@@ -105,12 +99,12 @@ def main(
         r=lora_r,
         alpha=lora_alpha,
         dropout=lora_dropout,
-        query_lora=query_lora,
-        key_lora=key_lora,
-        value_lora=value_lora,
-        projection_lora=projection_lora,
-        mlp_lora=mlp_lora,
-        head_lora=head_lora,
+        lora_query=lora_query,
+        lora_key=lora_key,
+        lora_value=lora_value,
+        lora_projection=lora_projection,
+        lora_mlp=lora_mlp,
+        lora_head=lora_head,
     )
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -99,12 +99,12 @@ def main(
         r=lora_r,
         alpha=lora_alpha,
         dropout=lora_dropout,
-        lora_query=lora_query,
-        lora_key=lora_key,
-        lora_value=lora_value,
-        lora_projection=lora_projection,
-        lora_mlp=lora_mlp,
-        lora_head=lora_head,
+        to_query=lora_query,
+        to_key=lora_key,
+        to_value=lora_value,
+        to_projection=lora_projection,
+        to_mlp=lora_mlp,
+        to_head=lora_head,
     )
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -81,7 +81,7 @@ class Config:
     @property
     def mlp_class(self) -> Type:
         # `self._mlp_class` cannot be the type to keep the config json serializable
-        obj = lit_gpt.lora if hasattr(self, "mlp_lora") else lit_gpt.model
+        obj = lit_gpt.lora if (hasattr(self, "mlp_lora") and self.mlp_lora) else lit_gpt.model
         return getattr(obj, self._mlp_class)
 
     @property

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -5,7 +5,7 @@ from typing import Optional, Any, Type, Literal
 import torch
 from typing_extensions import Self
 
-import lit_gpt.model
+import lit_gpt
 from lit_gpt.utils import find_multiple
 
 
@@ -81,7 +81,8 @@ class Config:
     @property
     def mlp_class(self) -> Type:
         # `self._mlp_class` cannot be the type to keep the config json serializable
-        return getattr(lit_gpt.model, self._mlp_class)
+        obj = lit_gpt.lora if hasattr(self, "mlp_lora") else lit_gpt.model
+        return getattr(obj, self._mlp_class)
 
     @property
     def norm_class(self) -> Type:

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -5,7 +5,7 @@ from typing import Optional, Any, Type, Literal
 import torch
 from typing_extensions import Self
 
-import lit_gpt
+import lit_gpt.model
 from lit_gpt.utils import find_multiple
 
 
@@ -82,8 +82,7 @@ class Config:
     @property
     def mlp_class(self) -> Type:
         # `self._mlp_class` cannot be the type to keep the config json serializable
-        obj = lit_gpt.lora if (hasattr(self, "mlp_lora") and self.mlp_lora) else lit_gpt.model
-        return getattr(obj, self._mlp_class)
+        return getattr(lit_gpt.model, self._mlp_class)
 
     @property
     def norm_class(self) -> Type:

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -475,32 +475,20 @@ class Config(BaseConfig):
         obj = lit_gpt.lora if self.to_mlp else lit_gpt.model
         return getattr(obj, self._mlp_class)
 
-class GptNeoxMLP(nn.Module):
+
+class GptNeoxMLP(lit_gpt.model.GptNeoxMLP):
     def __init__(self, config: Config) -> None:
         super().__init__()
         self.fc = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.fc(x)
-        x = torch.nn.functional.gelu(x)
-        x = self.proj(x)
-        return x
 
-
-class LLaMAMLP(nn.Module):
+class LLaMAMLP(lit_gpt.model.LLaMAMLP):
     def __init__(self, config: Config) -> None:
         super().__init__()
         self.fc_1 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.fc_2 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x_fc_1 = self.fc_1(x)
-        x_fc_2 = self.fc_2(x)
-        x = torch.nn.functional.silu(x_fc_1) * x_fc_2
-        x = self.proj(x)
-        return x
 
 
 class GPT(BaseModel):

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -325,7 +325,7 @@ class LoRAQKVLinear(LoRALinear):
 
         # despite being called from nn.Linear this method will put all layers into train mode, including nn.Dropout
         # of course except parameters (such as self.lora_A, self.lora_B)
-        super().train(mode)
+        super(LoRALinear, self).train(mode)
 
         # if train(True) -> unmerge unless we already have them unmerged
         # if train(False) -> merge unless we already have them merged

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -43,13 +43,14 @@ two matrices of a lower rank.
 
 import math
 from dataclasses import dataclass
-from typing import Optional, Tuple, Any, List, Union
+from typing import Optional, Tuple, Any, List, Type, Union
 
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 from typing_extensions import Self
 
+import lit_gpt
 from lit_gpt.config import Config as BaseConfig
 from lit_gpt.model import (
     GPT as BaseModel,
@@ -468,6 +469,11 @@ class Config(BaseConfig):
     mlp_lora: bool = False
     head_lora: bool = False
 
+    @property
+    def mlp_class(self) -> Type:
+        # `self._mlp_class` cannot be the type to keep the config json serializable
+        obj = lit_gpt.lora if self.mlp_lora else lit_gpt.model
+        return getattr(obj, self._mlp_class)
 
 class GptNeoxMLP(nn.Module):
     def __init__(self, config: Config) -> None:

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -476,21 +476,6 @@ class Config(BaseConfig):
         return getattr(obj, self._mlp_class)
 
 
-class GptNeoxMLP(lit_gpt.model.GptNeoxMLP):
-    def __init__(self, config: Config) -> None:
-        super().__init__()
-        self.fc = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-
-
-class LLaMAMLP(lit_gpt.model.LLaMAMLP):
-    def __init__(self, config: Config) -> None:
-        super().__init__()
-        self.fc_1 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-        self.fc_2 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
-
-
 class GPT(BaseModel):
     def __init__(self, config: Config) -> None:
         nn.Module.__init__(self)
@@ -623,3 +608,18 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             self.proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
 
         self.config = config
+
+
+class GptNeoxMLP(lit_gpt.model.GptNeoxMLP):
+    def __init__(self, config: Config) -> None:
+        super().__init__()
+        self.fc = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
+        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
+
+
+class LLaMAMLP(lit_gpt.model.LLaMAMLP):
+    def __init__(self, config: Config) -> None:
+        super().__init__()
+        self.fc_1 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
+        self.fc_2 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
+        self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -163,7 +163,7 @@ class LoRALinear(nn.Linear, LoRALayer):
 
         # despite being called from nn.Linear this method will put all layers into train mode, including nn.Dropout
         # of course except parameters (such as self.lora_A, self.lora_B)
-        super().train(self, mode)
+        super().train(mode)
 
         # if we want to put the layer into `train` mode then subtract LoRA weights if weights are already merged, so we
         # can keep original weights untouched and train LoRA's matrices A and B separately.
@@ -331,7 +331,7 @@ class LoRAQKVLinear(LoRALinear):
         Returns:
             A tensor with weight updates and zeros for deselected q, k or v
         """
-        # we need to do zero padding only if one of QKV matrices is disabled from LoRA
+        # we need to do zero padding only if LoRA is disabled for one of QKV matrices
         if all(self.enable_lora):
             return x
 

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -462,17 +462,17 @@ class Config(BaseConfig):
     r: int = 0.0
     alpha: int = 1.0
     dropout: float = 0.0
-    query_lora: bool = False
-    key_lora: bool = False
-    value_lora: bool = False
-    projection_lora: bool = False
-    mlp_lora: bool = False
-    head_lora: bool = False
+    lora_query: bool = False
+    lora_key: bool = False
+    lora_value: bool = False
+    lora_projection: bool = False
+    lora_mlp: bool = False
+    lora_head: bool = False
 
     @property
     def mlp_class(self) -> Type:
         # `self._mlp_class` cannot be the type to keep the config json serializable
-        obj = lit_gpt.lora if self.mlp_lora else lit_gpt.model
+        obj = lit_gpt.lora if self.lora_mlp else lit_gpt.model
         return getattr(obj, self._mlp_class)
 
 class GptNeoxMLP(nn.Module):
@@ -509,7 +509,7 @@ class GPT(BaseModel):
         assert config.padded_vocab_size is not None
         self.config = config
 
-        if config.head_lora:
+        if config.lora_head:
             self.lm_head = Linear(config.n_embd, config.padded_vocab_size, bias=False, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         else:
             self.lm_head = nn.Linear(config.n_embd, config.padded_vocab_size, bias=False)
@@ -620,7 +620,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             r=config.r,
             lora_alpha=config.alpha,
             lora_dropout=config.dropout,
-            enable_lora=(config.query_lora, config.key_lora, config.value_lora),
+            enable_lora=(config.lora_query, config.lora_key, config.lora_value),
             fan_in_fan_out=False,
             merge_weights=True,
             bias=config.bias,
@@ -629,7 +629,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             n_query_groups=config.n_query_groups,
         )
         # output projection
-        if config.projection_lora:
+        if config.lora_projection:
             self.proj = Linear(config.n_embd, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         else:
             self.proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -87,6 +87,71 @@ class LoRALayer:
         self.merge_weights = merge_weights
 
 
+class Linear(nn.Linear, LoRALayer):
+    # LoRA implemented in a dense layer
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.,
+        fan_in_fan_out: bool = False, # Set this to True if the layer to replace stores weight like (fan_in, fan_out)
+        merge_weights: bool = True,
+        **kwargs
+    ):
+        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+                           merge_weights=merge_weights)
+
+        self.fan_in_fan_out = fan_in_fan_out
+        # Actual trainable parameters
+        if r > 0:
+            self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
+            self.lora_B = nn.Parameter(self.weight.new_zeros((out_features, r)))
+            self.scaling = self.lora_alpha / self.r
+            # Freezing the pre-trained weight matrix
+            self.weight.requires_grad = False
+        self.reset_parameters()
+        if fan_in_fan_out:
+            self.weight.data = self.weight.data.transpose(0, 1)
+
+    def reset_parameters(self):
+        nn.Linear.reset_parameters(self)
+        if hasattr(self, 'lora_A'):
+            # initialize A the same way as the default for nn.Linear and B to zero
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+        nn.Linear.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                # Make sure that the weights are not merged
+                if self.r > 0:
+                    self.weight.data -= T(self.lora_B @ self.lora_A) * self.scaling
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                # Merge the weights and mark it
+                if self.r > 0:
+                    self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
+        if self.r > 0 and not self.merged:
+            result = F.linear(x, T(self.weight), bias=self.bias)
+            if self.r > 0:
+                result += (self.lora_dropout(x) @ self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1)) * self.scaling
+            return result
+        else:
+            return F.linear(x, T(self.weight), bias=self.bias)
+
+
 class MergedLinear(nn.Linear, LoRALayer):
     # LoRA implemented in a dense layer
     def __init__(

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -612,14 +612,14 @@ class CausalSelfAttention(BaseCausalSelfAttention):
 
 class GptNeoxMLP(lit_gpt.model.GptNeoxMLP):
     def __init__(self, config: Config) -> None:
-        super().__init__()
+        nn.Module.__init__(self)
         self.fc = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
 
 
 class LLaMAMLP(lit_gpt.model.LLaMAMLP):
     def __init__(self, config: Config) -> None:
-        super().__init__()
+        nn.Module.__init__(self)
         self.fc_1 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.fc_2 = Linear(config.n_embd, config.intermediate_size, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)
         self.proj = Linear(config.intermediate_size, config.n_embd, bias=config.bias, r=config.r, lora_alpha=config.alpha, lora_dropout=config.dropout)

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -331,6 +331,10 @@ class LoRAQKVLinear(LoRALinear):
         Returns:
             A tensor with weight updates and zeros for deselected q, k or v
         """
+        # we need to do zero padding only if one of QKV matrices is disabled from LoRA
+        if all(self.enable_lora):
+            return x
+
         # Let's image that:
         # ⚬ input x has shape (64, 64, 256): (batch_size, sequence_length, embeddings_size)
         # ⚬ embeddings_size: 128

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -455,6 +455,7 @@ class Config(BaseConfig):
             "This scaling helps to reduce the need to retune hyperparameters when we vary r"
             https://arxiv.org/pdf/2106.09685.pdf (section 4.1)
         dropout: dropout that is applied on the input in the LoRA branch (before multiplying by matrix A)
+        *_lora: either apply LoRA to the specified weights or not
     """
 
     r: int = 0.0

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -101,7 +101,7 @@ class LoRALinear(nn.Linear, LoRALayer):
         merge_weights: bool = True,
         **kwargs
     ):
-        nn.Linear.__init__(self, in_features, out_features, **kwargs)
+        super().__init__(in_features, out_features, **kwargs)
         LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout, merge_weights=merge_weights)
 
         self.fan_in_fan_out = fan_in_fan_out
@@ -118,7 +118,7 @@ class LoRALinear(nn.Linear, LoRALayer):
 
     def reset_parameters(self):
         """Reset all the weights, even including pretrained ones."""
-        nn.Linear.reset_parameters(self)
+        super().reset_parameters()
         if hasattr(self, "lora_A"):
             # initialize A the same way as the default for nn.Linear and B to zero
             # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -169,7 +169,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
 
 def test_lora_init_when_linear_overridden():
-    from lit_gpt.lora import MergedLinear
+    from lit_gpt.lora import LoRAQKVLinear
 
     class MyLinear(torch.nn.Linear):
         def __init__(self, *args, **kwargs):
@@ -179,7 +179,7 @@ def test_lora_init_when_linear_overridden():
     original_linear = torch.nn.Linear
     # Our bnb does this sort of monkey patching
     torch.nn.Linear = MyLinear
-    layer = MergedLinear(1, 1, 1, 1)
+    layer = LoRAQKVLinear(1, 1, 1, 1)
     assert isinstance(layer, original_linear)
     torch.nn.Linear = original_linear
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -19,7 +19,7 @@ def test_lora_layer_replacement():
 def test_lora_merge_unmerge():
     from lit_gpt.lora import mark_only_lora_as_trainable, GPT, Config
 
-    config = Config(n_layer=1, n_head=2, n_embd=8, block_size=8, vocab_size=8, r=8, alpha=8, dropout=0.1)
+    config = Config(n_layer=1, n_head=2, n_embd=8, block_size=8, vocab_size=8, r=8, alpha=8, dropout=0.1, to_query=True, to_value=True)
     model = GPT(config)
 
     initial_weight = model.transformer.h[0].attn.attn.weight.clone()
@@ -63,7 +63,7 @@ def test_lora_mqa_gqa():
     from lit_gpt.lora import GPT, Config
 
     # MHA
-    config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1)
+    config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, to_query=True, to_value=True)
     assert config.n_query_groups == config.n_head
     model = GPT(config)
     attn = model.transformer.h[0].attn.attn
@@ -101,7 +101,7 @@ def test_lora_filter(tmp_path):
     from lit_gpt.lora import lora_filter, GPT
 
     fabric = Fabric(devices=1)
-    model = GPT.from_name("pythia-70m", n_layer=3, r=1)
+    model = GPT.from_name("pythia-70m", n_layer=3, r=1, to_query=True, to_value=True)
     save_path = tmp_path / "model.pth"
     fabric.save(save_path, {"model": model}, filter={"model": lora_filter})
     saved = torch.load(save_path)["model"]

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -34,7 +34,9 @@ The finetuning requires at least one GPU with ~24 GB memory (RTX 3090).
 
 This script will save checkpoints periodically to the folder `out/`.
 
-
+**Note**: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projecton`, `mlp` and classification `head`.</br>
+Accordingly to [QLoRA](https://arxiv.org/abs/2305.14314) paper (section 4): "LoRA on all linear transformer block layers are required to match full finetuning performance".</br>
+By default LoRA applied only to `query` and `value` matrices. In order to apply LoRA to other weight matrices - change config in `finetune/lora.py` accordingly.
 
 ## Test the model
 

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -34,7 +34,7 @@ The finetuning requires at least one GPU with ~24 GB memory (RTX 3090).
 
 This script will save checkpoints periodically to the folder `out/`.
 
-**Note**: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projecton`, `mlp` and classification `head`.</br>
+**Note**: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projection`, `mlp` and classification `head`.</br>
 Accordingly to [QLoRA](https://arxiv.org/abs/2305.14314) paper (section 4): "LoRA on all linear transformer block layers are required to match full finetuning performance".</br>
 By default LoRA applied only to `query` and `value` matrices. In order to apply LoRA to other weight matrices - change config in `finetune/lora.py` accordingly.
 

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -34,9 +34,9 @@ The finetuning requires at least one GPU with ~24 GB memory (RTX 3090).
 
 This script will save checkpoints periodically to the folder `out/`.
 
-**Note**: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projection`, `mlp` and classification `head`.</br>
-Accordingly to [QLoRA](https://arxiv.org/abs/2305.14314) paper (section 4): "LoRA on all linear transformer block layers are required to match full finetuning performance".</br>
-By default LoRA applied only to `query` and `value` matrices. In order to apply LoRA to other weight matrices - change config in `finetune/lora.py` accordingly.
+> **Note**: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projection`, `mlp` and classification `head`.
+According to [QLoRA](https://arxiv.org/abs/2305.14314) paper (section 4): "LoRA on all linear transformer block layers are required to match full finetuning performance".
+By default LoRA is applied only to the `query` and `value` matrices. In order to apply LoRA to other weight matrices - change the variables in `finetune/lora.py` accordingly.
 
 ## Test the model
 


### PR DESCRIPTION
This is an experiment (perhaps it needs to be a `Draft`?) to apply LoRA to not only to query and value matrices, but to:
- query
- key
- value
- projection
- MLP
- head

as described in this [issue](https://github.com/Lightning-AI/lit-llama/issues/350) (in Lit-LLaMa repo).

Changes include porting `Linear` class from Microsoft's repo in order to use it as a replacement of `nn.Linear`. MergedLinear is for attention operations, Linear - for everything else.

So now experiments could be run within CLI by providing arguments:
```bash
python finetune/lora.py --checkpoint_dir ... --query_lora True --key_lora True --value_lora True --projection_lora True --mlp_lora True --head_lora True
```

*Naming is lame, I know, so I need a help with it.*

By default (if to not provide any arguments) for fine-tuning script LoRA is applied to only query and value so it mimics the previous behavior.

---
I don't have a GPU in my possession, so I did a sanity check on my laptop's CPU and a GPU in google colab with `pythia-70m` model and alpaca dataset.  So now someone with big guns from Lightning.ai team should check whether there are any improvements or not with a much-much bigger model. Of course when have time.

---
Note: when I tested in Google Colab with Nvidia T4 with "16-mixed" precision I've got:
> RuntimeError: probability tensor contains either `inf`, `nan` or element < 0

so I tested with "32-true". T4 doesn't support `bf-16`.
Still it was weird. I understand why I might got this type of error with `16-true` (as it's explained in this [article](https://lightning.ai/pages/community/tutorial/pytorch-memory-vit-llm/) from Lightning.ai blog), but with mixed precision it should work without problem, isn't it?
P.S. the same issue (or it's not an issue?) is true for the code from the main brunch.
