### PR TITLE
Bitsandbytes 4-bit quantization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ python chat/base.py
 
 ### Run large models on smaller consumer devices
 
-We support LLM.int8 and GPTQ.int4 inference by following [this guide](tutorials/inference.md#run-large-models-on-consumer-devices).
+We support 4-bit quantization (as in QLoRA), LLM.int8, and GPTQ.int4 inference by following [this guide](tutorials/quantize.md).
 
 ## Finetune the model
 

--- a/chat/base.py
+++ b/chat/base.py
@@ -123,7 +123,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     precision: str = "bf16-true",
 ) -> None:
@@ -134,8 +134,11 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
         checkpoint_dir: The checkpoint directory to load.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
     """
     check_valid_checkpoint_dir(checkpoint_dir)

--- a/chat/base.py
+++ b/chat/base.py
@@ -122,7 +122,9 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     precision: str = "bf16-true",
 ) -> None:
     """Starts a conversation with a tuned GPT model.
@@ -132,9 +134,8 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
         checkpoint_dir: The checkpoint directory to load.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
     """
     check_valid_checkpoint_dir(checkpoint_dir)

--- a/chat/base.py
+++ b/chat/base.py
@@ -123,7 +123,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     precision: str = "bf16-true",
 ) -> None:
@@ -135,7 +135,7 @@ def main(
             samples.
         checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/chat/base.py
+++ b/chat/base.py
@@ -123,7 +123,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     precision: str = "bf16-true",
 ) -> None:
@@ -136,7 +136,7 @@ def main(
         checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -28,7 +28,7 @@ def main(
     adapter_path: Path = Path("out/adapter/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -49,7 +49,7 @@ def main(
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import lightning as L
 import torch
@@ -27,7 +27,9 @@ def main(
     input: str = "",
     adapter_path: Path = Path("out/adapter/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,
@@ -45,9 +47,8 @@ def main(
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/adapter.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -28,7 +28,7 @@ def main(
     adapter_path: Path = Path("out/adapter/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -47,8 +47,11 @@ def main(
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/adapter.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -28,7 +28,7 @@ def main(
     adapter_path: Path = Path("out/adapter/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -48,7 +48,7 @@ def main(
             `finetune/adapter.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -30,7 +30,7 @@ def main(
     adapter_path: Path = Path("out/adapter_v2/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -50,7 +50,7 @@ def main(
             `finetune/adapter_v2.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import lightning as L
 import torch
@@ -29,7 +29,9 @@ def main(
     input: str = "",
     adapter_path: Path = Path("out/adapter_v2/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,
@@ -47,9 +49,8 @@ def main(
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/adapter_v2.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -30,7 +30,7 @@ def main(
     adapter_path: Path = Path("out/adapter_v2/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -51,7 +51,7 @@ def main(
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -30,7 +30,7 @@ def main(
     adapter_path: Path = Path("out/adapter_v2/alpaca/lit_model_adapter_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -49,8 +49,11 @@ def main(
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/adapter_v2.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/base.py
+++ b/generate/base.py
@@ -99,7 +99,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     strategy: str = "auto",
     devices: int = 1,
@@ -115,8 +115,11 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
         checkpoint_dir: The checkpoint directory to load.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         strategy: Indicates the Fabric strategy setting to use.
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.

--- a/generate/base.py
+++ b/generate/base.py
@@ -99,7 +99,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     strategy: str = "auto",
     devices: int = 1,
@@ -117,7 +117,7 @@ def main(
         checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         strategy: Indicates the Fabric strategy setting to use.

--- a/generate/base.py
+++ b/generate/base.py
@@ -98,7 +98,9 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     strategy: str = "auto",
     devices: int = 1,
     precision: str = "bf16-true",
@@ -113,9 +115,8 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
         checkpoint_dir: The checkpoint directory to load.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         strategy: Indicates the Fabric strategy setting to use.
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.

--- a/generate/base.py
+++ b/generate/base.py
@@ -99,7 +99,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     strategy: str = "auto",
     devices: int = 1,
@@ -116,7 +116,7 @@ def main(
             samples.
         checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/generate/full.py
+++ b/generate/full.py
@@ -28,7 +28,7 @@ def main(
     finetuned_path: Path = Path("out/full/alpaca/lit_model_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -49,7 +49,7 @@ def main(
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.

--- a/generate/full.py
+++ b/generate/full.py
@@ -28,7 +28,7 @@ def main(
     finetuned_path: Path = Path("out/full/alpaca/lit_model_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -48,7 +48,7 @@ def main(
             `finetune/full.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/generate/full.py
+++ b/generate/full.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import lightning as L
 import torch
@@ -27,7 +27,9 @@ def main(
     input: str = "",
     finetuned_path: Path = Path("out/full/alpaca/lit_model_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,
@@ -45,9 +47,8 @@ def main(
         finetuned_path: Path to the checkpoint with trained weights, which are the output of
             `finetune/full.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/full.py
+++ b/generate/full.py
@@ -28,7 +28,7 @@ def main(
     finetuned_path: Path = Path("out/full/alpaca/lit_model_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -47,8 +47,11 @@ def main(
         finetuned_path: Path to the checkpoint with trained weights, which are the output of
             `finetune/full.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -33,7 +33,7 @@ def main(
     lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -54,7 +54,7 @@ def main(
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - llm.int8: 8-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -33,7 +33,7 @@ def main(
     lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -52,8 +52,11 @@ def main(
         lora_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/lora.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method.
-            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        quantize: Whether to quantize the model and using which method:
+            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - llm.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -33,7 +33,7 @@ def main(
     lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[
-        Literal["qlora.nf4", "qlora.nf4-dq", "qlora.fp4", "qlora.fp4-dq", "llm.int8", "gptq.int4"]
+        Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "llm.int8", "gptq.int4"]
     ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -53,7 +53,7 @@ def main(
             `finetune/lora.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
-            - qlora.nf4, qlora.nf4-dq, qlora.fp4, qlora.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - llm.int8: 8-bit quantization from bitsandbytes
             - gptq.int4: 4-bit quantization from GPTQ
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import lightning as L
 import torch
@@ -32,7 +32,9 @@ def main(
     input: str = "",
     lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
     checkpoint_dir: Path = Path(f"checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Literal["llm.int8", "gptq.int4"] = None,
+    quantize: Optional[
+        Literal["llm.int8", "qlora.fp4", "qlora.fp4-dq", "qlora.nf4", "qlora.nf4-dq", "gptq.int4"]
+    ] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,
@@ -50,9 +52,8 @@ def main(
         lora_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune/lora.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
-        quantize: Whether to quantize the model and using which method:
-            ``"llm.int8"``: LLM.int8() mode,
-            ``"gptq.int4"``: GPTQ 4-bit mode.
+        quantize: Whether to quantize the model and using which method.
+            See https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import Optional, Any, Type, Literal
 

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for training and inference."""
 
-import functools
+from functools import partial
 import pickle
 import sys
 import warnings
@@ -30,13 +30,29 @@ def quantization(mode: Optional[str] = None):
         return
 
     if mode == "llm.int8":
-        from quantize.bnb import Linear8bitLt
+        from quantize.bnb import InferenceLinear8bitLt
 
-        quantized_linear_cls = Linear8bitLt
+        quantized_linear_cls = InferenceLinear8bitLt
+    elif mode == "qlora.fp4":
+        from quantize.bnb import Linear4bit
+
+        quantized_linear_cls = partial(Linear4bit, quant_type="fp4", compress_statistics=False)
+    elif mode == "qlora.fp4-dq":
+        from quantize.bnb import Linear4bit
+
+        quantized_linear_cls = partial(Linear4bit, quant_type="fp4", compress_statistics=True)
+    elif mode == "qlora.nf4":
+        from quantize.bnb import Linear4bit
+
+        quantized_linear_cls = partial(Linear4bit, quant_type="nf4", compress_statistics=False)
+    elif mode == "qlora.nf4-dq":
+        from quantize.bnb import Linear4bit
+
+        quantized_linear_cls = partial(Linear4bit, quant_type="nf4", compress_statistics=True)
     elif mode == "gptq.int4":
-        from quantize.bnb import ColBlockQuantizedLinear
+        from quantize.gptq import ColBlockQuantizedLinear
 
-        quantized_linear_cls = functools.partial(ColBlockQuantizedLinear, bits=4, tile_cols=-1)
+        quantized_linear_cls = partial(ColBlockQuantizedLinear, bits=4, tile_cols=-1)
     else:
         raise ValueError(f"Unknown quantization mode: {mode}")
 
@@ -159,11 +175,11 @@ class LazyLoadingUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
         res = super().find_class(module, name)
         if module == "torch._utils" and name == "_rebuild_tensor_v2":
-            return functools.partial(NotYetLoadedTensor.rebuild_tensor_v2, archiveinfo=self)
+            return partial(NotYetLoadedTensor.rebuild_tensor_v2, archiveinfo=self)
         elif module == "torch._tensor" and name == "_rebuild_from_type_v2":
-            return functools.partial(NotYetLoadedTensor.rebuild_from_type_v2, archiveinfo=self)
+            return partial(NotYetLoadedTensor.rebuild_from_type_v2, archiveinfo=self)
         elif module == "torch._utils" and name == "_rebuild_parameter":
-            return functools.partial(NotYetLoadedTensor.rebuild_parameter, archiveinfo=self)
+            return partial(NotYetLoadedTensor.rebuild_parameter, archiveinfo=self)
         return res
 
     def persistent_load(self, pid):

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -29,7 +29,7 @@ def quantization(mode: Optional[str] = None):
         yield
         return
 
-    if mode == "llm.int8":
+    if mode == "bnb.int8":
         from quantize.bnb import InferenceLinear8bitLt
 
         quantized_linear_cls = InferenceLinear8bitLt

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -33,19 +33,19 @@ def quantization(mode: Optional[str] = None):
         from quantize.bnb import InferenceLinear8bitLt
 
         quantized_linear_cls = InferenceLinear8bitLt
-    elif mode == "qlora.fp4":
+    elif mode == "bnb.fp4":
         from quantize.bnb import Linear4bit
 
         quantized_linear_cls = partial(Linear4bit, quant_type="fp4", compress_statistics=False)
-    elif mode == "qlora.fp4-dq":
+    elif mode == "bnb.fp4-dq":
         from quantize.bnb import Linear4bit
 
         quantized_linear_cls = partial(Linear4bit, quant_type="fp4", compress_statistics=True)
-    elif mode == "qlora.nf4":
+    elif mode == "bnb.nf4":
         from quantize.bnb import Linear4bit
 
         quantized_linear_cls = partial(Linear4bit, quant_type="nf4", compress_statistics=False)
-    elif mode == "qlora.nf4-dq":
+    elif mode == "bnb.nf4-dq":
         from quantize.bnb import Linear4bit
 
         quantized_linear_cls = partial(Linear4bit, quant_type="nf4", compress_statistics=True)

--- a/notebooks/falcon-inference.ipynb
+++ b/notebooks/falcon-inference.ipynb
@@ -96,7 +96,7 @@
     "!python generate/base.py \\\n",
     "        --prompt \"Hello, my name is\" \\\n",
     "        --checkpoint_dir checkpoints/tiiuae/falcon-7b \\\n",
-    "        --quantize llm.int8"
+    "        --quantize bnb.int8"
    ]
   }
  ],

--- a/quantize/bnb.py
+++ b/quantize/bnb.py
@@ -1,39 +1,21 @@
 import os
 import warnings
-import math
 
 import torch
+from lightning_utilities.core.imports import RequirementCache
 
 # configuration for bitsandbytes before import
 os.environ["BITSANDBYTES_NOWELCOME"] = "1"
-warnings.filterwarnings(
-    "ignore", message="MatMul8bitLt: inputs will be cast from torch.float32 to float16 during quantization"
-)
-warnings.filterwarnings(
-    "ignore", message="MatMul8bitLt: inputs will be cast from torch.bfloat16 to float16 during quantization"
-)
-warnings.filterwarnings(
-    "ignore",
-    message=(
-        "The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers and GPU quantization"
-        " are unavailable."
-    ),
-)
+warnings.filterwarnings("ignore", message=r".*bitsandbytes was compiled without GPU support.*")
+_BITSANDBYTES_AVAILABLE = RequirementCache("bitsandbytes>=0.40.0")
 
-try:
-    import bitsandbytes as bnb  # noqa: E402
-except:
-    bnb = None
+if _BITSANDBYTES_AVAILABLE:
+    warnings.filterwarnings(
+        "ignore", message=r"MatMul8bitLt: inputs will be cast from .* to float16 during quantization"
+    )
+    import bitsandbytes as bnb
 
-try:
-    import triton  # noqa: E402
-    import triton.language as tl  # noqa: E402
-except:
-    triton = None
-
-if bnb is not None:
-
-    class Linear8bitLt(bnb.nn.Linear8bitLt):
+    class InferenceLinear8bitLt(bnb.nn.Linear8bitLt):
         """Wraps `bnb.nn.Linear8bitLt` and enables instantiation directly on the device and
         re-quantizaton when loading the state dict.
 
@@ -42,7 +24,13 @@ if bnb is not None:
         """
 
         def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs, has_fp16_weights=False, threshold=6.0)
+            super().__init__(
+                *args,
+                **kwargs,
+                # true only for fine-tuning as the weights do not have to be converted back and forth for bwd.
+                has_fp16_weights=False,
+                threshold=6.0,
+            )
             # We quantize the initial weight here so we don't end up filling the device
             # memory with float32 weights which could lead to OOM.
             self._quantize_weight(self.weight.data)
@@ -71,453 +59,22 @@ if bnb is not None:
             setattr(self.weight, "CB", CB)
             setattr(self.weight, "SCB", SCB)
 
-
-if triton is not None:
-    # This is adapted from the OpenAI Triton matmul example.
-    @triton.autotune(
-        configs=[
-            triton.Config(
-                {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=3,
-                num_warps=8,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=3,
-                num_warps=8,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=4,
-                num_warps=4,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=5,
-                num_warps=2,
-            ),
-            triton.Config(
-                {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8},
-                num_stages=5,
-                num_warps=2,
-            ),
-        ],
-        key=["M", "N", "K"],
-    )
-    @triton.jit
-    def linear_kernel_4bit_weight(
-        # Pointers to matrices
-        a_ptr,
-        b_ptr,
-        c_ptr,
-        bscales_ptr,
-        bzeros_ptr,
-        # bdequant,
-        # Matrix dimensions
-        M,
-        N,
-        K,
-        # The stride variables represent how much to increase the ptr by when moving by 1
-        # element in a particular dimension. E.g. stride_am is how much to increase a_ptr
-        # by to get the element one row down (A has M rows)
-        stride_am,
-        stride_ak,
-        stride_bk,
-        stride_bn,
-        stride_cm,
-        stride_cn,
-        # Meta-parameters
-        BLOCK_SIZE_M: tl.constexpr,
-        BLOCK_SIZE_N: tl.constexpr,
-        BLOCK_SIZE_K: tl.constexpr,
-        GROUP_SIZE_M: tl.constexpr,
-    ):
-        """Kernel for computing the matmul C = A x B.T.
-        A has shape (M, K), B has shape (N, K) and C has shape (M, N)
-        """
-        # -----------------------------------------------------------
-        # Map program ids `pid` to the block of C it should compute.
-        # This is done in a grouped ordering to promote L2 data reuse
-        # See above `L2 Cache Optimizations` section for details
-        pid = tl.program_id(axis=0)
-        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-        num_pid_in_group = GROUP_SIZE_M * num_pid_n
-        group_id = pid // num_pid_in_group
-        first_pid_m = group_id * GROUP_SIZE_M
-        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-        pid_m = first_pid_m + (pid % group_size_m)
-        pid_n = (pid % num_pid_in_group) // group_size_m
-
-        # ----------------------------------------------------------
-        # Create pointers for the first blocks of A and B.
-        # We will advance this pointer as we move in the K direction
-        # and accumulate
-        # a_ptrs is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
-        # b_ptrs is a block of [BLOCK_SIZE_K, BLOCK_SIZE_n] pointers
-        # see above `Pointer Arithmetics` section for details
-        offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-        offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-        a_mask = offs_am[:, None] < M
-        b_mask = offs_bn[None, :] < N
-        offs_k = tl.arange(0, BLOCK_SIZE_K)
-        a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-        b_ptrs = b_ptr + ((offs_k[:, None] // 2) * stride_bk + offs_bn[None, :] * stride_bn)
-
-        bscales_ptrs = bscales_ptr + offs_bn[None, :]
-        bzeros_ptrs = bzeros_ptr + offs_bn[None, :]
-
-        scale = tl.load(bscales_ptrs)
-        zero = tl.load(bzeros_ptrs)
-        # -----------------------------------------------------------
-        # Iterate to compute a block of the C matrix
-        # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
-        # of fp32 values for higher accuracy.
-        # `accumulator` will be converted back to fp16 after the loop
-        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for k in range(0, K, BLOCK_SIZE_K):
-            # wasteful as it is to load everything twice, my attempts at avoiding it lead to slower code
-            b12 = tl.load(b_ptrs, mask=b_mask)
-            # Note that for simplicity, we don't apply a mask in K here.
-            a = tl.load(a_ptrs, mask=a_mask).to(tl.float32)
-            b = (((b12.to(tl.uint8) >> ((offs_k[:, None] % 2) * 4)) & 0xF).to(tl.float32) - zero) * scale
-            accumulator += tl.dot(a, b)
-
-            # Advance the ptrs to the next K block
-            a_ptrs += BLOCK_SIZE_K * stride_ak
-            b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
-        c = accumulator
-
-        # -----------------------------------------------------------
-        # Write back the block of the output matrix C
-        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-        tl.store(c_ptrs, c, mask=c_mask)
-
-    def qlinear_4bit_weight(inp, weight, scales, zeros):
-        weight = weight.t().contiguous()
-        c_shape = inp.shape[:-1] + weight.shape[-1:]
-        inp = inp.reshape(-1, inp.shape[-1]).contiguous()
-        # we pad the input to amortize triton compilation cost better
-        PAD_TO = 256
-        if inp.shape[0] % PAD_TO != 0:
-            c_crop = inp.shape[0]
-            new_inp_shape0 = inp.shape[0] + PAD_TO - inp.shape[0] % PAD_TO
-            inp2 = inp.new_empty((new_inp_shape0, inp.shape[1]))
-            inp2[: inp.shape[0]] = inp
-            inp2[inp.shape[0] :].zero_()
-            inp = inp2
-        else:
-            c_crop = None
-
-        assert inp.shape[1] == weight.shape[0] * 2, "incompatible dimensions"
-
-        assert scales.shape == (weight.shape[1], 1)
-        assert zeros.shape == (weight.shape[1], 1)
-        scales = scales.contiguous()
-        zeros = zeros.contiguous()
-        K, N = weight.shape
-        M, K = inp.shape
-        assert K % 32 == 0, "We don't check memory-out-of-bounds with K so K must be divisible by BLOCK_SIZE_K"
-        # allocates output
-        c = torch.empty((M, N), device=inp.device, dtype=inp.dtype)
-        # 1D launch kernel where each block gets its own program.
-        grid = lambda META: (triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),)
-        linear_kernel_4bit_weight[grid](
-            inp,
-            weight,
-            c,
-            scales,
-            zeros,
-            M,
-            N,
-            K,
-            inp.stride(0),
-            inp.stride(1),
-            weight.stride(0),
-            weight.stride(1),
-            c.stride(0),
-            c.stride(1),
-        )
-        return c[:c_crop].reshape(c_shape)
+    class Linear4bit(bnb.modules.Linear4bit):
+        def __init__(self, *args, device=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            if device is None:
+                device = torch.tensor(0).device
+            if device.type == "cuda":
+                # weight needs to be moved manually because it doesn't work with device as a context manager:
+                # `weight.to()` gets skipped if `weight.data` is already on CUDA. we avoid it by moving it back
+                # (inefficient). see condition:
+                # https://github.com/TimDettmers/bitsandbytes/blob/817bdf6/bitsandbytes/nn/modules.py#L177
+                self.weight.data = self.weight.data.to("cpu")
+                warnings.filterwarnings("ignore", message=r".*Fabric.setup\(\)` has parameters on different devices.*")
+                # we could manually move `self.weight.to(device)` here but that breaks checkpoint loading
+                # bnb expects that the layers are moved to the device after loading
 
 else:
-    qlinear_4bit_weight = None
 
-
-# for correctness but with terrible perf
-class ColBlockQuantizedLinear(torch.nn.Module):
-    def __init__(self, in_features, out_features, bias: bool, *, bits, tile_cols):
-        super().__init__()
-        self.in_features = in_features
-        self.out_features = out_features
-        self.tile_cols = tile_cols if tile_cols != -1 else self.in_features
-        self.bits = bits
-        self.entries_per_byte = 8 // bits
-        assert self.entries_per_byte > 0 and self.entries_per_byte * self.bits == 8
-        assert in_features % self.entries_per_byte == 0
-        self.register_buffer(
-            "quant_weight",
-            torch.empty((self.out_features, self.in_features // self.entries_per_byte), dtype=torch.uint8)
-            .t()
-            .contiguous()
-            .t(),
-        )
-        self.register_buffer(
-            "scales", torch.empty((self.out_features, (self.in_features + self.tile_cols - 1) // self.tile_cols))
-        )
-        self.register_buffer("zeros", torch.empty_like(self.scales))
-        assert isinstance(bias, bool)
-        if bias:
-            self.register_buffer("bias", torch.empty((self.out_features,)))
-        else:
-            self.register_buffer("bias", None)
-
-    def pack_weight(self, weight):
-        weight = weight.to(device=self.quant_weight.device, copy=True)
-        for j in range(self.scales.size(1)):
-            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] /= self.scales[:, j : j + 1]
-            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] += self.zeros[:, j : j + 1]
-        weight = weight.clamp_(min=0, max=2**self.bits - 1).to(dtype=torch.uint8)
-        self.quant_weight.zero_()
-        for nr in range(self.entries_per_byte):
-            self.quant_weight += weight[:, nr :: self.entries_per_byte] << (nr * self.bits)
-
-    def get_weight(self, dtype=torch.float):
-        weight = torch.empty((self.out_features, self.in_features), device=self.quant_weight.device, dtype=dtype)
-        mask = (1 << self.bits) - 1
-        for nr in range(self.entries_per_byte):
-            weight[:, nr :: self.entries_per_byte] = ((self.quant_weight >> (nr * self.bits)) & mask).float()
-        self.quant_weight.to(dtype)
-        for j in range(self.scales.size(1)):
-            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] -= self.zeros[:, j : j + 1]
-            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] *= self.scales[:, j : j + 1]
-        return weight
-
-    def forward(self, inp):
-        if (
-            triton is not None
-            and self.bits == 4
-            and self.quant_weight.device.type == "cuda"
-            and self.zeros.shape[1] == 1
-            and self.quant_weight.shape[1] % 32 == 0
-        ):
-            return qlinear_4bit_weight(inp, self.quant_weight, self.scales, self.zeros)
-        weight = self.get_weight(dtype=inp.dtype)
-        return torch.nn.functional.linear(inp, weight, self.bias)
-
-
-class GPTQQuantizer:
-    # The algorithm and code has been taken from  https://github.com/IST-DASLab/gptq/
-    # E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
-    # portions copyright by the authors licensed under the Apache License 2.0
-    # All errors are our own.
-
-    def __init__(
-        self,
-        linear_module,
-        *,
-        bits,
-        perchannel=True,
-        sym=False,
-        blocksize=128,
-        percdamp=0.01,
-        groupsize=-1,
-        actorder=False
-    ):
-        assert isinstance(linear_module, torch.nn.Linear)
-
-        self.linear_module = linear_module
-        self.dev = self.linear_module.weight.device
-        self.rows = linear_module.weight.shape[0]
-        self.columns = linear_module.weight.shape[1]
-        self.H = torch.zeros((self.columns, self.columns), device=self.dev)
-        self.nsamples = 0
-        self.bits = bits
-        self.maxq = 2**bits - 1
-        self.perchannel = perchannel
-        self.sym = sym
-        self.blocksize = blocksize
-        self.percdamp = percdamp
-        self.groupsize = groupsize
-        self.actorder = actorder
-        self.tile_cols = self.columns if groupsize == -1 else groupsize
-        self.scales = torch.zeros(
-            (self.rows, (self.columns + self.tile_cols - 1) // self.tile_cols),
-            dtype=self.linear_module.weight.dtype,
-            device=self.dev,
-        )
-        self.zeros = torch.zeros_like(self.scales)
-        assert not (
-            self.actorder and self.groupsize != -1
-        ), "The permutation trick does not work for grouped quantization"
-
-    @staticmethod
-    def quantize_weight(x, scale, zero, maxq):
-        q = torch.clamp(torch.round(x / scale) + zero, 0, maxq)
-        x_rec = scale * (q - zero)
-        return x_rec
-
-    def find_params_weight(self, x):
-        dev = x.device
-
-        shape = x.shape
-        if self.perchannel:
-            x = x.flatten(1)
-        else:
-            x = x.flatten().unsqueeze(0)
-
-        tmp = torch.zeros(x.shape[0], device=dev)
-        xmin = torch.minimum(x.min(1)[0], tmp)
-        xmax = torch.maximum(x.max(1)[0], tmp)
-
-        if self.sym:
-            xmax = torch.maximum(torch.abs(xmin), xmax)
-            tmp = xmin < 0
-            if torch.any(tmp):
-                xmin[tmp] = -xmax[tmp]
-        tmp = (xmin == 0) & (xmax == 0)
-        xmin[tmp] = -1
-        xmax[tmp] = +1
-
-        scale = (xmax - xmin) / self.maxq
-        if self.sym:
-            zero = torch.full_like(scale, (self.maxq + 1) / 2)
-        else:
-            zero = torch.round(-xmin / scale)
-
-        if not self.perchannel:
-            tmp = shape[0]
-            scale = scale.repeat(tmp)
-            zero = zero.repeat(tmp)
-
-        shape = [-1] + [1] * (len(shape) - 1)
-        scale = scale.reshape(shape)
-        zero = zero.reshape(shape)
-        return scale, zero
-
-    def collect_input_stats(self, _1, inp, _2):
-        inp = inp[0].detach()
-        self.last_inp = inp
-        if len(inp.shape) == 2:
-            inp = inp.unsqueeze(0)
-        tmp = inp.shape[0]
-        if len(inp.shape) == 3:
-            inp = inp.reshape((-1, inp.shape[-1]))
-        inp = inp.t()
-        self.H *= self.nsamples / (self.nsamples + tmp)
-        self.nsamples += tmp
-        # inp = inp.float()
-        inp = math.sqrt(2 / self.nsamples) * inp.float()
-        # self.H += 2 / self.nsamples * inp.matmul(inp.t())
-        self.H += inp.matmul(inp.t())
-
-    def quantize(self):
-        W = self.linear_module.weight.detach().to(dtype=torch.float, copy=True)
-
-        scale, zero = self.find_params_weight(W)
-        self.scales[:] = scale
-        self.zeros[:] = zero
-
-        H = self.H
-        del self.H
-        dead = torch.diag(H) == 0
-        H[dead, dead] = 1
-        W[:, dead] = 0
-        if self.actorder:
-            perm = torch.argsort(torch.diag(H), descending=True)
-            W = W[:, perm]
-            H = H[perm][:, perm]
-
-        Losses = torch.zeros_like(W)
-        Q = torch.zeros_like(W)
-
-        damp = self.percdamp * torch.mean(torch.diag(H))
-        diag = torch.arange(self.columns, device=self.dev)
-        H[diag, diag] += damp
-        H = torch.linalg.cholesky(H)
-        H = torch.cholesky_inverse(H)
-        H = torch.linalg.cholesky(H, upper=True)
-        Hinv = H
-
-        for i1 in range(0, self.columns, self.blocksize):
-            i2 = min(i1 + self.blocksize, self.columns)
-            count = i2 - i1
-
-            W1 = W[:, i1:i2].clone()
-            Q1 = torch.zeros_like(W1)
-            Err1 = torch.zeros_like(W1)
-            Losses1 = torch.zeros_like(W1)
-            Hinv1 = Hinv[i1:i2, i1:i2]
-
-            for i in range(count):
-                w = W1[:, i]
-                d = Hinv1[i, i]
-
-                if self.groupsize != -1:
-                    if (i1 + i) % self.groupsize == 0:
-                        scale, zero = self.find_params_weight(W[:, (i1 + i) : (i1 + i + self.groupsize)])
-                        self.scales[:, (i1 + i) // self.groupsize] = scale
-                        self.zeros[:, (i1 + i) // self.groupsize] = zero
-
-                q = self.quantize_weight(w.unsqueeze(1), scale, zero, self.maxq)
-                q = q.squeeze(1)
-                assert q.dim() == 1
-                Q1[:, i] = q
-                Losses1[:, i] = (w - q) ** 2 / d**2
-
-                err1 = (w - q) / d
-                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
-                Err1[:, i] = err1
-
-            Q[:, i1:i2] = Q1
-            Losses[:, i1:i2] = Losses1 / 2
-
-            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
-
-        if self.actorder:
-            invperm = torch.argsort(perm)
-            Q = Q[:, invperm]
-
-        weight = Q.reshape(self.linear_module.weight.shape).to(self.linear_module.weight.data.dtype)
-        error = torch.sum(Losses).item()
-
-        q_module = ColBlockQuantizedLinear(
-            self.linear_module.in_features,
-            self.linear_module.out_features,
-            self.linear_module.bias is not None,
-            bits=self.bits,
-            tile_cols=self.groupsize,
-        ).to(self.dev)
-        q_module.scales = self.scales
-        q_module.zeros = self.zeros
-        q_module.pack_weight(weight)
-        q_module.bias = self.linear_module.bias
-        return q_module, error
+    def __getattr__(name):
+        raise ModuleNotFoundError(str(_BITSANDBYTES_AVAILABLE))

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -9,8 +9,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from datasets import load_dataset
 import torch
+from datasets import load_dataset
 from lightning import Fabric
 
 # support running without installing as a package
@@ -19,6 +19,248 @@ sys.path.append(str(wd))
 
 from lit_gpt import GPT, Tokenizer, Config
 from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load
+
+import triton
+import triton.language as tl
+
+
+# This is adapted from the OpenAI Triton matmul example.
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=3, num_warps=8
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=3, num_warps=8
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=4, num_warps=4
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=5, num_warps=2
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 8}, num_stages=5, num_warps=2
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.jit
+def linear_kernel_4bit_weight(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    bscales_ptr,
+    bzeros_ptr,
+    # bdequant,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. stride_am is how much to increase a_ptr
+    # by to get the element one row down (A has M rows)
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.T.
+    A has shape (M, K), B has shape (N, K) and C has shape (M, N)
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse
+    # See above `L2 Cache Optimizations` section for details
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # a_ptrs is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # b_ptrs is a block of [BLOCK_SIZE_K, BLOCK_SIZE_n] pointers
+    # see above `Pointer Arithmetics` section for details
+    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    a_mask = offs_am[:, None] < M
+    b_mask = offs_bn[None, :] < N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + ((offs_k[:, None] // 2) * stride_bk + offs_bn[None, :] * stride_bn)
+
+    bscales_ptrs = bscales_ptr + offs_bn[None, :]
+    bzeros_ptrs = bzeros_ptr + offs_bn[None, :]
+
+    scale = tl.load(bscales_ptrs)
+    zero = tl.load(bzeros_ptrs)
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, K, BLOCK_SIZE_K):
+        # wasteful as it is to load everything twice, my attempts at avoiding it lead to slower code
+        b12 = tl.load(b_ptrs, mask=b_mask)
+        # Note that for simplicity, we don't apply a mask in K here.
+        a = tl.load(a_ptrs, mask=a_mask).to(tl.float32)
+        b = (((b12.to(tl.uint8) >> ((offs_k[:, None] % 2) * 4)) & 0xF).to(tl.float32) - zero) * scale
+        accumulator += tl.dot(a, b)
+
+        # Advance the ptrs to the next K block
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+    c = accumulator
+
+    # -----------------------------------------------------------
+    # Write back the block of the output matrix C
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def qlinear_4bit_weight(inp, weight, scales, zeros):
+    weight = weight.t().contiguous()
+    c_shape = inp.shape[:-1] + weight.shape[-1:]
+    inp = inp.reshape(-1, inp.shape[-1]).contiguous()
+    # we pad the input to amortize triton compilation cost better
+    PAD_TO = 256
+    if inp.shape[0] % PAD_TO != 0:
+        c_crop = inp.shape[0]
+        new_inp_shape0 = inp.shape[0] + PAD_TO - inp.shape[0] % PAD_TO
+        inp2 = inp.new_empty((new_inp_shape0, inp.shape[1]))
+        inp2[: inp.shape[0]] = inp
+        inp2[inp.shape[0] :].zero_()
+        inp = inp2
+    else:
+        c_crop = None
+
+    assert inp.shape[1] == weight.shape[0] * 2, "incompatible dimensions"
+
+    assert scales.shape == (weight.shape[1], 1)
+    assert zeros.shape == (weight.shape[1], 1)
+    scales = scales.contiguous()
+    zeros = zeros.contiguous()
+    K, N = weight.shape
+    M, K = inp.shape
+    assert K % 32 == 0, "We don't check memory-out-of-bounds with K so K must be divisible by BLOCK_SIZE_K"
+    # allocates output
+    c = torch.empty((M, N), device=inp.device, dtype=inp.dtype)
+    # 1D launch kernel where each block gets its own program.
+    grid = lambda META: (triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),)
+    linear_kernel_4bit_weight[grid](
+        inp,
+        weight,
+        c,
+        scales,
+        zeros,
+        M,
+        N,
+        K,
+        inp.stride(0),
+        inp.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        c.stride(0),
+        c.stride(1),
+    )
+    return c[:c_crop].reshape(c_shape)
+
+
+# for correctness but with terrible perf
+class ColBlockQuantizedLinear(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias: bool, *, bits, tile_cols):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.tile_cols = tile_cols if tile_cols != -1 else self.in_features
+        self.bits = bits
+        self.entries_per_byte = 8 // bits
+        assert self.entries_per_byte > 0 and self.entries_per_byte * self.bits == 8
+        assert in_features % self.entries_per_byte == 0
+        self.register_buffer(
+            "quant_weight",
+            torch.empty((self.out_features, self.in_features // self.entries_per_byte), dtype=torch.uint8)
+            .t()
+            .contiguous()
+            .t(),
+        )
+        self.register_buffer(
+            "scales", torch.empty((self.out_features, (self.in_features + self.tile_cols - 1) // self.tile_cols))
+        )
+        self.register_buffer("zeros", torch.empty_like(self.scales))
+        assert isinstance(bias, bool)
+        if bias:
+            self.register_buffer("bias", torch.empty((self.out_features,)))
+        else:
+            self.register_buffer("bias", None)
+
+    def pack_weight(self, weight):
+        weight = weight.to(device=self.quant_weight.device, copy=True)
+        for j in range(self.scales.size(1)):
+            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] /= self.scales[:, j : j + 1]
+            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] += self.zeros[:, j : j + 1]
+        weight = weight.clamp_(min=0, max=2**self.bits - 1).to(dtype=torch.uint8)
+        self.quant_weight.zero_()
+        for nr in range(self.entries_per_byte):
+            self.quant_weight += weight[:, nr :: self.entries_per_byte] << (nr * self.bits)
+
+    def get_weight(self, dtype=torch.float):
+        weight = torch.empty((self.out_features, self.in_features), device=self.quant_weight.device, dtype=dtype)
+        mask = (1 << self.bits) - 1
+        for nr in range(self.entries_per_byte):
+            weight[:, nr :: self.entries_per_byte] = ((self.quant_weight >> (nr * self.bits)) & mask).float()
+        self.quant_weight.to(dtype)
+        for j in range(self.scales.size(1)):
+            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] -= self.zeros[:, j : j + 1]
+            weight[:, j * self.tile_cols : (j + 1) * self.tile_cols] *= self.scales[:, j : j + 1]
+        return weight
+
+    def forward(self, inp):
+        if (
+            triton is not None
+            and self.bits == 4
+            and self.quant_weight.device.type == "cuda"
+            and self.zeros.shape[1] == 1
+            and self.quant_weight.shape[1] % 32 == 0
+        ):
+            return qlinear_4bit_weight(inp, self.quant_weight, self.scales, self.zeros)
+        weight = self.get_weight(dtype=inp.dtype)
+        return torch.nn.functional.linear(inp, weight, self.bias)
 
 
 class GPTQQuantizer:
@@ -196,7 +438,194 @@ class GPTQQuantizer:
         weight = Q.reshape(self.linear_module.weight.shape).to(self.linear_module.weight.data.dtype)
         error = torch.sum(Losses).item()
 
-        from quantize.bnb import ColBlockQuantizedLinear
+        q_module = ColBlockQuantizedLinear(
+            self.linear_module.in_features,
+            self.linear_module.out_features,
+            self.linear_module.bias is not None,
+            bits=self.bits,
+            tile_cols=self.groupsize,
+        ).to(self.dev)
+        q_module.scales = self.scales
+        q_module.zeros = self.zeros
+        q_module.pack_weight(weight)
+        q_module.bias = self.linear_module.bias
+        return q_module, error
+
+
+class GPTQQuantizer:
+    # The algorithm and code has been taken from  https://github.com/IST-DASLab/gptq/
+    # E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
+    # portions copyright by the authors licensed under the Apache License 2.0
+    # All errors are our own.
+
+    def __init__(
+        self,
+        linear_module,
+        *,
+        bits,
+        perchannel=True,
+        sym=False,
+        blocksize=128,
+        percdamp=0.01,
+        groupsize=-1,
+        actorder=False,
+    ):
+        assert isinstance(linear_module, torch.nn.Linear)
+
+        self.linear_module = linear_module
+        self.dev = self.linear_module.weight.device
+        self.rows = linear_module.weight.shape[0]
+        self.columns = linear_module.weight.shape[1]
+        self.H = torch.zeros((self.columns, self.columns), device=self.dev)
+        self.nsamples = 0
+        self.bits = bits
+        self.maxq = 2**bits - 1
+        self.perchannel = perchannel
+        self.sym = sym
+        self.blocksize = blocksize
+        self.percdamp = percdamp
+        self.groupsize = groupsize
+        self.actorder = actorder
+        self.tile_cols = self.columns if groupsize == -1 else groupsize
+        self.scales = torch.zeros(
+            (self.rows, (self.columns + self.tile_cols - 1) // self.tile_cols),
+            dtype=self.linear_module.weight.dtype,
+            device=self.dev,
+        )
+        self.zeros = torch.zeros_like(self.scales)
+        assert not (
+            self.actorder and self.groupsize != -1
+        ), "The permutation trick does not work for grouped quantization"
+
+    @staticmethod
+    def quantize_weight(x, scale, zero, maxq):
+        q = torch.clamp(torch.round(x / scale) + zero, 0, maxq)
+        x_rec = scale * (q - zero)
+        return x_rec
+
+    def find_params_weight(self, x):
+        dev = x.device
+
+        shape = x.shape
+        if self.perchannel:
+            x = x.flatten(1)
+        else:
+            x = x.flatten().unsqueeze(0)
+
+        tmp = torch.zeros(x.shape[0], device=dev)
+        xmin = torch.minimum(x.min(1)[0], tmp)
+        xmax = torch.maximum(x.max(1)[0], tmp)
+
+        if self.sym:
+            xmax = torch.maximum(torch.abs(xmin), xmax)
+            tmp = xmin < 0
+            if torch.any(tmp):
+                xmin[tmp] = -xmax[tmp]
+        tmp = (xmin == 0) & (xmax == 0)
+        xmin[tmp] = -1
+        xmax[tmp] = +1
+
+        scale = (xmax - xmin) / self.maxq
+        if self.sym:
+            zero = torch.full_like(scale, (self.maxq + 1) / 2)
+        else:
+            zero = torch.round(-xmin / scale)
+
+        if not self.perchannel:
+            tmp = shape[0]
+            scale = scale.repeat(tmp)
+            zero = zero.repeat(tmp)
+
+        shape = [-1] + [1] * (len(shape) - 1)
+        scale = scale.reshape(shape)
+        zero = zero.reshape(shape)
+        return scale, zero
+
+    def collect_input_stats(self, _1, inp, _2):
+        inp = inp[0].detach()
+        self.last_inp = inp
+        if len(inp.shape) == 2:
+            inp = inp.unsqueeze(0)
+        tmp = inp.shape[0]
+        if len(inp.shape) == 3:
+            inp = inp.reshape((-1, inp.shape[-1]))
+        inp = inp.t()
+        self.H *= self.nsamples / (self.nsamples + tmp)
+        self.nsamples += tmp
+        # inp = inp.float()
+        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        # self.H += 2 / self.nsamples * inp.matmul(inp.t())
+        self.H += inp.matmul(inp.t())
+
+    def quantize(self):
+        W = self.linear_module.weight.detach().to(dtype=torch.float, copy=True)
+
+        scale, zero = self.find_params_weight(W)
+        self.scales[:] = scale
+        self.zeros[:] = zero
+
+        H = self.H
+        del self.H
+        dead = torch.diag(H) == 0
+        H[dead, dead] = 1
+        W[:, dead] = 0
+        if self.actorder:
+            perm = torch.argsort(torch.diag(H), descending=True)
+            W = W[:, perm]
+            H = H[perm][:, perm]
+
+        Losses = torch.zeros_like(W)
+        Q = torch.zeros_like(W)
+
+        damp = self.percdamp * torch.mean(torch.diag(H))
+        diag = torch.arange(self.columns, device=self.dev)
+        H[diag, diag] += damp
+        H = torch.linalg.cholesky(H)
+        H = torch.cholesky_inverse(H)
+        H = torch.linalg.cholesky(H, upper=True)
+        Hinv = H
+
+        for i1 in range(0, self.columns, self.blocksize):
+            i2 = min(i1 + self.blocksize, self.columns)
+            count = i2 - i1
+
+            W1 = W[:, i1:i2].clone()
+            Q1 = torch.zeros_like(W1)
+            Err1 = torch.zeros_like(W1)
+            Losses1 = torch.zeros_like(W1)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+
+                if self.groupsize != -1:
+                    if (i1 + i) % self.groupsize == 0:
+                        scale, zero = self.find_params_weight(W[:, (i1 + i) : (i1 + i + self.groupsize)])
+                        self.scales[:, (i1 + i) // self.groupsize] = scale
+                        self.zeros[:, (i1 + i) // self.groupsize] = zero
+
+                q = self.quantize_weight(w.unsqueeze(1), scale, zero, self.maxq)
+                q = q.squeeze(1)
+                assert q.dim() == 1
+                Q1[:, i] = q
+                Losses1[:, i] = (w - q) ** 2 / d**2
+
+                err1 = (w - q) / d
+                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                Err1[:, i] = err1
+
+            Q[:, i1:i2] = Q1
+            Losses[:, i1:i2] = Losses1 / 2
+
+            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+
+        if self.actorder:
+            invperm = torch.argsort(perm)
+            Q = Q[:, invperm]
+
+        weight = Q.reshape(self.linear_module.weight.shape).to(self.linear_module.weight.data.dtype)
+        error = torch.sum(Losses).item()
 
         q_module = ColBlockQuantizedLinear(
             self.linear_module.in_features,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 lightning @ git+https://github.com/Lightning-AI/lightning@master
 tokenizers
 jsonargparse[signatures]  # CLI
-bitsandbytes  # quantize
+bitsandbytes>=0.40.0  # quantize
 scipy  # TODO: remove when bnb has resolved https://github.com/TimDettmers/bitsandbytes/issues/544 and released the fix
 datasets  # quantize/gptq.py
 zstandard  # prepare_redpajama.py

--- a/tutorials/inference.md
+++ b/tutorials/inference.md
@@ -27,32 +27,7 @@ fine-tuned for chatting such as `stabilityai/stablelm-tuned-alpha-3b` or `togeth
 
 ## Run a large model on one smaller device
 
-On GPUs with `bfloat16` support, the `generate.py` script will automatically convert the weights and consume less memory.
-For large models, GPUs with less memory, or ones that don't support `bfloat16`, enable quantization (`--quantize llm.int8`):
-
-```bash
-python generate.py --quantize llm.int8 --prompt "Hello, my name is"
-```
-
-For instance, `falcon-7b` requires ~15 GB without int8 and ~10GB with it. However, inference speed goes from 30 tokens/sec to 10 tokens/sec on an A100.
-See `python generate.py --help` for more options.
-
-You can also use GPTQ-style int4 quantization, but this needs conversions of the weights first:
-
-```bash
-python quantize/gptq.py --precision bf16-true
-```
-
-GPTQ-style int4 quantization brings GPU usage down. As only the weights of the Linear layers are quantized, it is useful to also use `--precision bf16-true` (default) even with the quantization enabled.
-
-With the generated quantized checkpoint generation quantization then works as usual with `--quantize gptq.int4` and the newly generated checkpoint file:
-
-```bash
-python generate.py --quantize gptq.int4
-```
-
-For instance, `falcon-40b` "only" requires ~24 GB to generate using this technique, otherwise more than +40GB are required. On an A100 it takes 1 token/sec.
-However, ~32 GB were required during the conversion step.
+Check out our [quantization tutorial](quantize.md).
 
 ## Run a large model on multiple smaller devices
 

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -19,20 +19,20 @@ Memory used: 14.51 GB
 
 To reduce the memory requirements further, Lit-GPT supports several quantization techniques:
 
-## `qlora.nf4`
+## `bnb.nf4`
 
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
 
 ```bash
-python generate/base.py --quantize qlora.nf4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+python generate/base.py --quantize bnb.nf4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 8.92 sec total, 28.69 tokens/sec
 Memory used: 5.72 GB
 ```
 
-## `qlora.nf4-dq`
+## `bnb.nf4-dq`
 
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
@@ -40,27 +40,26 @@ Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check o
 In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
 
 ```bash
-python generate/base.py --quantize qlora.nf4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+python generate/base.py --quantize bnb.nf4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 12.06 sec total, 21.23 tokens/sec
 Memory used: 5.37 GB
 ```
 
-## `qlora.fp4`
+## `bnb.fp4`
 
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
-The `qlora` suffix is used because this technique was introduced in the QLoRA paper, but it can be used with or without LoRA.
 Uses pure FP4 quantization.
 
 ```bash
-python generate/base.py --quantize qlora.fp4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+python generate/base.py --quantize bnb.fp4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 9.20 sec total, 27.83 tokens/sec
 Memory used: 5.72 GB
 ```
 
-## `qlora.fp4-dq`
+## `bnb.fp4-dq`
 
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
@@ -68,7 +67,7 @@ Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check o
 In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
 
 ```bash
-python generate/base.py --quantize qlora.fp4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+python generate/base.py --quantize bnb.fp4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 12.12 sec total, 21.13 tokens/sec
 Memory used: 5.37 GB

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -8,10 +8,10 @@ However, this might not be enough for large models or when using GPUs with limit
 
 ### Baseline
 
-All the examples below were run using the script parameters ` --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256` on an A100 40GB GPU.
+All the examples below were run on an A100 40GB GPU.
 
 ```bash
-python generate/base.py
+python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 9.76 sec total, 26.23 tokens/sec.
 Memory used: 14.51 GB
@@ -26,7 +26,7 @@ Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check o
 Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
 
 ```bash
-python generate/base.py --quantize qlora.nf4
+python generate/base.py --quantize qlora.nf4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 8.92 sec total, 28.69 tokens/sec
 Memory used: 5.72 GB
@@ -39,7 +39,7 @@ Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check o
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
 
 ```bash
-python generate/base.py --quantize qlora.nf4-dq
+python generate/base.py --quantize qlora.nf4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 12.06 sec total, 21.23 tokens/sec
 Memory used: 5.37 GB
@@ -53,7 +53,7 @@ The `qlora` suffix is used because this technique was introduced in the QLoRA pa
 Uses pure FP4 quantization.
 
 ```bash
-python generate/base.py --quantize qlora.fp4
+python generate/base.py --quantize qlora.fp4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 9.20 sec total, 27.83 tokens/sec
 Memory used: 5.72 GB
@@ -66,7 +66,7 @@ Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check o
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
 
 ```bash
-python generate/base.py --quantize qlora.fp4-dq
+python generate/base.py --quantize qlora.fp4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 12.12 sec total, 21.13 tokens/sec
 Memory used: 5.37 GB
@@ -77,7 +77,7 @@ Memory used: 5.37 GB
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
 
 ```bash
-python generate/base.py --quantize llm.int8
+python generate/base.py --quantize llm.int8 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 24.17 sec total, 10.59 tokens/sec
 Memory used: 8.71 GB
@@ -101,7 +101,7 @@ It is important to note that this conversion step required a considerable amount
 generation then works as usual with `--quantize gptq.int4` which will load the newly quantized checkpoint file:
 
 ```bash
-python generate/base.py --quantize gptq.int4 --precision 32-true
+python generate/base.py --quantize gptq.int4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 32-true --max_new_tokens 256
 ...
 Time for inference 1: 39.50 sec total, 6.48 tokens/sec
 Memory used: 5.05 GB

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -73,12 +73,12 @@ Time for inference 1: 12.12 sec total, 21.13 tokens/sec
 Memory used: 5.37 GB
 ```
 
-## `llm.int8`
+## `bnb.int8`
 
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
 
 ```bash
-python generate/base.py --quantize llm.int8 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+python generate/base.py --quantize bnb.int8 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
 ...
 Time for inference 1: 24.17 sec total, 10.59 tokens/sec
 Memory used: 8.71 GB

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -37,6 +37,7 @@ Memory used: 5.72 GB
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
+In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
 
 ```bash
 python generate/base.py --quantize qlora.nf4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
@@ -64,6 +65,7 @@ Memory used: 5.72 GB
 Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
+In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
 
 ```bash
 python generate/base.py --quantize qlora.fp4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -1,0 +1,108 @@
+# Quantize the model
+
+When `--precision bf16-true` or `--precision 16-true` is used, the model weights will automatically be converted and consume less memory.
+However, this might not be enough for large models or when using GPUs with limited memory.
+
+> **Note**: 
+> Quantization is only supported with inference (generate and chat scripts).
+
+### Baseline
+
+All the examples below were run using the script parameters ` --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256` on an A100 40GB GPU.
+
+```bash
+python generate/base.py
+...
+Time for inference 1: 9.76 sec total, 26.23 tokens/sec.
+Memory used: 14.51 GB
+```
+
+To reduce the memory requirements further, Lit-GPT supports several quantization techniques:
+
+## `llm.int8`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
+
+```bash
+python generate/base.py --quantize llm.int8
+...
+Time for inference 1: 24.17 sec total, 10.59 tokens/sec
+Memory used: 8.71 GB
+```
+
+## `qlora.fp4`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+The `qlora` suffix is used because this technique was introduced in the QLoRA paper, but it can be used with or without LoRA.
+Uses pure FP4 quantization.
+
+```bash
+python generate/base.py --quantize qlora.fp4
+...
+Time for inference 1: 9.20 sec total, 27.83 tokens/sec
+Memory used: 5.72 GB
+```
+
+## `qlora.fp4-dq`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+"dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
+
+```bash
+python generate/base.py --quantize qlora.fp4-dq
+...
+Time for inference 1: 12.12 sec total, 21.13 tokens/sec
+Memory used: 5.37 GB
+```
+
+## `qlora.nf4`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+Uses the normalized float 4 (nf4) data type. This is recommender over "fp4" based on the paper's experimental results and theoretical analysis. 
+
+```bash
+python generate/base.py --quantize qlora.nf4
+...
+Time for inference 1: 8.92 sec total, 28.69 tokens/sec
+Memory used: 5.72 GB
+```
+
+## `qlora.nf4-dq`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+"dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
+
+```bash
+python generate/base.py --quantize qlora.nf4-dq
+...
+Time for inference 1: 12.06 sec total, 21.23 tokens/sec
+Memory used: 5.37 GB
+```
+
+## `gptq.int4`
+
+Check out the [paper](https://arxiv.org/abs/2210.17323) to learn more about how it works.
+
+This technique needs a conversion of the weights first:
+
+```bash
+python quantize/gptq.py --precision bf16-true --checkpoint_dir checkpoints/tiiuae/falcon-7b
+...
+Time for quantization: 850.25 sec total
+Memory used: 23.68 GB
+```
+
+It is important to note that this conversion step required a considerable amount of memory (higher than regular inference) and may take a long time, depending on the size of the model.
+
+generation then works as usual with `--quantize gptq.int4` which will load the newly quantized checkpoint file:
+
+```bash
+python generate/base.py --quantize gptq.int4 --precision 32-true
+...
+Time for inference 1: 39.50 sec total, 6.48 tokens/sec
+Memory used: 5.05 GB
+```

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -19,15 +19,30 @@ Memory used: 14.51 GB
 
 To reduce the memory requirements further, Lit-GPT supports several quantization techniques:
 
-## `llm.int8`
+## `qlora.nf4`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
 
 ```bash
-python generate/base.py --quantize llm.int8
+python generate/base.py --quantize qlora.nf4
 ...
-Time for inference 1: 24.17 sec total, 10.59 tokens/sec
-Memory used: 8.71 GB
+Time for inference 1: 8.92 sec total, 28.69 tokens/sec
+Memory used: 5.72 GB
+```
+
+## `qlora.nf4-dq`
+
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+"dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
+
+```bash
+python generate/base.py --quantize qlora.nf4-dq
+...
+Time for inference 1: 12.06 sec total, 21.23 tokens/sec
+Memory used: 5.37 GB
 ```
 
 ## `qlora.fp4`
@@ -57,30 +72,15 @@ Time for inference 1: 12.12 sec total, 21.13 tokens/sec
 Memory used: 5.37 GB
 ```
 
-## `qlora.nf4`
+## `llm.int8`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
-
-Uses the normalized float 4 (nf4) data type. This is recommender over "fp4" based on the paper's experimental results and theoretical analysis. 
+Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
 
 ```bash
-python generate/base.py --quantize qlora.nf4
+python generate/base.py --quantize llm.int8
 ...
-Time for inference 1: 8.92 sec total, 28.69 tokens/sec
-Memory used: 5.72 GB
-```
-
-## `qlora.nf4-dq`
-
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
-
-"dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
-
-```bash
-python generate/base.py --quantize qlora.nf4-dq
-...
-Time for inference 1: 12.06 sec total, 21.23 tokens/sec
-Memory used: 5.37 GB
+Time for inference 1: 24.17 sec total, 10.59 tokens/sec
+Memory used: 8.71 GB
 ```
 
 ## `gptq.int4`


### PR DESCRIPTION
Adds 4-bit quantization support for inference.

Finetuning should be addressed with #176, but this is a first step in that direction.

Updated doc can be read in https://github.com/Lightning-AI/lit-gpt/blob/carmocca/bnb-0.40/tutorials/quantize.md