### PR TITLE
Use thousands separator in number of parameters output

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -104,9 +104,9 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
     num_params = sum(p.numel() for p in trainable_params)
-    fabric.print(f"Number of trainable parameters: {num_params}")
+    fabric.print(f"Number of trainable parameters: {num_params:,}")
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
-    fabric.print(f"Number of non trainable parameters: {num_params}")
+    fabric.print(f"Number of non trainable parameters: {num_params:,}")
 
     optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -110,9 +110,9 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
     num_params = sum(p.numel() for p in trainable_params)
-    fabric.print(f"Number of trainable parameters: {num_params}")
+    fabric.print(f"Number of trainable parameters: {num_params:,}")
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
-    fabric.print(f"Number of non trainable parameters: {num_params}")
+    fabric.print(f"Number of non trainable parameters: {num_params:,}")
 
     optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -99,7 +99,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
         model.load_state_dict(checkpoint)
 
     num_params = sum(p.numel() for p in model.parameters())
-    fabric.print(f"Number of trainable parameters: {num_params}")
+    fabric.print(f"Number of trainable parameters: {num_params:,}")
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -97,9 +97,9 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
     num_params = sum(p.numel() for p in trainable_params)
-    fabric.print(f"Number of trainable parameters: {num_params}")
+    fabric.print(f"Number of trainable parameters: {num_params:,}")
     num_params = sum(p.numel() for p in model.parameters() if not p.requires_grad)
-    fabric.print(f"Number of non trainable parameters: {num_params}")
+    fabric.print(f"Number of non trainable parameters: {num_params:,}")
 
     optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     model, optimizer = fabric.setup(model, optimizer)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -52,4 +52,4 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     logs = stdout.getvalue()
     assert logs.count("optimizer.step") == module.max_iters
     assert logs.count("val loss") == module.max_iters // module.eval_interval
-    assert "of trainable parameters: 1888" in logs
+    assert "of trainable parameters: 1,888" in logs


### PR DESCRIPTION
Hi there 👋 

As discussed in another [PR](https://github.com/Lightning-AI/lit-gpt/pull/248) this PR will apply nifty formatting for large numbers, which in the case of this project - number of trainable/non-trainable parameters.

As described in Python [docs](https://docs.python.org/3/library/string.html#format-specification-mini-language):
> The ',' option signals the use of a comma for a thousands separator.

So if you provide comma as an argument for formatting it will separate thousands in the number. Comes handy when the number is pretty large: easier to spot either this is 8 or 80 million:

<img width="312" alt="Screenshot 2023-07-13 at 2 28 19 PM" src="https://github.com/Lightning-AI/lit-gpt/assets/58434077/00108a87-522e-4157-98a3-5e8bff04aa9f">