### PR TITLE
Support lora with disabled qkv

### DIFF
--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -89,6 +89,8 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     train_data = torch.load(data_dir / "train.pt")
     val_data = torch.load(data_dir / "test.pt")
 
+    if not any((lora_query, lora_key, lora_value, lora_projection, lora_mlp, lora_head)):
+        fabric.print("Warning: all LoRA layers are disabled!")
     config = Config.from_name(
         name=checkpoint_dir.name,
         r=lora_r,

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -430,7 +430,7 @@ class LoRAQKVLinear(LoRALinear):
         else:
             # `F.linear` automatically transposes the second argument (T(self.weight) in our case)
             result = F.linear(x, T(self.weight), bias=self.bias)  # (64, 64, 128) @ (384, 128) -> (64, 64, 384)
-            if self.r > 0:
+            if self.r > 0 and any(self.enable_lora):
                 after_A = F.linear(self.lora_dropout(x), self.lora_A)  # (64, 64, 128) @ (4, 128) -> (64, 64, 4)
                 # For F.conv1d:
                 # ⚬ input: input tensor of shape (mini-batch, in_channels, iW)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -198,5 +198,21 @@ def test_lora_linear_utilization(apply_to, layer_name):
     config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, **{apply_to: True})
     state_dict = GPT(config).state_dict()
 
-    expected_layer_names = [layer_name + lora_sublayer for lora_sublayer in (".lora_A", ".lora_B")]
-    assert all(layer_name in state_dict for layer_name in expected_layer_names)
+    assert all(layer_name + lora_sublayer in state_dict for lora_sublayer in (".lora_A", ".lora_B"))
+
+
+@pytest.mark.parametrize(
+    "apply_to",
+    (None, "to_query", "to_key", "to_value", "to_projection", "to_mlp", "to_head"),
+)
+def test_lora_layer_forward_no_exception(apply_to):
+    from lit_gpt.lora import GPT, Config
+
+    config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1)
+    if apply_to:
+        setattr(config, apply_to, True)
+    input_ids = torch.tensor([[1]])
+    model = GPT(config)
+    model.eval()
+
+    model(input_ids)


### PR DESCRIPTION
Hi there 👋 

That's basically a leftover from my previous PR that I totally forgot to add.

Despite support of creating `LoRAQKVLinear` without `lora_A/lora_B` at all (if `enabled_lora=(False, False, False)`) by checking 
```python
if self.r > 0 and any(self.enable_lora)
```
in `__init__` and `train` methods, that for some reason hasn't been done in `forward` method (even in the orig code), so if someone wants to apply LoRA to projection head only - it's gonna fail. 