### PR TITLE
Support Flash Attention 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install --index-url https://download.pytorch.org/whl/nightly/cpu --pre 'torc
 **(Optional) install Flash Attention 2**
 
 ```bash
-pip install 'flash-attn>=2.0.0.post1' --no-build-isolation
+MAX_JOBS=4 pip install 'flash-attn>=2.0.0.post1' --no-build-isolation
 ```
 
 All good, now install the dependencies:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ pip install --index-url https://download.pytorch.org/whl/nightly/cu118 --pre 'to
 pip install --index-url https://download.pytorch.org/whl/nightly/cpu --pre 'torch>=2.1.0dev'
 ```
 
+**(Optional) install Flash Attention 2**
+
+```bash
+pip install 'flash-attn>=2.0.0.post1' --no-build-isolation
+```
+
 All good, now install the dependencies:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Don't forget to [join our Discord](https://discord.gg/VptPCZkGNa)!
 - [@TimDettmers](https://github.com/TimDettmers) for [bitsandbytes](https://github.com/TimDettmers/bitsandbytes)
 - [@IST-DASLab](https://github.com/IST-DASLab) for [GPTQ](https://github.com/IST-DASLab/gptq)
 - [@Microsoft](https://github.com/microsoft) for [LoRA](https://github.com/microsoft/LoRA)
-
+- [@tridao](https://github.com/tridao) for [Flash Attention 2](https://github.com/Dao-AILab/flash-attention)
 
 ## License
 

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -5,7 +5,6 @@ https://arxiv.org/abs/2303.16199
 
 Port for Lit-GPT
 """
-import math
 from dataclasses import dataclass
 from typing import Optional, Tuple, Any, List, Union
 

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -250,9 +250,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
                 adapter_kv_cache = (ak, av)
 
             amask = torch.ones(T, aT, dtype=torch.bool, device=x.device)
-            ay = torch.nn.functional.scaled_dot_product_attention(
-                q, ak, av, attn_mask=amask, dropout_p=0.0, is_causal=False
-            )
+            ay = self.scaled_dot_product_attention(q, ak, av, amask)
             y = y + self.gating_factor * ay
 
         y = y.transpose(1, 2).contiguous().view(B, T, C)  # re-assemble all head outputs side by side

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -230,10 +230,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             v = cache_v.index_copy_(2, input_pos, v)
             kv_cache = k, v
 
-        # efficient attention using Flash Attention CUDA kernels
-        y = torch.nn.functional.scaled_dot_product_attention(
-            q, k, v, attn_mask=mask, dropout_p=0.0, scale=1.0 / math.sqrt(self.config.head_size), is_causal=mask is None
-        )
+        y = self.scaled_dot_product_attention(q, k, v, mask=mask)
 
         if self.block_idx >= self.config.adapter_start_layer:
             aT = self.config.adapter_prompt_length

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple, Any
 
 import torch
 import torch.nn as nn
+from lightning_utilities.core.imports import RequirementCache
 from typing_extensions import Self
 
 from lit_gpt.config import Config
@@ -15,6 +16,8 @@ from lit_gpt.rmsnorm import RMSNorm
 
 RoPECache = Tuple[torch.Tensor, torch.Tensor]
 KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+FlashAttention2Available = RequirementCache("flash-attn>=2.0.0.post1")
 
 
 class GPT(nn.Module):
@@ -241,10 +244,7 @@ class CausalSelfAttention(nn.Module):
             v = cache_v.index_copy_(2, input_pos, v)
             kv_cache = k, v
 
-        # efficient attention using Flash Attention CUDA kernels
-        y = torch.nn.functional.scaled_dot_product_attention(
-            q, k, v, attn_mask=mask, dropout_p=0.0, scale=1.0 / math.sqrt(self.config.head_size), is_causal=mask is None
-        )
+        y = self.scaled_dot_product_attention(q, k, v, mask=mask)
 
         y = y.transpose(1, 2).contiguous().view(B, T, C)  # re-assemble all head outputs side by side
 
@@ -252,6 +252,21 @@ class CausalSelfAttention(nn.Module):
         y = self.proj(y)
 
         return y, kv_cache
+
+    def scaled_dot_product_attention(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+            mask: Optional[torch.Tensor] = None):
+        scale = 1.0 / math.sqrt(self.config.head_size)
+        if FlashAttention2Available and mask is None:
+            from flash_attn import flash_attn_func
+            # flash-attn requires (B, T, nh, hs)
+            q = q.permute(0, 2, 1, 3)
+            k = k.permute(0, 2, 1, 3)
+            v = v.permute(0, 2, 1, 3)
+            return flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=scale, causal=True)
+        return torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
+        )
+
 
 
 class GptNeoxMLP(nn.Module):

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -257,14 +257,19 @@ class CausalSelfAttention(nn.Module):
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: Optional[torch.Tensor] = None
     ):
         scale = 1.0 / math.sqrt(self.config.head_size)
-        if FlashAttention2Available and mask is None:
+        if (
+            FlashAttention2Available
+            and mask is None
+            and q.device.type == "cuda"
+            and q.dtype in (torch.float16, torch.bfloat16)
+        ):
             from flash_attn import flash_attn_func
 
             # flash-attn requires (B, T, nh, hs)
-            q = q.permute(0, 2, 1, 3)
-            k = k.permute(0, 2, 1, 3)
-            v = v.permute(0, 2, 1, 3)
-            return flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=scale, causal=True)
+            q = q.transpose(1, 2)
+            k = k.transpose(1, 2)
+            v = v.transpose(1, 2)
+            return flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=scale, causal=True).transpose(1, 2)
         return torch.nn.functional.scaled_dot_product_attention(
             q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
         )

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -253,11 +253,13 @@ class CausalSelfAttention(nn.Module):
 
         return y, kv_cache
 
-    def scaled_dot_product_attention(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
-            mask: Optional[torch.Tensor] = None):
+    def scaled_dot_product_attention(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
         scale = 1.0 / math.sqrt(self.config.head_size)
         if FlashAttention2Available and mask is None:
             from flash_attn import flash_attn_func
+
             # flash-attn requires (B, T, nh, hs)
             q = q.permute(0, 2, 1, 3)
             k = k.permute(0, 2, 1, 3)
@@ -266,7 +268,6 @@ class CausalSelfAttention(nn.Module):
         return torch.nn.functional.scaled_dot_product_attention(
             q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
         )
-
 
 
 class GptNeoxMLP(nn.Module):


### PR DESCRIPTION
The API can be found at https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/flash_attn_interface.py

It has some special functions for MQA and GQA. See `varlen` and `kvpacked` variants. Using them would be more efficient but it would complicate the implementation considerably and PyTorch doesn't support these. For this reason, I only added support for the basic case of having separate `q`, `k`, `v` tensors of equal size

> Multi-query attention and grouped-query attention. Multi-query attention (MQA) [15] and groupedquery attention (GQA) [1] are variants of attention where multiple heads of query attend to the same head of
key and value, in order to reduce the size of KV cache during inference. Instead of having to duplicate the
key and value heads for the computation, we implicitly manipulate the indices into the head to perform the
same computation. In the backward pass, we need to sum the gradients dK and dV across different heads
that were implicitly duplicated.

Right now, `backward` seems broken: https://github.com/Dao-AILab/flash-attention/issues/325

```python
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/_tensor.py", line 491, in backward
    torch.autograd.backward(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/autograd/__init__.py", line 204, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/autograd/function.py", line 274, in apply
    return user_fn(self, *args)
  File "/home/carlos/venv/lib/python3.10/site-packages/flash_attn/flash_attn_interface.py", line 269, in backward
    _flash_attn_backward(
  File "/home/carlos/venv/lib/python3.10/site-packages/flash_attn/flash_attn_interface.py", line 71, in _flash_attn_backward
    dq, dk, dv, softmax_d, = flash_attn_cuda.bwd(
RuntimeError: CUDA error: an illegal memory access was encountered
```