### PR TITLE
Enable fine tuning with QLORA 4-bit floating point and bitsandbytes int8 types.

### DIFF
--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict, Tuple, Literal
 
 import lightning as L
 import torch
@@ -15,7 +15,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt.lora import mark_only_lora_as_trainable, lora_filter, GPT, Config
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
+from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy, quantization
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
 from scripts.prepare_alpaca import generate_prompt
 
@@ -56,6 +56,7 @@ def setup(
     out_dir: Path = Path("out/lora/alpaca"),
     precision: Optional[str] = None,
     tpu: bool = False,
+    quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
 ):
     if precision is None:
         precision = "32-true" if tpu else "bf16-mixed"
@@ -73,10 +74,10 @@ def setup(
     logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
-    fabric.launch(main, data_dir, checkpoint_dir, out_dir)
+    fabric.launch(main, data_dir, checkpoint_dir, out_dir, quantize)
 
 
-def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
+def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path, quantize: Literal):
     check_valid_checkpoint_dir(checkpoint_dir)
 
     speed_monitor = SpeedMonitor(fabric, window_size=50, time_unit="seconds")
@@ -105,7 +106,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     )
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
-    with fabric.init_module(empty_init=False):
+    with fabric.init_module(empty_init=True), quantization(quantize):
         model = GPT(config)
         model.apply(model._init_weights)  # for the LoRA weights
     with lazy_load(checkpoint_path) as checkpoint:

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -203,7 +203,7 @@ class MergedLinear(nn.Linear, LoRALayer):
 
     def reset_parameters(self):
         """Reset all the weights, even including pretrained ones."""
-        nn.Linear.reset_parameters(self)
+        super().reset_parameters()
         if hasattr(self, "lora_A"):
             # initialize A the same way as the default for nn.Linear and B to zero
             # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314
@@ -267,7 +267,7 @@ class MergedLinear(nn.Linear, LoRALayer):
 
         # despite being called from nn.Linear this method will put all layers into train mode, including nn.Dropout
         # of course except parameters (such as self.lora_A, self.lora_B)
-        nn.Linear.train(self, mode)
+        super().train(mode)
 
         # if train(True) -> unmerge unless we already have them unmerged
         # if train(False) -> merge unless we already have them merged


### PR DESCRIPTION
Added quantize command-line option.  Allowed values are "bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", and "bnb.int8". GPTQ int4 format only supports inference, not training.

Note that fabric.init_module needed empty_init=True for bnb.int8 training; otherwise, a RuntimeError: "normal_kernel_cuda" not implemented for 'Char' error is thrown.

Only lora.py was extensively tested (see https://github.com/Lightning-AI/lit-gpt/issues/242#issuecomment-1640539404 for some results).  adapter.py was only tested to the point of running about 1K iterations for each of the quantization types.
