### PR TITLE
Make a note that bitsandbytes only support Cuda and Linux.

### DIFF
--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -21,7 +21,9 @@ To reduce the memory requirements further, Lit-GPT supports several quantization
 
 ## `bnb.nf4`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+
+> **Note**: for now `bitsandbytes` only supports `CUDA` device and `Linux` operating system.
 
 Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
 

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -3,7 +3,7 @@
 When `--precision bf16-true` or `--precision 16-true` is used, the model weights will automatically be converted and consume less memory.
 However, this might not be enough for large models or when using GPUs with limited memory.
 
-> **Note**: 
+> **Note**:
 > Quantization is only supported with inference (generate and chat scripts).
 
 ### Baseline
@@ -25,7 +25,7 @@ Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check 
 
 > **Note**: `bitsandbytes` only supports `CUDA` devices and the `Linux` operating system.
 
-Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
+Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis.
 
 ```bash
 python generate/base.py --quantize bnb.nf4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
@@ -36,7 +36,7 @@ Memory used: 5.72 GB
 
 ## `bnb.nf4-dq`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
 In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
@@ -50,7 +50,7 @@ Memory used: 5.37 GB
 
 ## `bnb.fp4`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 Uses pure FP4 quantization.
 
@@ -63,7 +63,7 @@ Memory used: 5.72 GB
 
 ## `bnb.fp4-dq`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
+Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
 "dq" stands for "Double Quantization" which reduces the average memory footprint by quantizing the quantization constants.
 In average, this amounts to about 0.37 bits per parameter (approximately 3 GB for a 65B model).
@@ -77,7 +77,7 @@ Memory used: 5.37 GB
 
 ## `bnb.int8`
 
-Enabled with [bitsandbyes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
+Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2110.02861) to learn more about how it works.
 
 ```bash
 python generate/base.py --quantize bnb.int8 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -23,7 +23,7 @@ To reduce the memory requirements further, Lit-GPT supports several quantization
 
 Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
-> **Note**: for now `bitsandbytes` only supports `CUDA` device and `Linux` operating system.
+> **Note**: `bitsandbytes` only supports `CUDA` devices and the `Linux` operating system.
 
 Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis. 
 


### PR DESCRIPTION
Hi there 👋 

Since `bitsandbytes` only supports `CUDA` device and `Linux` operating system I decided that it worth mentioning it in the quantize tutorial.