### PR TITLE
Refactor LoRA weights merging + support FSDP

### DIFF
--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -132,11 +132,6 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.time()
-    
-    # sanity check
-    save_path = out_dir / "sanity_checkpoint.pth"
-    save_lora_checkpoint(fabric, model, save_path)
-
     train(fabric, model, optimizer, train_data, val_data, checkpoint_dir, out_dir, speed_monitor)
     fabric.print(f"Training time: {(time.time()-train_time):.2f}s")
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -6,14 +6,14 @@ from typing import Optional, List, Dict, Tuple
 
 import lightning as L
 import torch
-from lightning.fabric.strategies import XLAStrategy
+from lightning.fabric.strategies import XLAStrategy, FSDPStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.lora import mark_only_lora_as_trainable, lora_filter, GPT, Config
+from lit_gpt.lora import mark_only_lora_as_trainable, lora_filter, GPT, Config, Block
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
@@ -24,7 +24,7 @@ eval_interval = 100
 save_interval = 100
 eval_iters = 100
 log_interval = 1
-devices = 1
+devices = 2
 # change this value to force a maximum sequence length
 override_max_seq_length = None
 
@@ -66,7 +66,11 @@ def setup(
             fabric_devices = "auto"
             strategy = XLAStrategy(sync_module_states=False)
         else:
-            raise NotImplementedError
+            precision="bf16-true"
+            strategy=FSDPStrategy(
+                auto_wrap_policy={Block},
+                activation_checkpointing_policy={Block},
+            )
     else:
         strategy = "auto"
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -52,7 +52,7 @@ hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str))
 
 def setup(
     data_dir: Path = Path("data/alpaca"),
-    checkpoint_dir: Path = Path("stabilityai/stablelm-base-alpha-3b"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/lora/alpaca"),
     precision: Optional[str] = None,
     tpu: bool = False,

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -24,7 +24,7 @@ eval_interval = 100
 save_interval = 100
 eval_iters = 100
 log_interval = 1
-devices = 2
+devices = 1
 # change this value to force a maximum sequence length
 override_max_seq_length = None
 
@@ -52,7 +52,7 @@ hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str))
 
 def setup(
     data_dir: Path = Path("data/alpaca"),
-    checkpoint_dir: Path = Path("checkpoints/EleutherAI/pythia-1b"),
+    checkpoint_dir: Path = Path("stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/lora/alpaca"),
     precision: Optional[str] = None,
     tpu: bool = False,

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -34,8 +34,8 @@ lora_head = False
 def main(
     prompt: str = "What food do lamas eat?",
     input: str = "",
-    lora_path: Path = Path("lit_model_lora_finetuned.pth"),
-    checkpoint_dir: Path = Path("stabilityai/stablelm-base-alpha-3b"),
+    lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -15,7 +15,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.lora import GPT, Config, Block
+from lit_gpt.lora import GPT, Config, Block, merge_lora_weights
 from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
 from scripts.prepare_alpaca import generate_prompt
 
@@ -34,8 +34,8 @@ lora_head = False
 def main(
     prompt: str = "What food do lamas eat?",
     input: str = "",
-    lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    lora_path: Path = Path("out/lora/alpaca/sanity_checkpoint.pth"),
+    checkpoint_dir: Path = Path("checkpoints/EleutherAI/pythia-1b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -111,6 +111,7 @@ def main(
     fabric.print(f"Time to load the model weights: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
+    merge_lora_weights(model)
     model = fabric.setup(model)
 
     tokenizer = Tokenizer(checkpoint_dir)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -34,8 +34,8 @@ lora_head = False
 def main(
     prompt: str = "What food do lamas eat?",
     input: str = "",
-    lora_path: Path = Path("out/lora/alpaca/sanity_checkpoint.pth"),
-    checkpoint_dir: Path = Path("checkpoints/EleutherAI/pythia-1b"),
+    lora_path: Path = Path("lit_model_lora_finetuned.pth"),
+    checkpoint_dir: Path = Path("stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -676,6 +676,5 @@ class LLaMAMLP(lit_gpt.model.LLaMAMLP):
 def merge_lora_weights(model: GPT) -> None:
     """Merge LoRA weights into the full-rank weights to speed up inference."""
     for module in model.modules():
-        merge_fn = getattr(module, "merge", None)
-        if callable(merge_fn):
-            merge_fn()
+        if isinstance(module, LoRALinear):
+            module.merge()

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -674,6 +674,7 @@ class LLaMAMLP(lit_gpt.model.LLaMAMLP):
 
 
 def merge_lora_weights(model: GPT) -> None:
+    """Merge LoRA weights into the full-rank weights to speed up inference."""
     for module in model.modules():
         merge_fn = getattr(module, "merge", None)
         if callable(merge_fn):

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -151,36 +151,17 @@ class LoRALinear(nn.Linear, LoRALayer):
             nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
             nn.init.zeros_(self.lora_B)
 
-    # def train(self, mode: bool = True):
-    #     """Set the module into train or eval mode.
+    def merge(self):
+        """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
 
-    #     Args:
-    #         mode: if True the module will be set into train mode, if False - eval mode.
-    #     """
+        def T(w):
+            return w.transpose(0, 1) if self.fan_in_fan_out else w
 
-    #     def T(w):
-    #         return w.transpose(0, 1) if self.fan_in_fan_out else w
-
-    #     # despite being called from nn.Linear this method will put all layers into train mode, including nn.Dropout
-    #     # of course except parameters (such as self.lora_A, self.lora_B)
-    #     super().train(mode)
-
-    #     # if we want to put the layer into `train` mode then subtract LoRA weights if weights are already merged, so we
-    #     # can keep original weights untouched and train LoRA's matrices A and B separately.
-    #     # if we want to put into 'eval` mode - merge pretrained weights with LoRA's matrices A and B (if it's not
-    #     # already done) to reduce computation overhead during inference.
-    #     if mode:
-    #         if self.merge_weights and self.merged:
-    #             # Make sure that the weights are not merged
-    #             if self.r > 0:
-    #                 self.weight.data -= T(self.lora_B @ self.lora_A) * self.scaling
-    #             self.merged = False
-    #     else:
-    #         if self.merge_weights and not self.merged:
-    #             # Merge the weights and mark it
-    #             if self.r > 0:
-    #                 self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
-    #             self.merged = True
+        if self.merge_weights and not self.merged:
+            # Merge the weights and mark it
+            if self.r > 0:
+                self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
+            self.merged = True
 
     def forward(self, x: torch.Tensor):
         def T(w):
@@ -354,50 +335,30 @@ class LoRAQKVLinear(LoRALinear):
         result = result.index_copy(1, self.lora_ind, x.reshape(-1, shape))  # (4096, 256)
         return result.view((*x.shape[:-1], self.out_features)).transpose(0, 1)  # (64, 64, 384)
 
-    # def train(self, mode: bool = True):
-    #     """Set the module into train or eval mode if `mode` is True of False respectively.
+    def merge(self):
+        """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
 
-    #     For train mode (train(True)) if weights are merged we need to subtract weights updates (LoRA_A @ LoRA_B) from
-    #     pretrained weights so we can continue training LoRA's matrices A and B and keep pretrained weights frozen.
+        def T(w):
+            return w.T if self.fan_in_fan_out else w
 
-    #     For eval mode (train(False)) if weights are not merged we need to add weight updates to pretrained weights in
-    #     order to reduce computational overhead during inference.
-
-    #     Args:
-    #         mode: if True the module will be set into train mode (affects Dropout and BatchNorm), if False - eval mode.
-
-    #     """
-
-    #     def T(w):
-    #         return w.T if self.fan_in_fan_out else w
-
-    #     # despite being called from nn.Linear this method will put all layers into train mode, including nn.Dropout
-    #     # of course except parameters (such as self.lora_A, self.lora_B)
-    #     super(LoRALinear, self).train(mode)
-
-    #     # if train(True) -> unmerge unless we already have them unmerged
-    #     # if train(False) -> merge unless we already have them merged
-    #     should = self.merged if mode else not self.merged
-
-    #     # Let's assume that:
-    #     # ⚬ self.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
-    #     # ⚬ self.lora_A.data: (4, 128)
-    #     # ⚬ self.lora_B.data: (256, 2)
-    #     if self.merge_weights and should:
-    #         if self.r > 0 and any(self.enable_lora):
-    #             delta_w = F.conv1d(
-    #                 self.lora_A.data.unsqueeze(0),  # (4, 128) -> (1, 4, 128)
-    #                 self.lora_B.data.unsqueeze(-1),  # (256, 2) -> (256, 2, 1)
-    #                 groups=sum(self.enable_lora),
-    #             ).squeeze(
-    #                 0
-    #             )  # (1, 4, 128) @ (256, 2, 1) -> (1, 256, 128) -> (256, 128)
-    #             # -1: W = W - delta_W (unmerge), +1: W = W + delta_W (merge)
-    #             sign = -1 if mode else 1
-    #             self.weight.data += sign * self.zero_pad(
-    #                 T(delta_w * self.scaling)
-    #             )  # (256, 128) after zero_pad (384, 128)
-    #         self.merged = not mode
+        # Let's assume that:
+        # ⚬ self.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
+        # ⚬ self.lora_A.data: (4, 128)
+        # ⚬ self.lora_B.data: (256, 2)
+        if self.merge_weights and not self.merged:
+            if self.r > 0 and any(self.enable_lora):
+                delta_w = F.conv1d(
+                    self.lora_A.data.unsqueeze(0),  # (4, 128) -> (1, 4, 128)
+                    self.lora_B.data.unsqueeze(-1),  # (256, 2) -> (256, 2, 1)
+                    groups=sum(self.enable_lora),
+                ).squeeze(
+                    0
+                )  # (1, 4, 128) @ (256, 2, 1) -> (1, 256, 128) -> (256, 128)
+                # W = W + delta_W (merge)
+                self.weight.data += self.zero_pad(
+                    T(delta_w * self.scaling)
+                )  # (256, 128) after zero_pad (384, 128)
+            self.merged = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Do the forward pass.
@@ -710,3 +671,10 @@ class LLaMAMLP(lit_gpt.model.LLaMAMLP):
             lora_alpha=config.alpha,
             lora_dropout=config.dropout,
         )
+
+
+def merge_lora_weights(model: GPT) -> None:
+    for module in model.modules():
+        merge_fn = getattr(module, "merge", None)
+        if callable(merge_fn):
+            merge_fn()

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -288,7 +288,7 @@ class LoRAQKVLinear(LoRALinear):
                 lora_ind.append(
                     torch.arange(self.in_features + self.kv_embd_size, self.out_features, device=self.weight.device)
                 )
-            self.register_buffer("lora_ind", torch.cat(lora_ind))
+            self.register_buffer("lora_ind", torch.cat(lora_ind), persistent=False)
         self.reset_parameters()
         if fan_in_fan_out:
             self.weight.data = self.weight.data.T
@@ -443,7 +443,7 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
 
 
 def lora_filter(key: str, value: Any) -> bool:
-    return "lora_" in key and "lora_ind" not in key
+    return "lora_" in key
 
 
 @dataclass

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -443,7 +443,7 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = "none") -> None:
 
 
 def lora_filter(key: str, value: Any) -> bool:
-    return "lora_" in key
+    return "lora_" in key and "lora_ind" not in key
 
 
 @dataclass


### PR DESCRIPTION
Fixes #161

Refactors the merging of LoRA weights.

**Before:**
Merging was implemented in `model.eval()`, and "unmerging" was implemented in `model.train()`. This was done to speed up the forward pass for inference where LoRA matrices aren't needed. Unmerging was needed to bring the weights back for optimization (assuming validation is interleaved at periodic intervals with training). However, due to the fact that the `eval()/train()` methods access the weights, they are sharded and so computations on them can't be performed directly. In FSDP, the full weights are only available during the forward. 

**Now:**
We don't need merging and unmerging implemented in `eval()/train()`. Our validation loop will be slightly slower but we can afford that cost since we're not validating extensively. The impact is not noticeable. Hence, we can move the implementation to a separate `merge()` method that can be used outside of training, e.g. when performing inference (see `generate/lora.py`).
Thus, `eval()` and `train()` are now used in the normal way without merging code, and are compatible with FSDP.

Notes:
1. Verified loss is decreasing, no negative impacts on convergence (1b pythia models, 4 devices, trained until loss < 1.0)
2. Instantiation is slow because model gets created in CPU memory first. This is expected because we don't yet have a reliable fast implementation for init-module with FSDP. 


