### PR TITLE
Use modernized llama spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hackable [implementation](lit_gpt/model.py) of state-of-the-art open-source larg
 
 Supports popular public checkpoints such as:
 
-- Meta AI [LLaMA 2](tutorials/download_llama_2.md)
+- Meta AI [Llama 2](tutorials/download_llama_2.md)
 - Stability AI [FreeWilly2](tutorials/download_freewilly_2.md)
 - TII UAE [Falcon](tutorials/download_falcon.md)
 - OpenLM Research [OpenLLaMA](tutorials/download_openllama.md)

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -555,7 +555,7 @@ def main(
     n_samples: int = 128,
     precision: str = "bf16-true",
 ) -> None:
-    """Generates text samples based on a pre-trained LLaMA model and tokenizer.
+    """Generates text samples based on a pre-trained LLM and tokenizer.
 
     Args:
         checkpoint_dir: The checkpoint directory to load.

--- a/tutorials/download_freewilly_2.md
+++ b/tutorials/download_freewilly_2.md
@@ -2,7 +2,7 @@
 ## Download [FreeWilly 2](https://stability.ai/blog/freewilly-large-instruction-fine-tuned-models) weights
 
 Stability AI announced FreeWilly inspired by the methodology pioneered by Microsoft in its paper: "Orca: Progressive Learning from Complex Explanation Traces of GPT-4”.
-FreeWilly2 leverages the LLaMA 2 70B foundation model to reach a performance that compares favorably with GPT-3.5 for some tasks.
+FreeWilly2 leverages the Llama 2 70B foundation model to reach a performance that compares favorably with GPT-3.5 for some tasks.
 
 
 ```bash

--- a/tutorials/download_llama_2.md
+++ b/tutorials/download_llama_2.md
@@ -1,4 +1,4 @@
-## Download [LLaMA 2](https://ai.meta.com/llama) weights
+## Download [Llama 2](https://ai.meta.com/llama) weights
 
 Meta developed and publicly released the Llama 2 family of large language models (LLMs), a collection of pretrained and
 fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. Its fine-tuned LLMs,
@@ -6,7 +6,7 @@ called Llama-2-Chat, are optimized for dialogue use cases. Llama-2-Chat models o
 most benchmarks we tested, and in our human evaluations for helpfulness and safety, are on par with some popular
 closed-source models like ChatGPT and PaLM.
 
-Llama 2 models are trained on 2 trillion tokens (40% more data than Llama 1) and have double the context length of Llama 1 (4096 tokens).
+Llama 2 models are trained on 2 trillion tokens (40% more data than LLaMA 1) and have double the context length of LLaMA 1 (4096 tokens).
 
 Llama 2 comes in a range of parameter sizes — 7B, 13B, and 70B — as well as pretrained and fine-tuned variations.
 


### PR DESCRIPTION
Being a hairsplitter, this PR addresses the LLaMA vs Llama 2 capitalization. Like others pointed out to me, for Llama 2 the official spelling does not use capitalization. (Others like the NeurIPS challenge organizers also distinguish between LLaMA and Llama 2 :))