### PR TITLE
Add note about neurips challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 ---
 
-**NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1GPU + 1Day**
+**NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
 
-Lit-GPT is the official starter kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is focused on tackling the three main challenges of LLMs: 1) transparency, 2) standard benchmarks, and 3) hardware access. 
+Lit-GPT is the official starter kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is competition centered around training a foundational (base) LLM for 24h on a single A100 or 4090.
 
 If you are interested in participating, you can learn more about the official NeurIPS LLM efficiency challenge website [here](https://llm-efficiency-challenge.github.io). **The submission deadline is Oct 15th, 2023.**
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 ---
 
-**NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
+**🏆 NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
 
 The Lit-GPT is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing foundational (base) LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 **NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
 
-Lit-GPT is the official starter kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is competition centered around training a foundational (base) LLM for 24h on a single A100 or 4090.
+The Lit-GPT is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing foundational (base) LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
 
-If you are interested in participating, you can learn more about the official NeurIPS LLM efficiency challenge website [here](https://llm-efficiency-challenge.github.io). **The submission deadline is Oct 15th, 2023.**
+If you are interested in participating, you can learn more about the NeurIPS LLM Efficiency Challenge on the official website [here](https://llm-efficiency-challenge.github.io). 
+
+**The submission deadline is Oct 15th, 2023.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,23 @@ Supports popular public checkpoints such as:
 
 This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-llama) and [nanoGPT](https://github.com/karpathy/nanoGPT), and it's **powered by [Lightning Fabric](https://lightning.ai/docs/fabric/stable/) ⚡**.
 
-## Design principles
+
+
+---
+
+**NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1GPU + 1Day**
+
+Lit-GPT is the official starter-kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is focused on tackling the three main challenges of LLMs: 1) transparency, standard benchmarks, and 3) hardware access. 
+
+If you are interested in participating, you can learn more on the official NeurIPS LLM efficiency challenge website [here](https://llm-efficiency-challenge.github.io). **The submission deadline is Oct 15th, 2023.**
+
+---
+
+
+
+
+
+## Lit-GPT design principles
 
 This repository follows the main principle of **openness through clarity**.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 **NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1GPU + 1Day**
 
-Lit-GPT is the official starter-kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is focused on tackling the three main challenges of LLMs: 1) transparency, standard benchmarks, and 3) hardware access. 
+Lit-GPT is the official starter kit of the [NeurIPS 2023 LLM efficiency challenge](https://llm-efficiency-challenge.github.io), which is focused on tackling the three main challenges of LLMs: 1) transparency, 2) standard benchmarks, and 3) hardware access. 
 
-If you are interested in participating, you can learn more on the official NeurIPS LLM efficiency challenge website [here](https://llm-efficiency-challenge.github.io). **The submission deadline is Oct 15th, 2023.**
+If you are interested in participating, you can learn more about the official NeurIPS LLM efficiency challenge website [here](https://llm-efficiency-challenge.github.io). **The submission deadline is Oct 15th, 2023.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 **🏆 NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
 
-The Lit-GPT is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing non-instruction tuned LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
+The Lit-GPT repository is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing non-instruction tuned LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
 
 If you are interested in participating, you can learn more about the NeurIPS LLM Efficiency Challenge on the official website [here](https://llm-efficiency-challenge.github.io). 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 **🏆 NeurIPS 2023 Large Language Model Efficiency Challenge: 1 LLM + 1 GPU + 1 Day**
 
-The Lit-GPT is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing foundational (base) LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
+The Lit-GPT is the official starter kit for the [NeurIPS 2023 LLM Efficiency Challenge](https://llm-efficiency-challenge.github.io), which is a competition focused on finetuning an existing non-instruction tuned LLM for 24 hours on a single GPU. The competition has two tracks, one for the A100 and another for the 4090 GPUs.
 
 If you are interested in participating, you can learn more about the NeurIPS LLM Efficiency Challenge on the official website [here](https://llm-efficiency-challenge.github.io). 
 


### PR DESCRIPTION
Given that Lit-GPT was elected as the official starter kit for the NeurIPS 2023 challenge, I thought it may be worthwhile mentioning it in the Readme. 

It's really nice that the challenge has the 1 day 1 GPU restriction, and I bet a lot of researchers might be interested in participating but haven't heard of the challenge yet.