### PR TITLE
Extend explanations in quantize doc and add 32-bit baseline

### DIFF
--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -14,13 +14,13 @@ It's useful to start with a baseline to have a reference point for memory saving
 
 
 ```bash
-python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 32-full --max_new_tokens 256
+python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 32-true --max_new_tokens 256
 ...
 Time for inference 1: 10.69 sec total, 23.95 tokens/sec.
 Memory used: 28.95 GB
 ```bash
 
-First, using a lower precision compared to 32-bit float can result in two times reduced memory consumption. You can either try setting `--precision 16-full` for regular 16-bit precision or  `--precision bf16-full` if your GPU supports brain-float 16-bit precision. ([This brief video](https://lightning.ai/courses/deep-learning-fundamentals/9.0-overview-techniques-for-speeding-up-model-training/unit-9.1-accelerated-model-training-via-mixed-precision-training/) explains the difference between regular 16-bit and bf16-bit precision.) 
+First, using a lower precision compared to 32-bit float can result in two times reduced memory consumption. You can either try setting `--precision 16-true` for regular 16-bit precision or  `--precision bf16-true` if your GPU supports brain-float 16-bit precision. ([This brief video](https://lightning.ai/courses/deep-learning-fundamentals/9.0-overview-techniques-for-speeding-up-model-training/unit-9.1-accelerated-model-training-via-mixed-precision-training/) explains the difference between regular 16-bit and bf16-bit precision.) 
 
 
 In short, when `--precision bf16-true` or `--precision 16-true` is used, the model weights will automatically be converted and consume less memory.

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -1,14 +1,32 @@
 # Quantize the model
 
-When `--precision bf16-true` or `--precision 16-true` is used, the model weights will automatically be converted and consume less memory.
-However, this might not be enough for large models or when using GPUs with limited memory.
+This document provides different strategies for quantizing the various models available in Lit-GPT to reduce GPU memory usage, which is useful for running larger models on certain GPU hardware. 
+
+**All the examples below were run on an A100 40GB GPU.**
 
 > **Note**:
 > Quantization is only supported with inference (generate and chat scripts).
 
+
 ### Baseline
 
-All the examples below were run on an A100 40GB GPU.
+It's useful to start with a baseline to have a reference point for memory savings via the various quantization methods.
+
+
+```bash
+python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 32-full --max_new_tokens 256
+...
+Time for inference 1: 10.69 sec total, 23.95 tokens/sec.
+Memory used: 28.95 GB
+```bash
+
+First, using a lower precision compared to 32-bit float can result in two times reduced memory consumption. You can either try setting `--precision 16-full` for regular 16-bit precision or  `--precision bf16-full` if your GPU supports brain-float 16-bit precision. ([This brief video](https://lightning.ai/courses/deep-learning-fundamentals/9.0-overview-techniques-for-speeding-up-model-training/unit-9.1-accelerated-model-training-via-mixed-precision-training/) explains the difference between regular 16-bit and bf16-bit precision.) 
+
+
+In short, when `--precision bf16-true` or `--precision 16-true` is used, the model weights will automatically be converted and consume less memory.
+However, this might not be enough for large models or when using GPUs with limited memory.
+
+
 
 ```bash
 python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
@@ -17,7 +35,10 @@ Time for inference 1: 9.76 sec total, 26.23 tokens/sec.
 Memory used: 14.51 GB
 ```
 
-To reduce the memory requirements further, Lit-GPT supports several quantization techniques:
+To reduce the memory requirements further, Lit-GPT supports several quantization techniques, which are shown below. 
+
+> **Note**:
+> Most quantization examples below also use the `--precision bf16-true` setting explained above. If your GPU does not support the bfloat-format, you can change it to `--precision 16-true`.
 
 ## `bnb.nf4`
 


### PR DESCRIPTION
I added a 32-bit baseline and extended the explanations a bit.