### PR TITLE
LoRA fixes/simplifications

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -452,17 +452,14 @@ class GPT(BaseModel):
         assert config.padded_vocab_size is not None
         self.config = config
 
-        if config.to_head:
-            self.lm_head = LoRALinear(
-                config.n_embd,
-                config.padded_vocab_size,
-                bias=False,
-                r=config.r,
-                lora_alpha=config.alpha,
-                lora_dropout=config.dropout,
-            )
-        else:
-            self.lm_head = nn.Linear(config.n_embd, config.padded_vocab_size, bias=False)
+        self.lm_head = LoRALinear(
+            config.n_embd,
+            config.padded_vocab_size,
+            bias=False,
+            r=config.r if config.to_head else 0,
+            lora_alpha=config.alpha,
+            lora_dropout=config.dropout,
+        )
 
         self.transformer = nn.ModuleDict(
             dict(
@@ -577,17 +574,14 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             n_query_groups=config.n_query_groups,
         )
         # output projection
-        if config.to_projection:
-            self.proj = LoRALinear(
-                config.n_embd,
-                config.n_embd,
-                bias=config.bias,
-                r=config.r,
-                lora_alpha=config.alpha,
-                lora_dropout=config.dropout,
-            )
-        else:
-            self.proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
+        self.proj = LoRALinear(
+            config.n_embd,
+            config.n_embd,
+            bias=config.bias,
+            r=config.r if config.to_projection else 0,
+            lora_alpha=config.alpha,
+            lora_dropout=config.dropout,
+        )
 
         self.config = config
 

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -62,7 +62,7 @@ from lit_gpt.model import (
 
 
 class LoRALayer:
-    def __init__(self, r: int, lora_alpha: int, lora_dropout: float, merge_weights: bool):
+    def __init__(self, r: int, lora_alpha: int, lora_dropout: float):
         """Store LoRA specific attributes in a class.
 
         Args:
@@ -72,9 +72,6 @@ class LoRALayer:
                 "This scaling helps to reduce the need to retune hyperparameters when we vary r"
                 https://arxiv.org/pdf/2106.09685.pdf (section 4.1)
             lora_dropout: dropout that is applied on the input in the LoRA branch (before multiplying by matrix A)
-            merge_weights: whether we want to merge pretrained weights and LoRA weight updates. This is useful if one wants to use
-                fine-tuned model as a standalone one (without storing LoRA weights separately) plus it helps to reduce
-                overhead during inference.
         """
         self.r = r
         self.lora_alpha = lora_alpha
@@ -85,7 +82,6 @@ class LoRALayer:
             self.lora_dropout = lambda x: x
         # Mark the weight as unmerged
         self.merged = False
-        self.merge_weights = merge_weights
 
 
 class LoRALinear(nn.Linear, LoRALayer):
@@ -100,7 +96,6 @@ class LoRALinear(nn.Linear, LoRALayer):
         lora_alpha: int = 1,
         lora_dropout: float = 0.0,
         fan_in_fan_out: bool = False,
-        merge_weights: bool = True,
         **kwargs,
     ):
         """LoRA wrapper around linear class.
@@ -120,15 +115,12 @@ class LoRALinear(nn.Linear, LoRALayer):
                 "This scaling helps to reduce the need to retune hyperparameters when we vary r"
                 https://arxiv.org/pdf/2106.09685.pdf (section 4.1)
             lora_dropout: dropout that is applied on the input in the LoRA branch (before multiplying by matrix A)
-            fan_in_fan_out: set this to True if the layer to replace stores weight like (fan_in, fan_out).  For example, gpt-2 uses
+            fan_in_fan_out: set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses
                 `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`
                 https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora.py#LL53C9-L53C112
-            merge_weights: whether we want to merge pretrained weights and LoRA weight updates. This is useful if one wants to use
-                fine-tuned model as a standalone one (without storing LoRA weight separately) plus it helps to reduce
-                overhead during inference.
         """
         super().__init__(in_features, out_features, **kwargs)
-        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout, merge_weights=merge_weights)
+        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
 
         self.fan_in_fan_out = fan_in_fan_out
         # Actual trainable parameters
@@ -157,7 +149,7 @@ class LoRALinear(nn.Linear, LoRALayer):
         def T(w):
             return w.transpose(0, 1) if self.fan_in_fan_out else w
 
-        if self.merge_weights and not self.merged:
+        if not self.merged:
             # Merge the weights and mark it
             if self.r > 0:
                 self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
@@ -194,7 +186,6 @@ class LoRAQKVLinear(LoRALinear):
         lora_dropout: float = 0.0,
         enable_lora: Union[bool, Tuple[bool, bool, bool]] = False,
         fan_in_fan_out: bool = False,
-        merge_weights: bool = True,
         **kwargs,
     ):
         """LoRA wrapper around linear class that is used for calculation of q, k and v matrices.
@@ -219,15 +210,12 @@ class LoRAQKVLinear(LoRALinear):
             enable_lora: MergeLinear class is for attention mechanism where qkv are calculated with a single weight matrix. If we
                 don't want to apply LoRA we can set it as False. For example if we want to apply LoRA only to `query`
                 and `value` but keep `key` without weight updates we should pass `[True, False, True]`
-            fan_in_fan_out: set this to True if the layer to replace stores weight like (fan_in, fan_out).  For example, gpt-2 uses
+            fan_in_fan_out: set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses
                 `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`
                 https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora.py#LL53C9-L53C112
-            merge_weights: whether we want to merge pretrained weights and LoRA weight updates. This is useful if one wants to use
-                fine-tuned model as a standalone one (without storing LoRA weight separately) plus it helps to reduce
-                overhead during inference.
         """
         super().__init__(in_features, out_features, **kwargs)
-        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout, merge_weights=merge_weights)
+        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
         if isinstance(enable_lora, bool):
             enable_lora = [enable_lora] * 3
         assert len(enable_lora) == 3
@@ -345,7 +333,7 @@ class LoRAQKVLinear(LoRALinear):
         # ⚬ self.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
         # ⚬ self.lora_A.data: (4, 128)
         # ⚬ self.lora_B.data: (256, 2)
-        if self.merge_weights and not self.merged:
+        if not self.merged:
             if self.r > 0 and any(self.enable_lora):
                 delta_w = F.conv1d(
                     self.lora_A.data.unsqueeze(0),  # (4, 128) -> (1, 4, 128)
@@ -601,7 +589,6 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             lora_dropout=config.dropout,
             enable_lora=(config.to_query, config.to_key, config.to_value),
             fan_in_fan_out=False,
-            merge_weights=True,
             bias=config.bias,
             # for MQA/GQA support
             n_head=config.n_head,

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -35,7 +35,7 @@ def test_lora_merge():
     )
     model = GPT(config)
     model.train()
-    
+
     initial_weight = model.transformer.h[0].attn.proj.weight.clone()
     assert torch.equal(model.transformer.h[0].attn.proj.weight, initial_weight)
 
@@ -201,18 +201,38 @@ def test_lora_init_when_linear_overridden():
 
 
 @pytest.mark.parametrize(
-    ("apply_to", "layer_name"),
-    (("to_projection", "transformer.h.0.attn.proj"), ("to_mlp", "transformer.h.0.mlp.fc"), ("to_head", "lm_head")),
+    ("apply_to", "target_layer_names", "mlp_class_name"),
+    (
+        ("to_projection", "transformer.h.0.attn.proj", "GptNeoxMLP"),
+        ("to_mlp", ("transformer.h.0.mlp.fc", "transformer.h.0.mlp.proj"), "GptNeoxMLP"),
+        ("to_head", "lm_head", "GptNeoxMLP"),
+        ("to_projection", "transformer.h.0.attn.proj", "LLaMAMLP"),
+        ("to_mlp", ("transformer.h.0.mlp.fc_1", "transformer.h.0.mlp.fc_2", "transformer.h.0.mlp.proj"), "LLaMAMLP"),
+        ("to_head", "lm_head", "LLaMAMLP"),
+    ),
 )
-def test_lora_linear_utilization(apply_to, layer_name):
+def test_lora_linear_utilization(apply_to, target_layer_names, mlp_class_name):
     from lit_gpt.lora import GPT, Config
 
     config = Config(
         n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, **{apply_to: True}
     )
+    config._mlp_class = mlp_class_name
     state_dict = GPT(config).state_dict()
 
-    assert all(layer_name + lora_sublayer in state_dict for lora_sublayer in (".lora_A", ".lora_B"))
+    if isinstance(target_layer_names, str):
+        target_layer_names = (target_layer_names,)
+    lora_sublayers = (".lora_A", ".lora_B")
+
+    # check that all the target layers have LoRA weights
+    for layer_name in target_layer_names:
+        for lora_sublayer in lora_sublayers:
+            assert layer_name + lora_sublayer in state_dict
+
+    # check that only target layers have LoRA weights
+    for key in state_dict:
+        if key.endswith(lora_sublayers):
+            assert key.startswith(target_layer_names)
 
 
 @pytest.mark.parametrize("apply_to", (None, "to_query", "to_key", "to_value", "to_projection", "to_mlp", "to_head"))


### PR DESCRIPTION
Hello there 👋 

This PR contains couple of fixes/simplifications for LoRA:

1. There is no need to have `self.merge` attribute. Previously it could be used to prevent from merging pretrained and LoRA weights when `self.train` method is called. Since now we have a separate method for it (`self.merge`) we can get rid of the attribute. Besides it is hardcoded to be always True (in `CausalSelfAttention`) anyway.
2. Instead of transposing function `T` in every merge/forward method a class method `def T` is created.
3. Slightly simplified if statements for merge/forward methods. Plus added printing info if the weights cannot be merged as they are disabled either via rank value or enable_lora booleans. `Verbose` argument was added to control those print statements: if someone manually applies `merge` this person might want to see the info, but when we call `merge_lora_weights` we might not want to see it (as we could use regular Linear layer for e.g. projection and it was done through setting r = 0 so it's expected behavior and there is no need to show this info). Although I'm not 100% sure that it's a perfect solution so we can discuss it in the comment.
4. Tests now check that LoRA applied to only the target layers (and for both MLP classes).