### PR TITLE
Mark LoRA and pretrained weights as merged only when it's possible

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -143,17 +143,20 @@ class LoRALinear(nn.Linear, LoRALayer):
             nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
             nn.init.zeros_(self.lora_B)
 
-    def merge(self):
-        """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
+    def merge(self, verbose: bool = True):
+        """Merges the LoRA weights into the full-rank weights (W = W + delta_W).
 
+        Args:
+            verbose: notify if something is preventing from merging the weights
+        """
         def T(w):
             return w.transpose(0, 1) if self.fan_in_fan_out else w
 
-        if not self.merged:
-            # Merge the weights and mark it
-            if self.r > 0:
-                self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
+        if self.r > 0 and not self.merged:
+            self.weight.data += T(self.lora_B @ self.lora_A) * self.scaling
             self.merged = True
+        elif self.r <= 0 and verbose:
+            print("LoRA weights are disabled and thus cannot be merged.")
 
     def forward(self, x: torch.Tensor):
         def T(w):
@@ -323,8 +326,12 @@ class LoRAQKVLinear(LoRALinear):
         result = result.index_copy(1, self.lora_ind, x.reshape(-1, shape))  # (4096, 256)
         return result.view((*x.shape[:-1], self.out_features)).transpose(0, 1)  # (64, 64, 384)
 
-    def merge(self):
-        """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
+    def merge(self, verbose: bool = True):
+        """Merges the LoRA weights into the full-rank weights (W = W + delta_W).
+
+        Args:
+            verbose: notify if something is preventing from merging the weights
+        """
 
         def T(w):
             return w.T if self.fan_in_fan_out else w
@@ -333,20 +340,21 @@ class LoRAQKVLinear(LoRALinear):
         # ⚬ self.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
         # ⚬ self.lora_A.data: (4, 128)
         # ⚬ self.lora_B.data: (256, 2)
-        if not self.merged:
-            if self.r > 0 and any(self.enable_lora):
-                delta_w = F.conv1d(
-                    self.lora_A.data.unsqueeze(0),  # (4, 128) -> (1, 4, 128)
-                    self.lora_B.data.unsqueeze(-1),  # (256, 2) -> (256, 2, 1)
-                    groups=sum(self.enable_lora),
-                ).squeeze(
-                    0
-                )  # (1, 4, 128) @ (256, 2, 1) -> (1, 256, 128) -> (256, 128)
-                # W = W + delta_W (merge)
-                self.weight.data += self.zero_pad(
-                    T(delta_w * self.scaling)
-                )  # (256, 128) after zero_pad (384, 128)
+        if all((self.r > 0, any(self.enable_lora), not self.merged)):
+            delta_w = F.conv1d(
+                self.lora_A.data.unsqueeze(0),  # (4, 128) -> (1, 4, 128)
+                self.lora_B.data.unsqueeze(-1),  # (256, 2) -> (256, 2, 1)
+                groups=sum(self.enable_lora),
+            ).squeeze(0)  # (1, 4, 128) @ (256, 2, 1) -> (1, 256, 128) -> (256, 128)
+            # W = W + delta_W (merge)
+            self.weight.data += self.zero_pad(
+                T(delta_w * self.scaling)
+            )  # (256, 128) after zero_pad (384, 128)
             self.merged = True
+        elif self.r <= 0 and verbose:
+            print("LoRA weights are disabled and thus cannot be merged.")
+        elif not any(self.enable_lora) and verbose:
+            print("LoRA weights are disabled for query, key and value matrices and thus cannot be merged.")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Do the forward pass.
@@ -664,4 +672,4 @@ def merge_lora_weights(model: GPT) -> None:
     """Merge LoRA weights into the full-rank weights to speed up inference."""
     for module in model.modules():
         if isinstance(module, LoRALinear):
-            module.merge()
+            module.merge(verbose=False)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -247,3 +247,33 @@ def test_lora_layer_forward_no_exception(apply_to):
     model.eval()
 
     model(input_ids)
+
+
+@pytest.mark.parametrize(("rank", "expected_merged"), ((-1, False), (0, False), (1, True)))
+def test_lora_linear_weights_merged_status(rank, expected_merged):
+    from lit_gpt.lora import LoRALinear
+
+    layer = LoRALinear(10, 10, r=rank)
+    assert not layer.merged
+    layer.merge()
+    assert layer.merged == expected_merged
+
+
+@pytest.mark.parametrize(
+    ("rank", "enable_lora", "expected_merged"),
+    (
+        (-1, True, False),
+        (0, True, False),
+        (1, True, True),
+        (-1, False, False),
+        (0, False, False),
+        (1, False, False),
+    ),
+)
+def test_lora_qkv_linear_weights_merged_status(rank, enable_lora, expected_merged):
+    from lit_gpt.lora import LoRAQKVLinear
+
+    layer = LoRAQKVLinear(10, 3 * 10, n_head=2, n_query_groups=2, r=rank, enable_lora=enable_lora)
+    assert not layer.merged
+    layer.merge()
+    assert layer.merged == expected_merged


### PR DESCRIPTION
Hi there 👋 

The rationale for this PR is that anyone who uses modules from lora file (maybe for neurips challenge) should know if `merge` method in fact cannot merge the weights either because `rank` is set to zero or to a negative value (which disables LoRA and leaves only pretrained weights) or through setting all `enable_lora` booleans as False.

`Verbose` argument was added to control it.
For example we can intentionally disable LoRA weights for let's say `projection` layer but still want to use `LoRALinear` class. It's possible to do by setting rank to be zero. In such case we don't need to pollute logs with information that merging is not possible as it's an expected behavior.
For instance in `merge_lora_weights`.

In contrary anyone who explicitly calls `merge` method by default should see if anything goes wrong.