### PR TITLE
Check if the checkpoint path exists before lazy loading it

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -1,5 +1,5 @@
 """Utility functions for training and inference."""
-
+import os
 import pickle
 import sys
 import warnings
@@ -217,8 +217,10 @@ class LazyLoadingUnpickler(pickle.Unpickler):
 
 
 class lazy_load:
-    def __init__(self, fn):
-        self.zf = torch._C.PyTorchFileReader(str(fn))
+    def __init__(self, path: Union[Path, str]) -> None:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Path {str(path)!r} does not exist or is not a file.")
+        self.zf = torch._C.PyTorchFileReader(str(path))
         with BytesIO(self.zf.get_record("data.pkl")) as pkl:
             mup = LazyLoadingUnpickler(pkl, self)
             self.sd = mup.load()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 import os
-import pathlib
 import sys
-import tempfile
 from contextlib import redirect_stderr
 from io import StringIO
 
@@ -14,39 +12,38 @@ class ATensor(torch.Tensor):
     pass
 
 
-def test_lazy_load_basic():
+def test_lazy_load_basic(tmp_path):
     import lit_gpt.utils
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        m = torch.nn.Linear(5, 3)
-        path = pathlib.Path(tmpdirname)
-        fn = str(path / "test.pt")
-        torch.save(m.state_dict(), fn)
-        with lit_gpt.utils.lazy_load(fn) as sd_lazy:
-            assert "NotYetLoadedTensor" in str(next(iter(sd_lazy.values())))
-            m2 = torch.nn.Linear(5, 3)
-            m2.load_state_dict(sd_lazy)
+    fn = str(tmp_path / "test.pt")
+    with pytest.raises(FileNotFoundError, match="test.pt' does not exist"), lit_gpt.utils.lazy_load(fn) as sd_lazy:
+        pass
 
-        x = torch.randn(2, 5)
-        actual = m2(x)
-        expected = m(x)
-        torch.testing.assert_close(actual, expected)
+    m = torch.nn.Linear(5, 3)
+    torch.save(m.state_dict(), fn)
+    with lit_gpt.utils.lazy_load(fn) as sd_lazy:
+        assert "NotYetLoadedTensor" in str(next(iter(sd_lazy.values())))
+        m2 = torch.nn.Linear(5, 3)
+        m2.load_state_dict(sd_lazy)
+
+    x = torch.randn(2, 5)
+    actual = m2(x)
+    expected = m(x)
+    torch.testing.assert_close(actual, expected)
 
 
-def test_lazy_load_subclass():
+def test_lazy_load_subclass(tmp_path):
     import lit_gpt.utils
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        path = pathlib.Path(tmpdirname)
-        fn = str(path / "test.pt")
-        t = torch.randn(2, 3)[:, 1:]
-        sd = {1: t, 2: torch.nn.Parameter(t), 3: torch.Tensor._make_subclass(ATensor, t)}
-        torch.save(sd, fn)
-        with lit_gpt.utils.lazy_load(fn) as sd_lazy:
-            for k in sd:
-                actual = sd_lazy[k]
-                expected = sd[k]
-                torch.testing.assert_close(actual._load_tensor(), expected)
+    fn = str(tmp_path / "test.pt")
+    t = torch.randn(2, 3)[:, 1:]
+    sd = {1: t, 2: torch.nn.Parameter(t), 3: torch.Tensor._make_subclass(ATensor, t)}
+    torch.save(sd, fn)
+    with lit_gpt.utils.lazy_load(fn) as sd_lazy:
+        for k in sd:
+            actual = sd_lazy[k]
+            expected = sd[k]
+            torch.testing.assert_close(actual._load_tensor(), expected)
 
 
 def test_find_multiple():


### PR DESCRIPTION
When using `--lora_path` or `--adapter_path` in the `generate/` scripts & someone accidentally specifies a non-existing path or a folder instead of a checkpoint file there was a `PytorchStreamReader failed` error. I added more specific error messages to help users debug input path issues.