### PR TITLE
Make all args required in `convert_lit_checkpoint`

### DIFF
--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -217,7 +217,7 @@ def convert_lit_checkpoint(
 
     # checkpoint_name cannot be hardcoded because there exists different outputs such as
     # ("lit_model_finetuned.pth", "lit_model_lora_finetuned.pth", "lit_model_adapter_finetuned.pth"")
-    pth_file = checkpoint_dir / checkpoint_name
+    pth_file = out_dir / checkpoint_name
     bin_file = pth_file.with_suffix(".bin")
 
     with incremental_save(bin_file) as saver:

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -200,7 +200,7 @@ def maybe_unwrap_state_dict(lit_weights: Dict[str, torch.Tensor]) -> Dict[str, t
 def convert_lit_checkpoint(
     *,
     checkpoint_name: str,
-    checkpoint_dir: Path,
+    out_dir: Path,
     model_name: str,
 ) -> None:
     config = Config.from_name(model_name)

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -200,11 +200,9 @@ def maybe_unwrap_state_dict(lit_weights: Dict[str, torch.Tensor]) -> Dict[str, t
 def convert_lit_checkpoint(
     *,
     checkpoint_name: str,
-    checkpoint_dir: Path = Path("checkpoints/tiiuae/falcon-7b"),
-    model_name: Optional[str] = None,
+    checkpoint_dir: Path,
+    model_name: str,
 ) -> None:
-    if model_name is None:
-        model_name = checkpoint_dir.name
     config = Config.from_name(model_name)
 
     if "falcon" in model_name:

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -206,7 +206,7 @@ def test_maybe_unwrap_state_dict(tmp_path):
 
     # convert and check that model key does not exist
     # and that a known key for pythia exists
-    convert_lit_checkpoint(checkpoint_name=ckpt_name, checkpoint_dir=tmp_path, model_name=model_name)
+    convert_lit_checkpoint(checkpoint_name=ckpt_name, out_dir=tmp_path, model_name=model_name)
     bin_file = ckpt_path.with_suffix(".bin")
     ckpt_from_unwrapped = torch.load(bin_file)
     assert ckpt_from_unwrapped.get("model") is None
@@ -214,5 +214,5 @@ def test_maybe_unwrap_state_dict(tmp_path):
 
     # assert maybe_unwrap_state_dict is called
     with mock.patch("scripts.convert_lit_checkpoint.maybe_unwrap_state_dict") as maybe_unwrap:
-        convert_lit_checkpoint(checkpoint_name=ckpt_name, checkpoint_dir=tmp_path, model_name=model_name)
+        convert_lit_checkpoint(checkpoint_name=ckpt_name, out_dir=tmp_path, model_name=model_name)
     maybe_unwrap.assert_called()

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -15,12 +15,12 @@ def test_convert_lit_checkpoint(tmp_path):
     ckpt_name = "lit_model.pth"
 
     with pytest.raises(RuntimeError, match="open file failed because of errno 2 on fopen"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_name, checkpoint_dir=tmp_path, model_name="falcon-7b")
+        convert_lit_checkpoint(checkpoint_name=ckpt_name, out_dir=tmp_path, model_name="falcon-7b")
 
     ckpt_path = tmp_path / "lit_model.pth"
     ckpt_path.touch()
     with mock.patch("scripts.convert_lit_checkpoint.lazy_load") as load:
-        convert_lit_checkpoint(checkpoint_name=ckpt_name, checkpoint_dir=tmp_path, model_name="falcon-7b")
+        convert_lit_checkpoint(checkpoint_name=ckpt_name, out_dir=tmp_path, model_name="falcon-7b")
     load.assert_called_with(ckpt_path)
 
     assert {p.name for p in tmp_path.glob("*")} == {"lit_model.pth", "lit_model.bin"}
@@ -51,7 +51,7 @@ def test_convert_lit_checkpoint_llama2(tmp_path):
     # save checkpoint to avoid RunTimeError for PytorchStreamReader
     save_checkpoint(fabric, ours_model, ckpt_path)
     # this should not cause a TypeError
-    convert_lit_checkpoint(checkpoint_name=ckpt_name, checkpoint_dir=tmp_path, model_name=model_name)
+    convert_lit_checkpoint(checkpoint_name=ckpt_name, out_dir=tmp_path, model_name=model_name)
 
 
 @torch.inference_mode()


### PR DESCRIPTION
This PR makes all arguments of `convert_lit_checkpoint` required. More context as to why is provided below.

The default output during finetuning saves checkpoints in the shown manner.

<img width="254" src="https://github.com/Lightning-AI/lit-gpt/assets/26209687/bdeb510d-63ab-44dd-9b60-f124b5604954">

This structure does not set the model name correctly when using the current method shown below.

```python
def convert_lit_checkpoint(
    *,
    checkpoint_name: str,
    checkpoint_dir: Path = Path("checkpoints/tiiuae/falcon-7b"),
    model_name: Optional[str] = None,
) -> None:
    if model_name is None:
        model_name = checkpoint_dir.name
    config = Config.from_name(model_name)
```

Making all args required allows users to convert exactly the finetuned model they intend to convert with something similar to:

```sh
python scripts/convert_lit_checkpoint.py \
    --checkpoint_name lit_model_adapter_finetuned.pth  \
    --checkpoint_dir out/adapter_v2/alpaca/ \
    --model_name Llama-2-7b-chat-hf
```
