### PR TITLE
Fix LoRA with grouped queries

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -261,8 +261,8 @@ def test_lora_gpt_apply_lora_forward_no_exception(apply_to):
         ),
     ),
 )
-def test_lora_gpt_query_groups_forward_no_exception(n_query_groups, apply_to):
-    from lit_gpt.lora import GPT, Config, mark_only_lora_as_trainable
+def test_lora_gpt_query_groups_merge_and_forward_no_exception(n_query_groups, apply_to):
+    from lit_gpt.lora import GPT, Config, merge_lora_weights
 
     keys = ("to_query", "to_key", "to_value")
     values = apply_to
@@ -281,7 +281,9 @@ def test_lora_gpt_query_groups_forward_no_exception(n_query_groups, apply_to):
         **apply_to,
     )
     model = GPT(config)
-    mark_only_lora_as_trainable(model)
+    merge_lora_weights(model)
+    input_ids = torch.tensor([[1]])
+    model(input_ids)
 
 
 @torch.inference_mode()

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -79,8 +79,23 @@ def test_lora_mqa_gqa():
         alpha=8,
         dropout=0.1,
         to_query=True,
+        # to_key=True,
         to_value=True,
     )
+    # Falcon-7B config
+    # config = Config(
+    #     block_size=2048,
+    #     padded_vocab_size=65024,
+    #     n_layer=32,
+    #     n_head=71,
+    #     n_embd=4544,
+    #     rotary_percentage=1.0,
+    #     parallel_residual=True,
+    #     n_query_groups=1,
+    #     bias=False,
+    #     # this is not in the config, but in the original model implementation, only for this config
+    #     shared_attention_norm=True,
+    # )
     assert config.n_query_groups == config.n_head
     model = GPT(config)
     attn = model.transformer.h[0].attn.attn
@@ -247,6 +262,27 @@ def test_lora_layer_forward_no_exception(apply_to):
     model.eval()
 
     model(input_ids)
+
+@torch.inference_mode()
+def test_lora_layer_forward_no_exception_1():
+    from lit_gpt.lora import GPT, Config
+
+    # config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, to_query=True, to_key=True, to_value=True)
+    config = Config(n_layer=1, n_head=6, n_query_groups=2, n_embd=12, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, to_query=True, to_key=True, to_value=True)
+    input_ids = torch.tensor([[1]])
+    model = GPT(config)
+
+    model(input_ids)
+
+@torch.inference_mode()
+def test_lora_layer_forward_no_exception_2():
+    from lit_gpt.lora import GPT, Config, merge_lora_weights
+
+    # config = Config(n_layer=1, n_head=4, n_embd=8, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, to_query=True, to_key=True, to_value=True)
+    config = Config(n_layer=1, n_head=6, n_query_groups=2, n_embd=12, block_size=1, vocab_size=1, r=2, alpha=8, dropout=0.1, to_query=True, to_key=True, to_value=True)
+    input_ids = torch.tensor([[1]])
+    model = GPT(config)
+    merge_lora_weights(model)
 
 
 @pytest.mark.parametrize(("rank", "expected_merged"), ((-1, False), (0, False), (1, True)))


### PR DESCRIPTION
Hi there 👋 

Fixes #348: there you can find error output
Fixes #357:  a technical explanation of the problem

----

In a nutshell the solution is to use `torch.nn.functional.conv1d` with `groups` parameter when grouped queries are not used (number of heads is equal to the number of query groups: see the scheme in `lit_gpt/config.py:Config`) and in other case do it manually: split input and weight tensors to the correct shapes, apply each weight matrix to the corresponding input matrix, concatenate the result.

----

Tested on a single T4 with `Pythia-410m` with default parameters (except `max_iters` which I set to a 1,000).
```bash
python finetune/lora.py --checkpoint_dir checkpoints/EleutherAI/pythia-410m  --data_dir data/alpaca/ --precision 16-mixed
```

I used this model as it's relatively small and doesn't require these changes (as it doesn't use grouped queries) so it allows to compare two approaches: conv1d with `groups` parameter and manual one with splitting and concatenating tensors:
1. conv1d with groups finished in 169 seconds
2. manual approach finished in 128 seconds

Loss after 1,000 iterations is the same in both cases: ~1.801

So it looks like splitting a tensor is not only doesn't hurt performance, but in fact brings some speed improvements. At least in case of this particular model on this particular dataset running on this particular hardware.