### PR TITLE
Use composition with LoRA

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -102,7 +102,7 @@ class LoRALinear(LoRALayer):
         """LoRA wrapper around linear class.
 
         This class has three weight matrices:
-            1. Pretrained weights are stored as `self.linear.weight` (because of the nn.Linear inheritance)
+            1. Pretrained weights are stored as `self.linear.weight`
             2. LoRA A matrix as `self.lora_A`
             3. LoRA B matrix as `self.lora_B`
         Only LoRA's A and B matrices are updated, pretrained weights stay frozen.
@@ -137,7 +137,7 @@ class LoRALinear(LoRALayer):
 
     def reset_parameters(self):
         """Reset all the weights, even including pretrained ones."""
-        if self.r > 0:
+        if hasattr(self, "lora_A"):
             # initialize A the same way as the default for nn.Linear and B to zero
             # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314
             nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
@@ -185,7 +185,7 @@ class LoRAQKVLinear(LoRALinear):
         """LoRA wrapper around linear class that is used for calculation of q, k and v matrices.
 
         This class has three weight matrices:
-            1. Pretrained weights are stored as `self.linear.weight` (because of the nn.Linear inheritance)
+            1. Pretrained weights are stored as `self.linear.weight`
             2. LoRA A matrix as `self.lora_A`
             3. LoRA B matrix as `self.lora_B`
         Only LoRA's A and B matrices are updated, pretrained weights stay frozen.
@@ -208,7 +208,8 @@ class LoRAQKVLinear(LoRALinear):
                 `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`
                 https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora.py#LL53C9-L53C112
         """
-        super().__init__(in_features, out_features, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout, **kwargs)
+        super(LoRALinear, self).__init__(r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
+        self.linear = torch.nn.Linear(in_features, out_features, **kwargs)
         if isinstance(enable_lora, bool):
             enable_lora = [enable_lora] * 3
         assert len(enable_lora) == 3

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -61,7 +61,7 @@ from lit_gpt.model import (
 )
 
 
-class LoRALayer:
+class LoRALayer(nn.Module):
     def __init__(self, r: int, lora_alpha: int, lora_dropout: float):
         """Store LoRA specific attributes in a class.
 
@@ -73,6 +73,7 @@ class LoRALayer:
                 https://arxiv.org/pdf/2106.09685.pdf (section 4.1)
             lora_dropout: dropout that is applied on the input in the LoRA branch (before multiplying by matrix A)
         """
+        super().__init__()
         self.r = r
         self.lora_alpha = lora_alpha
         # Optional dropout
@@ -84,7 +85,7 @@ class LoRALayer:
         self.merged = False
 
 
-class LoRALinear(nn.Linear, LoRALayer):
+class LoRALinear(LoRALayer):
     # LoRA implemented in a dense layer
     def __init__(
         self,
@@ -101,7 +102,7 @@ class LoRALinear(nn.Linear, LoRALayer):
         """LoRA wrapper around linear class.
 
         This class has three weight matrices:
-            1. Pretrained weights are stored as `self.weight` (because of the nn.Linear inheritance)
+            1. Pretrained weights are stored as `self.linear.weight` (because of the nn.Linear inheritance)
             2. LoRA A matrix as `self.lora_A`
             3. LoRA B matrix as `self.lora_B`
         Only LoRA's A and B matrices are updated, pretrained weights stay frozen.
@@ -119,24 +120,23 @@ class LoRALinear(nn.Linear, LoRALayer):
                 `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`
                 https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora.py#LL53C9-L53C112
         """
-        super().__init__(in_features, out_features, **kwargs)
-        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
+        super().__init__(r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
+        self.linear = torch.nn.Linear(in_features, out_features, **kwargs)
 
         self.fan_in_fan_out = fan_in_fan_out
         # Actual trainable parameters
         if r > 0:
-            self.lora_A = nn.Parameter(self.weight.new_zeros((r, in_features)))
-            self.lora_B = nn.Parameter(self.weight.new_zeros((out_features, r)))
+            self.lora_A = nn.Parameter(self.linear.weight.new_zeros((r, in_features)))
+            self.lora_B = nn.Parameter(self.linear.weight.new_zeros((out_features, r)))
             self.scaling = self.lora_alpha / self.r
             # Freezing the pre-trained weight matrix
-            self.weight.requires_grad = False
+            self.linear.weight.requires_grad = False
         self.reset_parameters()
         if fan_in_fan_out:
-            self.weight.data = self.weight.data.transpose(0, 1)
+            self.linear.weight.data = self.linear.weight.data.transpose(0, 1)
 
     def reset_parameters(self):
         """Reset all the weights, even including pretrained ones."""
-        super().reset_parameters()
         if hasattr(self, "lora_A"):
             # initialize A the same way as the default for nn.Linear and B to zero
             # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314
@@ -149,16 +149,15 @@ class LoRALinear(nn.Linear, LoRALayer):
 
     def merge(self):
         """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
-
         if self.r > 0 and not self.merged:
             # Merge the weights and mark it
-            self.weight.data += self.T(self.lora_B @ self.lora_A) * self.scaling
+            self.linear.weight.data += self.T(self.lora_B @ self.lora_A) * self.scaling
             self.merged = True
 
     def forward(self, x: torch.Tensor):
         # if weights are merged or rank is less or equal to zero (LoRA is disabled) - it's only a regular nn.Linear forward pass;
         # otherwise in addition do the forward pass with LoRA weights and add it's output to the output from pretrained weights
-        result = F.linear(x, self.T(self.weight), bias=self.bias)
+        result = F.linear(x, self.T(self.linear.weight), bias=self.linear.bias)
         if self.r > 0 and not self.merged:
             result += (
                 self.lora_dropout(x) @ self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1)
@@ -186,7 +185,7 @@ class LoRAQKVLinear(LoRALinear):
         """LoRA wrapper around linear class that is used for calculation of q, k and v matrices.
 
         This class has three weight matrices:
-            1. Pretrained weights are stored as `self.weight` (because of the nn.Linear inheritance)
+            1. Pretrained weights are stored as `self.linear.weight` (because of the nn.Linear inheritance)
             2. LoRA A matrix as `self.lora_A`
             3. LoRA B matrix as `self.lora_B`
         Only LoRA's A and B matrices are updated, pretrained weights stay frozen.
@@ -209,8 +208,7 @@ class LoRAQKVLinear(LoRALinear):
                 `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`
                 https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora.py#LL53C9-L53C112
         """
-        super().__init__(in_features, out_features, **kwargs)
-        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout)
+        super().__init__(in_features, out_features, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout, **kwargs)
         if isinstance(enable_lora, bool):
             enable_lora = [enable_lora] * 3
         assert len(enable_lora) == 3
@@ -224,11 +222,11 @@ class LoRAQKVLinear(LoRALinear):
         # ⚬ r: 2
         # ⚬ enable_lora: [True, False, True]
         if r > 0 and any(enable_lora):
-            self.lora_A = nn.Parameter(self.weight.new_zeros((r * sum(enable_lora), in_features)))  # (4, 128)
+            self.lora_A = nn.Parameter(self.linear.weight.new_zeros((r * sum(enable_lora), in_features)))  # (4, 128)
             enable_q, enable_k, enable_v = enable_lora
-            self.kv_embd_size = self.in_features // (n_head // n_query_groups)
-            shape = self.in_features * enable_q + self.kv_embd_size * enable_k + self.kv_embd_size * enable_v
-            self.lora_B = nn.Parameter(self.weight.new_zeros(shape, r))  # (256, 2))
+            self.kv_embd_size = self.linear.in_features // (n_head // n_query_groups)
+            shape = self.linear.in_features * enable_q + self.kv_embd_size * enable_k + self.kv_embd_size * enable_v
+            self.lora_B = nn.Parameter(self.linear.weight.new_zeros(shape, r))  # (256, 2))
             # Notes about shapes above
             # - self.lora_A has shape (4, 128): 4 because rank is 2 and LoRA is applied only to two matrices;
             # 128 is the input size of the x (embedding size). (4, 128) and not (128, 4) because later on in
@@ -247,7 +245,7 @@ class LoRAQKVLinear(LoRALinear):
             self.scaling = self.lora_alpha / self.r
 
             # Freezing the pre-trained weight matrix
-            self.weight.requires_grad = False  # (384, 128)
+            self.linear.weight.requires_grad = False  # (384, 128)
 
             # Compute the indices
             # Indices are needed to properly pad weight updates with zeros. If we want to fine-tune queries and values,
@@ -262,14 +260,14 @@ class LoRAQKVLinear(LoRALinear):
             # ----------------------------------------
             self.lora_ind = []
             if enable_q:
-                self.lora_ind.extend(range(0, self.in_features))
+                self.lora_ind.extend(range(0, self.linear.in_features))
             if enable_k:
-                self.lora_ind.extend(range(self.in_features, self.in_features + self.kv_embd_size))
+                self.lora_ind.extend(range(self.linear.in_features, self.linear.in_features + self.kv_embd_size))
             if enable_v:
-                self.lora_ind.extend(range(self.in_features + self.kv_embd_size, self.out_features))
+                self.lora_ind.extend(range(self.linear.in_features + self.kv_embd_size, self.linear.out_features))
         self.reset_parameters()
         if fan_in_fan_out:
-            self.weight.data = self.weight.data.T
+            self.linear.weight.data = self.linear.weight.data.T
 
     def zero_pad(self, x: torch.Tensor) -> torch.Tensor:
         """Properly pad weight updates with zeros.
@@ -298,26 +296,26 @@ class LoRAQKVLinear(LoRALinear):
         # Let's image that:
         # ⚬ input x has shape (64, 64, 256): (batch_size, sequence_length, embeddings_size)
         # ⚬ embeddings_size: 128
-        # ⚬ self.out_features: 384 (3 * embeddings_size)
+        # ⚬ self.linear.out_features: 384 (3 * embeddings_size)
         # ⚬ enable_lora: [True, False, True]
         # Then x has embeddings_size of 256 (2 * 128 as enable_lora only for query and value, not keys) and expected
-        # embeddings_size is 384 (self.out_features), so that means that we need to pad from 256 to 384 with zeros, but
+        # embeddings_size is 384 (self.linear.out_features), so that means that we need to pad from 256 to 384 with zeros, but
         # only for key updates (this is where self.lora_ind comes in handy)
         # Note: double transpose (in the beginning and in the end) is basically a guard for two-dimensional tensors
         # for example when we want to merge/unmerge LoRA weights and pretrained weights
         x = x.transpose(0, 1)
-        result = x.new_zeros((*x.shape[:-1], self.out_features))  # (64, 64, 384)
-        result = result.view(-1, self.out_features)  # (4096, 384)
+        result = x.new_zeros((*x.shape[:-1], self.linear.out_features))  # (64, 64, 384)
+        result = result.view(-1, self.linear.out_features)  # (4096, 384)
         enable_q, enable_k, enable_v = self.enable_lora
-        shape = self.in_features * enable_q + self.kv_embd_size * enable_k + self.kv_embd_size * enable_v
+        shape = self.linear.in_features * enable_q + self.kv_embd_size * enable_k + self.kv_embd_size * enable_v
         result = result.index_copy(1, torch.tensor(self.lora_ind, device=result.device), x.reshape(-1, shape)) # (4096, 256)
-        return result.view((*x.shape[:-1], self.out_features)).transpose(0, 1)  # (64, 64, 384)
+        return result.view((*x.shape[:-1], self.linear.out_features)).transpose(0, 1)  # (64, 64, 384)
 
     def merge(self):
         """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
 
         # Let's assume that:
-        # ⚬ self.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
+        # ⚬ self.linear.weight.data: (384, 128) or (3 * embedding_size, embedding_size)
         # ⚬ self.lora_A.data: (4, 128)
         # ⚬ self.lora_B.data: (256, 2)
         if self.r > 0 and any(self.enable_lora) and not self.merged:
@@ -327,7 +325,7 @@ class LoRAQKVLinear(LoRALinear):
                 groups=sum(self.enable_lora),
             ).squeeze(0)  # (1, 4, 128) @ (256, 2, 1) -> (1, 256, 128) -> (256, 128)
             # W = W + delta_W (merge)
-            self.weight.data += self.zero_pad(
+            self.linear.weight.data += self.zero_pad(
                 self.T(delta_w * self.scaling)
             )  # (256, 128) after zero_pad (384, 128)
             self.merged = True
@@ -347,13 +345,13 @@ class LoRAQKVLinear(LoRALinear):
 
         # Let's assume that:
         # ⚬ x: (64, 64, 128) or (batch_size, context_length, embedding_size)
-        # ⚬ self.weight: (384, 128) or (3 * embedding_size, embedding_size)
+        # ⚬ self.linear.weight: (384, 128) or (3 * embedding_size, embedding_size)
         # ⚬ self.lora_A.data: (4, 128)
         # ⚬ self.lora_B.data: (256, 2)
 
         # if weights are merged or LoRA is disabled (r <= 0 or all `enable_lora` are False) - it's only a regular nn.Linear forward pass;
         # otherwise in addition do the forward pass with LoRA weights and add it's output to the output from pretrained weights
-        result = F.linear(x, self.T(self.weight), bias=self.bias)
+        result = F.linear(x, self.T(self.linear.weight), bias=self.linear.bias)
         if self.r > 0 and any(self.enable_lora) and not self.merged:
             after_A = F.linear(self.lora_dropout(x), self.lora_A)  # (64, 64, 128) @ (4, 128) -> (64, 64, 4)
             # For F.conv1d:

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -137,7 +137,7 @@ class LoRALinear(LoRALayer):
 
     def reset_parameters(self):
         """Reset all the weights, even including pretrained ones."""
-        if hasattr(self, "lora_A"):
+        if self.r > 0:
             # initialize A the same way as the default for nn.Linear and B to zero
             # Wondering why 'a' is equal to math.sqrt(5)?: https://github.com/pytorch/pytorch/issues/15314
             nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -157,7 +157,7 @@ class LoRALinear(LoRALayer):
     def forward(self, x: torch.Tensor):
         # if weights are merged or rank is less or equal to zero (LoRA is disabled) - it's only a regular nn.Linear forward pass;
         # otherwise in addition do the forward pass with LoRA weights and add it's output to the output from pretrained weights
-        result = F.linear(x, self.T(self.linear.weight), bias=self.linear.bias)
+        result = self.linear(x)
         if self.r > 0 and not self.merged:
             result += (
                 self.lora_dropout(x) @ self.lora_A.transpose(0, 1) @ self.lora_B.transpose(0, 1)
@@ -352,7 +352,7 @@ class LoRAQKVLinear(LoRALinear):
 
         # if weights are merged or LoRA is disabled (r <= 0 or all `enable_lora` are False) - it's only a regular nn.Linear forward pass;
         # otherwise in addition do the forward pass with LoRA weights and add it's output to the output from pretrained weights
-        result = F.linear(x, self.T(self.linear.weight), bias=self.linear.bias)
+        result = self.linear(x)
         if self.r > 0 and any(self.enable_lora) and not self.merged:
             after_A = F.linear(self.lora_dropout(x), self.lora_A)  # (64, 64, 128) @ (4, 128) -> (64, 64, 4)
             # For F.conv1d:

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -291,9 +291,16 @@ def test_lora_qkv_linear_weights_merged_status(rank, enable_lora, expected_merge
         ("bnb.nf4-dq", "Linear4bit"),
         ("bnb.fp4", "Linear4bit"),
         ("bnb.fp4-dq", "Linear4bit"),
-        # platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cget_col_row_stats
-        pytest.param("bnb.int8", "Linear8bitLt", marks=pytest.mark.xfail(raises=AttributeError, strict=False)),
-    )
+        pytest.param(
+            "bnb.int8",
+            "Linear8bitLt",
+            marks=[
+                pytest.mark.skipif(not torch.cuda.is_available(), reason="8bit requires CUDA"),
+                # platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cget_col_row_stats
+                pytest.mark.xfail(raises=AttributeError, strict=False),
+            ],
+        ),
+    ),
 )
 def test_bnb_replacement(mode, expected):
     from quantize.bnb import _BITSANDBYTES_AVAILABLE

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -292,11 +292,6 @@ def test_bnb_replacement():
 
     from quantize.bnb import bnb
     from lit_gpt.utils import quantization
-
-    with quantization("bnb.nf4"):
-        linear = torch.nn.Linear(1, 1)
-    assert isinstance(linear, bnb.modules.Linear4bit)
-
     from lit_gpt.lora import LoRAQKVLinear, LoRALinear
 
     with quantization("bnb.nf4"):


### PR DESCRIPTION
Replaces inheritance with composition for the LoRA Linear layers.

This should workaround the issue described in https://github.com/pytorch/xla/pull/5437 and https://github.com/Lightning-AI/lit-gpt/issues/352

Fixes https://github.com/Lightning-AI/lit-gpt/issues/352