### PR TITLE
Automated code fixes: Isort edition

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -4,7 +4,7 @@ import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Optional, Tuple, List, Literal, Iterator
+from typing import Iterator, List, Literal, Optional, Tuple
 
 import lightning as L
 import torch
@@ -13,8 +13,8 @@ import torch
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt import GPT, Tokenizer, Config
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt import GPT, Config, Tokenizer
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 
 
 @torch.no_grad()

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -15,10 +15,10 @@ from lm_eval.base import BaseLM
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
+from generate.base import generate
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
 from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
-from generate.base import generate
 
 
 class EvalHarnessBase(BaseLM):

--- a/eval/lm_eval_harness_lora.py
+++ b/eval/lm_eval_harness_lora.py
@@ -14,12 +14,12 @@ from lm_eval.base import BaseLM
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
+from lm_eval_harness import EvalHarnessAdapter
+
 from lit_gpt import Tokenizer
 from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
 from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
-
-from lm_eval_harness import EvalHarnessAdapter
 
 lora_r = 8
 lora_alpha = 16

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Tuple, Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
@@ -13,10 +13,11 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.adapter import GPT, Config, mark_only_adapter_as_trainable, Block, adapter_filter
+from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import lazy_load, num_parameters, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, List, Dict, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
@@ -13,15 +13,16 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.adapter import GPT, Config, Block
+from lit_gpt.adapter import GPT, Block, Config
 from lit_gpt.adapter_v2 import (
-    mark_only_adapter_v2_as_trainable,
-    add_adapter_v2_parameters_to_linear_layers,
     adapter_filter,
+    add_adapter_v2_parameters_to_linear_layers,
+    mark_only_adapter_v2_as_trainable,
 )
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import lazy_load, num_parameters, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Tuple, Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
@@ -13,10 +13,11 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.model import GPT, Config, Block
+from lit_gpt.model import GPT, Block, Config
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import lazy_load, num_parameters, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -2,23 +2,23 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, List, Dict, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
-from lightning.fabric.strategies import XLAStrategy, FSDPStrategy
+from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.lora import mark_only_lora_as_trainable, lora_filter, GPT, Config, Block
+from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trainable
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import lazy_load, num_parameters, check_valid_checkpoint_dir, step_csv_logger, chunked_cross_entropy
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
-
 
 eval_interval = 100
 save_interval = 100

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -15,8 +15,8 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.adapter import GPT, Config, Block
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt.adapter import GPT, Block, Config
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -15,10 +15,9 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.adapter import Block
-from lit_gpt.adapter import GPT, Config
+from lit_gpt.adapter import GPT, Block, Config
 from lit_gpt.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 

--- a/generate/base.py
+++ b/generate/base.py
@@ -3,7 +3,7 @@ import sys
 import time
 import warnings
 from pathlib import Path
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 import lightning as L
 import torch
@@ -13,9 +13,9 @@ from lightning.fabric.strategies import FSDPStrategy
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt import GPT, Tokenizer, Config
+from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 
 
 @torch.no_grad()

--- a/generate/full.py
+++ b/generate/full.py
@@ -13,11 +13,11 @@ from lightning.fabric.strategies import FSDPStrategy
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from scripts.prepare_alpaca import generate_prompt
 from generate.base import generate
-from lit_gpt import GPT, Tokenizer, Config
+from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from scripts.prepare_alpaca import generate_prompt
 
 
 def main(

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -15,10 +15,9 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.lora import GPT, Config, Block, merge_lora_weights
-from lit_gpt.utils import lazy_load, check_valid_checkpoint_dir, quantization
+from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
-
 
 lora_r = 8
 lora_alpha = 16

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -6,20 +6,16 @@ https://arxiv.org/abs/2303.16199
 Port for Lit-GPT
 """
 from dataclasses import dataclass
-from typing import Optional, Tuple, Any, List, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 from typing_extensions import Self
 
 from lit_gpt.config import Config as BaseConfig
-from lit_gpt.model import (
-    GPT as BaseModel,
-    CausalSelfAttention as BaseCausalSelfAttention,
-    apply_rope,
-    RoPECache,
-    KVCache,
-)
+from lit_gpt.model import GPT as BaseModel
+from lit_gpt.model import CausalSelfAttention as BaseCausalSelfAttention
+from lit_gpt.model import KVCache, RoPECache, apply_rope
 
 
 @dataclass

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Any, Type, Literal
+from typing import Any, Literal, Optional, Type
 
 import torch
 from typing_extensions import Self

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -43,7 +43,7 @@ two matrices of a lower rank.
 
 import math
 from dataclasses import dataclass
-from typing import Optional, Tuple, Any, List, Type, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -52,13 +52,10 @@ from typing_extensions import Self
 
 import lit_gpt
 from lit_gpt.config import Config as BaseConfig
-from lit_gpt.model import (
-    GPT as BaseModel,
-    Block as BaseBlock,
-    CausalSelfAttention as BaseCausalSelfAttention,
-    RoPECache,
-    KVCache,
-)
+from lit_gpt.model import GPT as BaseModel
+from lit_gpt.model import Block as BaseBlock
+from lit_gpt.model import CausalSelfAttention as BaseCausalSelfAttention
+from lit_gpt.model import KVCache, RoPECache
 
 
 class LoRALayer(nn.Module):

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -4,7 +4,7 @@ Based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT and
 https://github.com/EleutherAI/gpt-neox/tree/main/megatron/model.
 """
 import math
-from typing import List, Optional, Tuple, Any
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.nn as nn

--- a/lit_gpt/packed_dataset.py
+++ b/lit_gpt/packed_dataset.py
@@ -3,13 +3,12 @@
 
 
 import os
-import struct
 import random
+import struct
 
 import numpy as np
 import torch
 from torch.utils.data import IterableDataset, get_worker_info
-
 
 dtypes = {1: np.uint8, 2: np.int8, 3: np.int16, 4: np.int32, 5: np.int64, 6: np.float32, 7: np.float64, 8: np.uint16}
 

--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -1,10 +1,10 @@
 import time
 from collections import deque
 from contextlib import nullcontext
-from typing import Deque, Optional, Any, Dict, Callable
+from typing import Any, Callable, Deque, Dict, Optional
 
 import torch
-from lightning import Fabric, Callback, Trainer, LightningModule
+from lightning import Callback, Fabric, LightningModule, Trainer
 from lightning.fabric.utilities.rank_zero import rank_zero_only as fabric_rank_zero_only
 from lightning.pytorch.utilities.rank_zero import rank_zero_only as trainer_rank_zero_only
 from torch.utils.flop_counter import FlopCounterMode

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -1,14 +1,14 @@
 """Utility functions for training and inference."""
 
-from functools import partial
 import pickle
 import sys
 import warnings
 from contextlib import contextmanager
+from functools import partial
 from io import BytesIO
 from pathlib import Path
 from types import MethodType
-from typing import Optional, Any, Union, List, TypeVar, Type
+from typing import Any, List, Optional, Type, TypeVar, Union
 
 import torch
 import torch.nn as nn

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -7,8 +7,8 @@ from typing import Optional, Union
 import lightning as L
 import numpy as np
 import torch
-from torch.utils.data import DataLoader, IterableDataset
 from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
+from torch.utils.data import DataLoader, IterableDataset
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -16,8 +16,9 @@ sys.path.append(str(wd))
 
 from lit_gpt import Config
 from lit_gpt.model import GPT, Block
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, measure_flops, estimate_flops
-from lit_gpt.utils import num_parameters, step_csv_logger, chunked_cross_entropy
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
+from lit_gpt.utils import chunked_cross_entropy, num_parameters, step_csv_logger
 
 model_name = "pythia-70m"
 name = "openwebtext"

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -2,15 +2,15 @@ import math
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Any
+from typing import Any, Optional
 
 import lightning as L
 import numpy as np
 import torch
-from torch.utils.data import DataLoader, IterableDataset
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import CSVLogger
 from lightning.pytorch.strategies import FSDPStrategy, XLAStrategy
+from torch.utils.data import DataLoader, IterableDataset
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -18,8 +18,8 @@ sys.path.append(str(wd))
 
 from lit_gpt import Config
 from lit_gpt.model import GPT, Block
-from lit_gpt.speed_monitor import measure_flops, estimate_flops, SpeedMonitorCallback
-from lit_gpt.utils import step_csv_logger, chunked_cross_entropy
+from lit_gpt.speed_monitor import SpeedMonitorCallback, estimate_flops, measure_flops
+from lit_gpt.utils import chunked_cross_entropy, step_csv_logger
 
 model_name = "pythia-70m"
 name = "openwebtext"

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -3,7 +3,7 @@ import math
 import sys
 import time
 from pathlib import Path
-from typing import Tuple, Optional, Union
+from typing import Optional, Tuple, Union
 
 import lightning as L
 import torch
@@ -14,10 +14,11 @@ from torch.utils.data import DataLoader
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt.model import Block, GPT, Config
-from lit_gpt.packed_dataset import PackedDataset, CombinedDataset
-from lit_gpt.utils import num_parameters, step_csv_logger, chunked_cross_entropy
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, estimate_flops, measure_flops
+from lit_gpt.model import GPT, Block, Config
+from lit_gpt.packed_dataset import CombinedDataset, PackedDataset
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
+from lit_gpt.utils import chunked_cross_entropy, num_parameters, step_csv_logger
 
 model_name = "pythia-70m"
 name = "redpajama"

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -17,11 +17,11 @@ from lightning import Fabric
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt import GPT, Tokenizer, Config
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load
-
 import triton
 import triton.language as tl
+
+from lit_gpt import GPT, Config, Tokenizer
+from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load
 
 
 # This is adapted from the OpenAI Triton matmul example.

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -4,7 +4,7 @@ import json
 import sys
 from functools import partial
 from pathlib import Path
-from typing import Optional, Literal, Tuple, Dict, List, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import torch
 
@@ -13,7 +13,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Config
-from lit_gpt.utils import lazy_load, incremental_save, NotYetLoadedTensor
+from lit_gpt.utils import NotYetLoadedTensor, incremental_save, lazy_load
 
 
 def copy_weights_gpt_neox(

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -3,7 +3,7 @@ import gc
 import sys
 from functools import partial
 from pathlib import Path
-from typing import Optional, Literal, Dict, Union
+from typing import Dict, Literal, Optional, Union
 
 import torch
 
@@ -12,8 +12,8 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Config
-from lit_gpt.utils import lazy_load, incremental_save, NotYetLoadedTensor
-from scripts.convert_hf_checkpoint import load_param, layer_template
+from lit_gpt.utils import NotYetLoadedTensor, incremental_save, lazy_load
+from scripts.convert_hf_checkpoint import layer_template, load_param
 
 
 def copy_weights_falcon(

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -11,9 +11,8 @@ from tqdm import tqdm
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt import Tokenizer, Config
 import lit_gpt.packed_dataset as packed_dataset
-
+from lit_gpt import Config, Tokenizer
 
 filenames_sample = [
     "arxiv_sample.jsonl",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 _PATH_ROOT = os.path.dirname(__file__)
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -8,8 +8,8 @@ from lightning import Fabric
 
 def test_config_identical():
     import lit_gpt.adapter as gpt_adapter
-    from lit_gpt.adapter_v2 import adapter_v2_linear_with_bias_and_scale
     import lit_gpt.model as gpt
+    from lit_gpt.adapter_v2 import adapter_v2_linear_with_bias_and_scale
 
     name = "pythia-70m"
     with Fabric(accelerator="cpu").init_module(empty_init=True):

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -1,5 +1,5 @@
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 from urllib.request import urlretrieve
 
 import lightning as L
@@ -27,9 +27,9 @@ def test_convert_lit_checkpoint(tmp_path):
 
 
 def test_convert_lit_checkpoint_llama2(tmp_path):
-    from lit_gpt import Config, GPT
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
     from finetune.full import save_checkpoint
+    from lit_gpt import GPT, Config
+    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
 
     # fabric is needed for finetune.full::save_checkpoint
     fabric = L.Fabric(devices=1)
@@ -54,9 +54,9 @@ def test_against_original_falcon_40b():
     if not file_path.is_file():
         urlretrieve(url=url, filename=file_path)
 
-    from tests.original_falcon_40b import RWConfig, RWForCausalLM
-    from lit_gpt import Config, GPT
+    from lit_gpt import GPT, Config
     from scripts.convert_lit_checkpoint import copy_weights_falcon as copy_to_theirs
+    from tests.original_falcon_40b import RWConfig, RWForCausalLM
 
     ours_config = Config.from_name("falcon-40b", n_layer=2, n_head=8, n_query_groups=4, n_embd=32)
     theirs_config = RWConfig(
@@ -81,9 +81,10 @@ def test_against_original_falcon_40b():
 
 @torch.inference_mode()
 def test_against_original_gpt_neox():
-    from lit_gpt import Config, GPT
-    from scripts.convert_lit_checkpoint import copy_weights_gpt_neox as copy_to_theirs
     from transformers import GPTNeoXConfig, GPTNeoXForCausalLM
+
+    from lit_gpt import GPT, Config
+    from scripts.convert_lit_checkpoint import copy_weights_gpt_neox as copy_to_theirs
 
     ours_config = Config.from_name("pythia-1b", block_size=2048, n_layer=2, n_embd=2048, n_head=8, padding_multiple=128)
     theirs_config = GPTNeoXConfig(
@@ -115,10 +116,11 @@ def test_against_original_gpt_neox():
 @torch.inference_mode()
 @pytest.mark.parametrize("size", ("7b", "70b"))
 def test_against_original_llama2(size):
-    from lit_gpt import Config, GPT
-    from scripts.convert_lit_checkpoint import copy_weights_llama as copy_to_theirs
-    from transformers.models.llama.modeling_llama import LlamaForCausalLM
     from transformers.models.llama.configuration_llama import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+    from lit_gpt import GPT, Config
+    from scripts.convert_lit_checkpoint import copy_weights_llama as copy_to_theirs
 
     if size == "7b":
         ours_kwargs = {"name": "Llama-2-7b-hf"}
@@ -157,9 +159,9 @@ def test_against_original_llama2(size):
 
 
 def test_maybe_unwrap_state_dict(tmp_path):
-    from lit_gpt import Config, GPT
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
     from finetune.full import save_checkpoint
+    from lit_gpt import GPT, Config
+    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
 
     # fabric is needed for finetune.full::save_checkpoint
     fabric = L.Fabric(devices=1)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,11 +1,11 @@
 import json
 import subprocess
 import sys
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock, call, ANY
+from unittest.mock import ANY, Mock, call
 
 import pytest
 import torch
@@ -14,7 +14,6 @@ import torch
 @pytest.mark.parametrize("max_seq_length", (10, 20 + 5))
 def test_generate(max_seq_length):
     import generate.base as generate
-
     from lit_gpt import GPT, Config
 
     T = 5

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -1,10 +1,10 @@
 import json
 import subprocess
 import sys
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
-from unittest.mock import Mock, call, ANY
+from unittest.mock import ANY, Mock, call
 
 import pytest
 import torch

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -1,10 +1,10 @@
 import json
 import subprocess
 import sys
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
-from unittest.mock import Mock, call, ANY
+from unittest.mock import ANY, Mock, call
 
 import torch
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -8,7 +8,8 @@ from lightning import Fabric
 
 
 def test_lora_layer_replacement():
-    from lit_gpt.lora import CausalSelfAttention as LoRACausalSelfAttention, GPT, Config, LoRALinear
+    from lit_gpt.lora import GPT, Config, LoRALinear
+    from lit_gpt.lora import CausalSelfAttention as LoRACausalSelfAttention
 
     config = Config(n_layer=2, n_head=4, n_embd=8, block_size=8, vocab_size=8, r=8, alpha=8, dropout=0.1)
     model = GPT(config)
@@ -20,7 +21,7 @@ def test_lora_layer_replacement():
 
 
 def test_lora_merge():
-    from lit_gpt.lora import mark_only_lora_as_trainable, merge_lora_weights, GPT, Config
+    from lit_gpt.lora import GPT, Config, mark_only_lora_as_trainable, merge_lora_weights
 
     config = Config(
         n_layer=1,
@@ -117,7 +118,7 @@ def test_lora_mqa_gqa():
 
 
 def test_lora_filter(tmp_path):
-    from lit_gpt.lora import lora_filter, GPT
+    from lit_gpt.lora import GPT, lora_filter
 
     fabric = Fabric(devices=1)
     model = GPT.from_name("pythia-70m", n_layer=3, r=1, to_query=True, to_value=True)
@@ -308,9 +309,9 @@ def test_bnb_replacement(mode, expected):
     if not _BITSANDBYTES_AVAILABLE:
         pytest.skip("BNB not available")
 
-    from quantize.bnb import bnb
+    from lit_gpt.lora import LoRALinear, LoRAQKVLinear
     from lit_gpt.utils import quantization
-    from lit_gpt.lora import LoRAQKVLinear, LoRALinear
+    from quantize.bnb import bnb
 
     with quantization(mode):
         linear = LoRALinear(1, 1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,8 @@ wd = Path(__file__).parent.parent.absolute()
 @pytest.mark.parametrize("parallel_residual", (False, True))
 @pytest.mark.parametrize("kv_cache", (False, True))
 def test_against_hf_model(rotary_pct, batch_size, n_embd, parallel_residual, kv_cache) -> None:
-    from transformers import GPTNeoXForCausalLM, GPTNeoXConfig
+    from transformers import GPTNeoXConfig, GPTNeoXForCausalLM
+
     import lit_gpt
     from scripts.convert_hf_checkpoint import copy_weights_gpt_neox
 
@@ -97,9 +98,9 @@ def test_against_original_falcon_40b():
     if not file_path.is_file():
         urlretrieve(url=url, filename=file_path)
 
-    from tests.original_falcon_40b import RWConfig, RWForCausalLM
-    from lit_gpt import Config, GPT
+    from lit_gpt import GPT, Config
     from scripts.convert_hf_checkpoint import copy_weights_falcon
+    from tests.original_falcon_40b import RWConfig, RWForCausalLM
 
     ours_config = Config.from_name("falcon-40b", n_layer=2, n_head=8, n_query_groups=4, n_embd=32)
     theirs_config = RWConfig(
@@ -122,11 +123,12 @@ def test_against_original_falcon_40b():
 
 @torch.inference_mode()
 def test_against_original_open_llama_3b():
-    from lit_gpt import Config, GPT
-    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
-    from transformers.models.llama.modeling_llama import LlamaForCausalLM, apply_rotary_pos_emb
     from transformers.models.llama.configuration_llama import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaForCausalLM, apply_rotary_pos_emb
+
+    from lit_gpt import GPT, Config
     from lit_gpt.model import apply_rope
+    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
 
     ours_config = Config.from_name("open_llama_3b", n_layer=2, n_head=8, n_embd=32, intermediate_size=86)
     T = 5
@@ -169,10 +171,11 @@ def test_against_original_open_llama_3b():
 @torch.inference_mode()
 @pytest.mark.parametrize("size", ("7b", "70b"))
 def test_against_hf_llama2(size):
-    from lit_gpt import Config, GPT
-    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
-    from transformers.models.llama.modeling_llama import LlamaForCausalLM
     from transformers.models.llama.configuration_llama import LlamaConfig
+    from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+    from lit_gpt import GPT, Config
+    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
 
     if size == "7b":
         ours_kwargs = {"name": "Llama-2-7b-hf"}

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -1,7 +1,7 @@
 import os
 from unittest.mock import MagicMock
-import requests
 
+import requests
 from torch.utils.data import IterableDataset
 
 
@@ -28,7 +28,7 @@ def test_packed_dataset(tmp_path):
 
     texts = ["The moment of truth is upon us. " * 4, "Time to open the fridge. " * 4]
 
-    from lit_gpt.packed_dataset import PackedDatasetBuilder, PackedDataset, HDR_SIZE
+    from lit_gpt.packed_dataset import HDR_SIZE, PackedDataset, PackedDatasetBuilder
 
     block_size = 10
     n_blocks = 2

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -3,8 +3,9 @@ import torch
 
 @torch.inference_mode()
 def test_rope():
-    from lit_gpt.model import build_rope_cache, apply_rope
     from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXRotaryEmbedding, apply_rotary_pos_emb
+
+    from lit_gpt.model import apply_rope, build_rope_cache
 
     bs, seq_len, n_head, n_embed = 1, 6, 2, 8
     head_size = n_embed // n_head


### PR DESCRIPTION
Hi there 👋 

In addition to what @carmocca does from time to time (automated style formatting and some code fixes) this PR also includes sorting of imports with `isort`. 
Isort of course is somewhat opinionated sometimes, nevertheless it brings some level of consistency across the repo when it comes to imports ordering.

I used this command:
```bash
ruff check * --select E,W,F,S --extend-select C4,SIM,RET,PT,I001 --ignore E501,E731,S108,S101,S113,S603,PT007,S310,E402,PT004,C408 --per-file-ignores __init__.py:I001 --line-length 120 --fix; black -l120 -C --preview finetune scripts tests pretrain quantize lit_gpt notebooks chat generate eval
``` 
[I001](https://beta.ruff.rs/docs/rules/unsorted-imports/) rule was added to what Carlos is using, but ignored for `lit_gpt/__init__.py` file as with different ordering we can get circular import for the Config class.

Note: if anyone wants to repeat it should install `black` and `ruff` packages.