### PR TITLE
Add more explanation to evaluation tutorial

### DIFF
--- a/tutorials/evaluation.md
+++ b/tutorials/evaluation.md
@@ -12,18 +12,39 @@ cd lm-evaluation-harness
 pip install -e .
 ```
 
-### To evaluate Lit-GPT base models:
+
+
+### Evaluating Lit-GPT base models
+
+Use the following command to evaluate Lit-GPT models on all tasks in Eleuther AI's Evaluation Harness.
 
 ```bash
 python eval/lm_eval_harness.py \
         --checkpoint_dir "checkpoints/Llama-2-7b-hf/" \
         --precision "bf16-true" \
-        --eval_tasks "[truthfulqa_mc,hellaswag]" \
         --batch_size 4 \
         --save_filepath "results.json"
 ```
 
-### To evaluate LoRA finetuned LLMs:
+To evaluate on LLMs on specific tasks, for example, TruthfulQA and HellaSwag, you can use the `--eval_task` flag as follows:
+
+
+```python
+python eval/lm_eval_harness.py \
+        --checkpoint_dir "checkpoints/Llama-2-7b-hf/" \
+        --eval_tasks "[truthfulqa_mc,hellaswag]" \
+        --precision "bf16-true" \
+        --batch_size 4 \
+        --save_filepath "results.json"
+```
+
+A list of supported tasks can be found [here](https://github.com/EleutherAI/lm-evaluation-harness/blob/master/docs/task_table.md).
+
+
+
+### Evaluating LoRA-finetuned LLMs
+
+The above command can be used to evaluate models that are saved via a single checkpoint file. This includes downloaded checkpoints and base models finetuned via the full and adapter finetuning scripts. For LoRA-finetuned models, use the `lm_eval_harness_lora.py` script instead:
 
 ```bash
 python eval/lm_eval_harness_lora.py \


### PR DESCRIPTION
I think we should lead with the default setting most people will be interested in. That is evaluating on all tasks. I also added a link to the task table, which is super useful (otherwise, it may look like we only support 2 tasks).