### PR TITLE
Add `convert_lit_checkpoint::check_conversion_supported`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 </div>
 
+&nbsp;
+
 # ⚡ Lit-GPT
 
 Hackable [implementation](lit_gpt/model.py) of state-of-the-art open-source large language models released under the **Apache 2.0 license**.
@@ -36,7 +38,7 @@ Supports the following popular model checkpoints:
 
 This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-llama) and [nanoGPT](https://github.com/karpathy/nanoGPT), and it's **powered by [Lightning Fabric](https://lightning.ai/docs/fabric/stable/) ⚡**.
 
-
+&nbsp;
 
 ---
 
@@ -51,7 +53,7 @@ If you are interested in participating, you can learn more about the NeurIPS LLM
 ---
 
 
-
+&nbsp;
 
 
 ## Lit-GPT design principles
@@ -66,6 +68,8 @@ This repository follows the main principle of **openness through clarity**.
 - **Open-source:** No strings attached.
 
 Avoiding code duplication is **not** a goal. **Readability** and **hackability** are.
+
+&nbsp;
 
 ## Get involved!
 
@@ -83,7 +87,9 @@ cd lit-gpt
 ```
 
 Lit-GPT currently relies on flash attention from PyTorch nightly. Until PyTorch 2.1 is released you'll need to install nightly manually.
-Luckily that is straightforward:
+Luckily this is straightforward, as shown below.
+
+&nbsp;
 
 **On CUDA**
 
@@ -133,9 +139,13 @@ You can also chat with the model interactively:
 python chat/base.py
 ```
 
+&nbsp;
+
 ### Run large models on smaller consumer devices
 
 We support 4-bit quantization (as in QLoRA), LLM.int8, and GPTQ.int4 inference by following [this guide](tutorials/quantize.md).
+
+&nbsp;
 
 ## Finetune the model
 
@@ -176,12 +186,16 @@ The finetuning requires at least one GPU with ~12 GB memory (RTX 3060).
 It is expected that you have downloaded the pretrained weights as described above.
 More details about each finetuning method and how you can apply it to your own data can be found in our technical how-to guides.
 
+&nbsp;
+
 ### Finetuning How-To Guides
 
 These technical tutorials illustrate how to run the finetuning code.
 
 - [Finetune with Adapters](tutorials/finetune_adapter.md)
 - [Finetune with LoRA](tutorials/finetune_lora.md)
+
+&nbsp;
 
 ### Understanding Finetuning -- Conceptual Tutorials
 
@@ -191,9 +205,13 @@ Looking for conceptual tutorials and explanations? We have some additional artic
 
 - [Parameter-Efficient LLM Finetuning With Low-Rank Adaptation (LoRA)](https://lightning.ai/pages/community/tutorial/lora-llm/)
 
+&nbsp;
+
 ## Pre-training
 
 Porting from Lit-LLaMA in progress 👷
+
+&nbsp;
 
 ## Get involved!
 
@@ -215,6 +233,8 @@ Unsure about contributing? Check out our [How to Contribute to Lit-GPT and Lit-L
 
 Don't forget to [join our Discord](https://discord.gg/VptPCZkGNa)!
 
+&nbsp;
+
 ## Acknowledgements
 
 - [@karpathy](https://github.com/karpathy) for [nanoGPT](https://github.com/karpathy/nanoGPT)
@@ -223,6 +243,8 @@ Don't forget to [join our Discord](https://discord.gg/VptPCZkGNa)!
 - [@IST-DASLab](https://github.com/IST-DASLab) for [GPTQ](https://github.com/IST-DASLab/gptq)
 - [@Microsoft](https://github.com/microsoft) for [LoRA](https://github.com/microsoft/LoRA)
 - [@tridao](https://github.com/tridao) for [Flash Attention 2](https://github.com/Dao-AILab/flash-attention)
+
+&nbsp;
 
 ## License
 

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -205,7 +205,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
     elif "adapter_bias" in weight_names:
         raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported.")
     # adapter. gating_factor is in adapter and adapter_v2
-    if "gating_factor" in weight_names:
+    elif "gating_factor" in weight_names:
         raise NotImplementedError(f"Converting models finetuned with adapter not yet supported.")
 
 

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -203,7 +203,7 @@ def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor], checkpoin
         raise Exception(f"Converting models finetuned with adapter not yet support")
     # adapter v2
     elif "adapter_bias" in weight_names:
-        raise Exception(f"Converting models finetuned with adapterV2 not yet support")
+        raise Exception(f"Converting models finetuned with adapter_v2 not yet support")
     # LoRA or QLoRA
     elif any(["lora" in wn for wn in weight_names]):
         technique = checkpoint_dir.parent.name

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -198,7 +198,6 @@ def maybe_unwrap_state_dict(lit_weights: Dict[str, torch.Tensor]) -> Dict[str, t
 
 def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor], checkpoint_dir: Path) -> None:
     weight_names = set([wk.split(".")[-1] for wk in lit_weights.keys()])
-    print(weight_names)
     # adapter
     if "gating_factor" in weight_names:
         raise Exception(f"Converting models finetuned with adapter not yet support")

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -196,18 +196,17 @@ def maybe_unwrap_state_dict(lit_weights: Dict[str, torch.Tensor]) -> Dict[str, t
     return lit_weights.get("model", lit_weights)
 
 
-def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor], checkpoint_dir: Path) -> None:
-    weight_names = set([wk.split(".")[-1] for wk in lit_weights.keys()])
+def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor]) -> None:
+    weight_names = {wk.split(".")[-1] for wk in lit_weights}
     # adapter
     if "gating_factor" in weight_names:
-        raise Exception(f"Converting models finetuned with adapter not yet support")
+        raise NotImplementedError(f"Converting models finetuned with adapter not yet supported")
     # adapter v2
     elif "adapter_bias" in weight_names:
-        raise Exception(f"Converting models finetuned with adapter_v2 not yet support")
+        raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported")
     # LoRA or QLoRA
     elif any(["lora" in wn for wn in weight_names]):
-        technique = checkpoint_dir.parent.name
-        raise Exception(f"Converting models finetuned with {technique} not yet support")
+        raise NotImplementedError(f"Converting models finetuned with LoRA or QLoRA not yet supported")
 
 
 @torch.inference_mode()
@@ -238,7 +237,7 @@ def convert_lit_checkpoint(
         with contextlib.ExitStack() as stack:
             lit_weights = stack.enter_context(lazy_load(pth_file))
             lit_weights = maybe_unwrap_state_dict(lit_weights)
-            maybe_raise_finetune_warning(lit_weights, checkpoint_dir)
+            maybe_raise_finetune_warning(lit_weights)
             copy_fn(sd, lit_weights, saver=saver)
             gc.collect()
         saver.save(sd)

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -196,17 +196,17 @@ def maybe_unwrap_state_dict(lit_weights: Dict[str, torch.Tensor]) -> Dict[str, t
     return lit_weights.get("model", lit_weights)
 
 
-def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor]) -> None:
+def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
     weight_names = {wk.split(".")[-1] for wk in lit_weights}
-    # adapter
-    if "gating_factor" in weight_names:
-        raise NotImplementedError(f"Converting models finetuned with adapter not yet supported.")
-    # adapter v2
+    # LoRA or QLoRA
+    if any("lora" in wn for wn in weight_names):
+        raise NotImplementedError(f"Model weights must be merged using `lora.merge_lora_weights()` before conversion.")
+    # adapter v2. adapter_bias will only be in adapter_v2
     elif "adapter_bias" in weight_names:
         raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported.")
-    # LoRA or QLoRA
-    elif any(["lora" in wn for wn in weight_names]):
-        raise NotImplementedError(f"Model weights must be merged using `lora.merge_lora_weights()` before conversion.")
+    # adapter. gating_factor is in adapter and adapter_v2
+    if "gating_factor" in weight_names:
+        raise NotImplementedError(f"Converting models finetuned with adapter not yet supported.")
 
 
 @torch.inference_mode()
@@ -237,7 +237,7 @@ def convert_lit_checkpoint(
         with contextlib.ExitStack() as stack:
             lit_weights = stack.enter_context(lazy_load(pth_file))
             lit_weights = maybe_unwrap_state_dict(lit_weights)
-            maybe_raise_finetune_warning(lit_weights)
+            check_conversion_supported(lit_weights)
             copy_fn(sd, lit_weights, saver=saver)
             gc.collect()
         saver.save(sd)

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -200,13 +200,13 @@ def maybe_raise_finetune_warning(lit_weights: Dict[str, torch.Tensor]) -> None:
     weight_names = {wk.split(".")[-1] for wk in lit_weights}
     # adapter
     if "gating_factor" in weight_names:
-        raise NotImplementedError(f"Converting models finetuned with adapter not yet supported")
+        raise NotImplementedError(f"Converting models finetuned with adapter not yet supported.")
     # adapter v2
     elif "adapter_bias" in weight_names:
-        raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported")
+        raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported.")
     # LoRA or QLoRA
     elif any(["lora" in wn for wn in weight_names]):
-        raise NotImplementedError(f"Converting models finetuned with LoRA or QLoRA not yet supported")
+        raise NotImplementedError(f"Model weights must be merged using `lora.merge_lora_weights()` before conversion.")
 
 
 @torch.inference_mode()

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -200,7 +200,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
     weight_names = {wk.split(".")[-1] for wk in lit_weights}
     # LoRA or QLoRA
     if any("lora" in wn for wn in weight_names):
-        raise NotImplementedError(f"Model weights must be merged using `lora.merge_lora_weights()` before conversion.")
+        raise ValueError(f"Model weights must be merged using `lora.merge_lora_weights()` before conversion.")
     # adapter v2. adapter_bias will only be in adapter_v2
     elif "adapter_bias" in weight_names:
         raise NotImplementedError(f"Converting models finetuned with adapter_v2 not yet supported.")

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -193,91 +193,28 @@ def test_maybe_unwrap_state_dict(tmp_path):
     maybe_unwrap.assert_called()
 
 
-def test_maybe_raise_finetune_warning_adapter(tmp_path):
-    from lit_gpt.adapter import GPT, Config
-    from finetune.adapter import save_adapter_checkpoint
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
+def test_check_conversion_supported_adapter(tmp_path):
+    from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    # fabric is needed for finetune.full::save_checkpoint
-    fabric = L.Fabric(devices=1)
-
-    model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(
-        model_name,
-        adapter_start_layer=0,
-        block_size=8,
-        n_layer=2,
-        n_embd=32,
-        n_head=2,
-        padding_multiple=128,
-    )
-    ours_model = GPT(ours_config)
-
-    ckpt_path = tmp_path / "lit_model_adapter.pth"
-
-    # save checkpoint to avoid RunTimeError for PytorchStreamReader
-    save_adapter_checkpoint(fabric, ours_model, ckpt_path)
+    lit_weights = {"some.key.name": "some.key.value", "some.key.name.gating_factor": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter *"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)
+        check_conversion_supported(lit_weights=lit_weights)
 
 
-def test_maybe_raise_finetune_warning_adapter_v2(tmp_path):
-    from lit_gpt.adapter import Config
-    from lit_gpt.adapter_v2 import GPT
-    from finetune.adapter_v2 import save_adapter_v2_checkpoint, add_adapter_v2_parameters_to_linear_layers
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
+def test_check_conversion_supported_adapter_v2(tmp_path):
+    from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    # fabric is needed for finetune.full::save_checkpoint
-    fabric = L.Fabric(devices=1)
-
-    model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(
-        model_name,
-        adapter_start_layer=0,
-        block_size=8,
-        n_layer=2,
-        n_embd=32,
-        n_head=2,
-        padding_multiple=128,
-    )
-    ours_model = GPT(ours_config)
-    add_adapter_v2_parameters_to_linear_layers(ours_model)
-
-    ckpt_path = tmp_path / "lit_model_adapter_v2.pth"
-
-    # save checkpoint to avoid RunTimeError for PytorchStreamReader
-    save_adapter_v2_checkpoint(fabric, ours_model, ckpt_path)
+    lit_weights = {"some.key.name": "some.key.value", "some.key.name.adapter_bias": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter_v2"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)
+        check_conversion_supported(lit_weights=lit_weights)
 
 
-def test_maybe_raise_finetune_warning_lora(tmp_path):
-    from lit_gpt.lora import GPT, Config
-    from finetune.lora import save_lora_checkpoint
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
+def test_check_conversion_supported_lora(tmp_path):
+    from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    # fabric is needed for finetune.full::save_checkpoint
-    fabric = L.Fabric(devices=1)
-
-    model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(
-        model_name,
-        r=1,
-        to_mlp=True,
-        block_size=8,
-        n_layer=2,
-        n_embd=32,
-        n_head=2,
-        padding_multiple=128,
-    )
-    ours_model = GPT(ours_config)
-
-    ckpt_path = tmp_path / "lit_model_lora.pth"
-
-    # save checkpoint to avoid RunTimeError for PytorchStreamReader
-    save_lora_checkpoint(fabric, ours_model, ckpt_path)
+    lit_weights = {"some.key.name": "some.key.value", "some.key.name.lora": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match=r"Model weights must be merged using"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)
+        check_conversion_supported(lit_weights=lit_weights)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -193,28 +193,6 @@ def test_maybe_unwrap_state_dict(tmp_path):
     maybe_unwrap.assert_called()
 
 
-def test_maybe_raise_finetune_warning_lora(tmp_path):
-    from lit_gpt.lora import GPT, Config
-    from finetune.lora import save_lora_checkpoint
-    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
-
-    # fabric is needed for finetune.full::save_checkpoint
-    fabric = L.Fabric(devices=1)
-
-    model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(model_name, block_size=8, n_layer=2, n_embd=32, n_head=2, padding_multiple=128)
-    ours_model = GPT(ours_config)
-    ours_model.lora_A = torch.nn.Parameter()
-
-    ckpt_path = tmp_path / "lit_model.pth"
-
-    # save checkpoint to avoid RunTimeError for PytorchStreamReader
-    save_lora_checkpoint(fabric, ours_model, ckpt_path)
-
-    with pytest.raises(Exception, match=r"Converting models finetuned with *"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, checkpoint_dir=ckpt_path.parent, model_name=model_name)
-
-
 def test_maybe_raise_finetune_warning_adapter(tmp_path):
     from lit_gpt.adapter import GPT, Config
     from finetune.adapter import save_adapter_checkpoint
@@ -228,18 +206,16 @@ def test_maybe_raise_finetune_warning_adapter(tmp_path):
     ours_model = GPT(ours_config)
     ours_model.gating_factor = torch.nn.Parameter()
 
-    ckpt_path = tmp_path / "lit_model.pth"
+    ckpt_path = tmp_path / "lit_model_adapter.pth"
 
     # save checkpoint to avoid RunTimeError for PytorchStreamReader
     save_adapter_checkpoint(fabric, ours_model, ckpt_path)
 
-    with pytest.raises(Exception, match="Converting models finetuned with adapter *"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, checkpoint_dir=ckpt_path.parent, model_name=model_name)
+    with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter *"):
+        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)
 
 
 def test_maybe_raise_finetune_warning_adapter_v2(tmp_path):
-    # same config as adapter is required
-    # lit_gpt.config.Config will throw AttributeError for no 'adapter_start_layer'
     from lit_gpt.adapter import Config
     from lit_gpt.adapter_v2 import GPT
     from finetune.adapter_v2 import save_adapter_v2_checkpoint
@@ -253,10 +229,41 @@ def test_maybe_raise_finetune_warning_adapter_v2(tmp_path):
     ours_model = GPT(ours_config)
     ours_model.adapter_bias = torch.nn.Parameter()
 
-    ckpt_path = tmp_path / "lit_model.pth"
+    ckpt_path = tmp_path / "lit_model_adapter_v2.pth"
 
     # save checkpoint to avoid RunTimeError for PytorchStreamReader
     save_adapter_v2_checkpoint(fabric, ours_model, ckpt_path)
 
-    with pytest.raises(Exception, match="Converting models finetuned with adapter *"):
-        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, checkpoint_dir=ckpt_path.parent, model_name=model_name)
+    with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter_v2"):
+        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)
+
+
+def test_maybe_raise_finetune_warning_lora(tmp_path):
+    from lit_gpt.lora import GPT, Config
+    from finetune.lora import save_lora_checkpoint
+    from scripts.convert_lit_checkpoint import convert_lit_checkpoint
+
+    # fabric is needed for finetune.full::save_checkpoint
+    fabric = L.Fabric(devices=1)
+
+    model_name = "Llama-2-7b-hf"
+    ours_config = Config.from_name(
+        model_name,
+        r=1,
+        to_mlp=True,
+        block_size=8,
+        n_layer=2,
+        n_embd=32,
+        n_head=2,
+        padding_multiple=128,
+    )
+    ours_model = GPT(ours_config)
+    print(ours_model.state_dict().keys())
+
+    ckpt_path = tmp_path / "lit_model_lora.pth"
+
+    # save checkpoint to avoid RunTimeError for PytorchStreamReader
+    save_lora_checkpoint(fabric, ours_model, ckpt_path)
+
+    with pytest.raises(NotImplementedError, match=r"Converting models finetuned with LoRA *"):
+        convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -202,9 +202,16 @@ def test_maybe_raise_finetune_warning_adapter(tmp_path):
     fabric = L.Fabric(devices=1)
 
     model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(model_name, block_size=8, n_layer=2, n_embd=32, n_head=2, padding_multiple=128)
+    ours_config = Config.from_name(
+        model_name,
+        adapter_start_layer=0,
+        block_size=8,
+        n_layer=2,
+        n_embd=32,
+        n_head=2,
+        padding_multiple=128,
+    )
     ours_model = GPT(ours_config)
-    ours_model.gating_factor = torch.nn.Parameter()
 
     ckpt_path = tmp_path / "lit_model_adapter.pth"
 

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -265,5 +265,5 @@ def test_maybe_raise_finetune_warning_lora(tmp_path):
     # save checkpoint to avoid RunTimeError for PytorchStreamReader
     save_lora_checkpoint(fabric, ours_model, ckpt_path)
 
-    with pytest.raises(NotImplementedError, match=r"Converting models finetuned with LoRA *"):
+    with pytest.raises(NotImplementedError, match=r"Model weights must be merged using"):
         convert_lit_checkpoint(checkpoint_name=ckpt_path.name, out_dir=ckpt_path.parent, model_name=model_name)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -193,7 +193,7 @@ def test_maybe_unwrap_state_dict(tmp_path):
     maybe_unwrap.assert_called()
 
 
-def test_check_conversion_supported_adapter(tmp_path):
+def test_check_conversion_supported_adapter():
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
     lit_weights = {"some.key.name": "some.key.value", "error.key.gating_factor": "some.key.value"}
@@ -202,7 +202,7 @@ def test_check_conversion_supported_adapter(tmp_path):
         check_conversion_supported(lit_weights=lit_weights)
 
 
-def test_check_conversion_supported_adapter_v2(tmp_path):
+def test_check_conversion_supported_adapter_v2():
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
     lit_weights = {"some.key.name": "some.key.value", "error.key.adapter_bias": "some.key.value"}
@@ -211,10 +211,10 @@ def test_check_conversion_supported_adapter_v2(tmp_path):
         check_conversion_supported(lit_weights=lit_weights)
 
 
-def test_check_conversion_supported_lora(tmp_path):
+def test_check_conversion_supported_lora():
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
     lit_weights = {"some.key.name": "some.key.value", "error.key.lora": "some.key.value"}
 
-    with pytest.raises(NotImplementedError, match=r"Model weights must be merged using"):
+    with pytest.raises(ValueError, match=r"Model weights must be merged using"):
         check_conversion_supported(lit_weights=lit_weights)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -138,7 +138,7 @@ def test_against_original_llama2(size):
         intermediate_size=ours_config.intermediate_size,
         max_position_embeddings=T,
         rms_norm_eps=1e-5,
-        **theirs_kwargs
+        **theirs_kwargs,
     )
     assert ours_config.intermediate_size == theirs_config.intermediate_size
 
@@ -196,7 +196,7 @@ def test_maybe_unwrap_state_dict(tmp_path):
 def test_check_conversion_supported_adapter(tmp_path):
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    lit_weights = {"some.key.name": "some.key.value", "some.key.name.gating_factor": "some.key.value"}
+    lit_weights = {"some.key.name": "some.key.value", "error.key.gating_factor": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter *"):
         check_conversion_supported(lit_weights=lit_weights)
@@ -205,7 +205,7 @@ def test_check_conversion_supported_adapter(tmp_path):
 def test_check_conversion_supported_adapter_v2(tmp_path):
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    lit_weights = {"some.key.name": "some.key.value", "some.key.name.adapter_bias": "some.key.value"}
+    lit_weights = {"some.key.name": "some.key.value", "error.key.adapter_bias": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match="Converting models finetuned with adapter_v2"):
         check_conversion_supported(lit_weights=lit_weights)
@@ -214,7 +214,7 @@ def test_check_conversion_supported_adapter_v2(tmp_path):
 def test_check_conversion_supported_lora(tmp_path):
     from scripts.convert_lit_checkpoint import check_conversion_supported
 
-    lit_weights = {"some.key.name": "some.key.value", "some.key.name.lora": "some.key.value"}
+    lit_weights = {"some.key.name": "some.key.value", "error.key.lora": "some.key.value"}
 
     with pytest.raises(NotImplementedError, match=r"Model weights must be merged using"):
         check_conversion_supported(lit_weights=lit_weights)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -218,16 +218,24 @@ def test_maybe_raise_finetune_warning_adapter(tmp_path):
 def test_maybe_raise_finetune_warning_adapter_v2(tmp_path):
     from lit_gpt.adapter import Config
     from lit_gpt.adapter_v2 import GPT
-    from finetune.adapter_v2 import save_adapter_v2_checkpoint
+    from finetune.adapter_v2 import save_adapter_v2_checkpoint, add_adapter_v2_parameters_to_linear_layers
     from scripts.convert_lit_checkpoint import convert_lit_checkpoint
 
     # fabric is needed for finetune.full::save_checkpoint
     fabric = L.Fabric(devices=1)
 
     model_name = "Llama-2-7b-hf"
-    ours_config = Config.from_name(model_name, block_size=8, n_layer=2, n_embd=32, n_head=2, padding_multiple=128)
+    ours_config = Config.from_name(
+        model_name,
+        adapter_start_layer=0,
+        block_size=8,
+        n_layer=2,
+        n_embd=32,
+        n_head=2,
+        padding_multiple=128,
+    )
     ours_model = GPT(ours_config)
-    ours_model.adapter_bias = torch.nn.Parameter()
+    add_adapter_v2_parameters_to_linear_layers(ours_model)
 
     ckpt_path = tmp_path / "lit_model_adapter_v2.pth"
 
@@ -258,7 +266,6 @@ def test_maybe_raise_finetune_warning_lora(tmp_path):
         padding_multiple=128,
     )
     ours_model = GPT(ours_config)
-    print(ours_model.state_dict().keys())
 
     ckpt_path = tmp_path / "lit_model_lora.pth"
 


### PR DESCRIPTION
Raises `Exception` to inform users that converting models finetuned with `lora`, `adapter`, and `adapter_v2` is not yet supported.

See #374 and #355.