### PR TITLE
Improve FLOPs calculation for finetuning scripts

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -135,10 +135,10 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
-        estimated_flops = estimate_flops(meta_model) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))
+        # estimated flops doesn't account for frozen weights, so it's not reported
+        mark_only_adapter_as_trainable(meta_model)
+        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -141,10 +141,11 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
-        estimated_flops = estimate_flops(meta_model) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))
+        # estimated flops doesn't account for frozen weights, so it's not reported
+        add_adapter_v2_parameters_to_linear_layers(meta_model)
+        mark_only_adapter_v2_as_trainable(meta_model)
+        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -132,7 +132,8 @@ def train(
         # estimated is too much of an optimistic estimate, left just for reference
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))
+        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -154,10 +154,10 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
-        estimated_flops = estimate_flops(meta_model) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))
+        # estimated flops doesn't account for frozen weights, so it's not reported
+        mark_only_lora_as_trainable(meta_model)
+        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x


### PR DESCRIPTION
Whilst getting XLA FLOP numbers, the MFU was >1. Give it's meant to be a percentage, it couldn't be correct.

Noticed 2 issues:
- We were computing the estimated FLOPs for a batch of the model's context length, even though the samples are often smaller
- We were computing estimated FLOPs for the full model without the frozen weights

Note that XLA will use padding to the longest sample in the dataset, so the FLOP numbers will be inflated as they don't take padding into account. In this case, samples/sec would be a more realistic metric.