### PR TITLE
Compute measured FLOPs per batch

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -189,7 +189,7 @@ def train(
                 f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
                 f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
                 f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
-                f" Batch shape: {input_ids.shape}"
+                f" Batch shape: {tuple(input_ids.shape)}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:
@@ -284,7 +284,7 @@ def save_adapter_checkpoint(fabric, model, file_path: Path):
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
-def measured_flops(meta_model: GPT, batch_shape: Tuple[int, ...]) -> int:
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
     with torch.device("meta"):
         x = torch.randint(0, 1, batch_shape)
         return measure_flops(meta_model, x)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -204,6 +204,11 @@ def train(
             save_adapter_checkpoint(fabric, model, checkpoint_path)
 
 
+def save_adapter_checkpoint(fabric, model, file_path: Path):
+    fabric.print(f"Saving adapter weights to {str(file_path)!r}")
+    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
+
+
 @torch.no_grad()
 def validate(
     fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, longest_seq_length: int
@@ -277,11 +282,6 @@ def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
         max_seq_length,
         longest_seq_ix,
     )
-
-
-def save_adapter_checkpoint(fabric, model, file_path: Path):
-    fabric.print(f"Saving adapter weights to {str(file_path)!r}")
-    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
 def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -204,9 +204,10 @@ def train(
             save_adapter_checkpoint(fabric, model, checkpoint_path)
 
 
-def save_adapter_checkpoint(fabric, model, file_path: Path):
-    fabric.print(f"Saving adapter weights to {str(file_path)!r}")
-    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
+    with torch.device("meta"):
+        x = torch.randint(0, 1, batch_shape)
+        return measure_flops(meta_model, x)
 
 
 @torch.no_grad()
@@ -284,10 +285,9 @@ def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
     )
 
 
-def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
-    with torch.device("meta"):
-        x = torch.randint(0, 1, batch_shape)
-        return measure_flops(meta_model, x)
+def save_adapter_checkpoint(fabric, model, file_path: Path):
+    fabric.print(f"Saving adapter weights to {str(file_path)!r}")
+    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
 if __name__ == "__main__":

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -194,7 +194,7 @@ def train(
                 f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
                 f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
                 f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
-                f" Batch shape: {input_ids.shape}"
+                f" Batch shape: {tuple(input_ids.shape)}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import lightning as L
 import torch
@@ -12,7 +12,7 @@ from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from generate.base import generate
+from finetune.adapter import measured_flops, get_max_seq_length, validate, get_batch
 from lit_gpt.adapter import GPT, Block, Config
 from lit_gpt.adapter_v2 import (
     adapter_filter,
@@ -20,10 +20,8 @@ from lit_gpt.adapter_v2 import (
     mark_only_adapter_v2_as_trainable,
 )
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
-from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
-from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
 save_interval = 1000
@@ -144,11 +142,6 @@ def train(
         # estimated flops doesn't account for frozen weights, so it's not reported
         add_adapter_v2_parameters_to_linear_layers(meta_model)
         mark_only_adapter_v2_as_trainable(meta_model)
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
-        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
-        measured_flops = measure_flops(meta_model, x)
-        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
-        del meta_model, x
 
     step_count = 0
     total_lengths = 0
@@ -188,18 +181,20 @@ def train(
 
         t1 = time.perf_counter()
         total_lengths += input_ids.size(1)
+        flops_per_batch = measured_flops(meta_model, input_ids.shape)
         speed_monitor.on_train_batch_end(
             (iter_num + 1) * micro_batch_size,
             t1 - total_t0,
-            # this assumes that device FLOPs are the same and that all devices have the same batch size
             fabric.world_size,
-            flops_per_batch=measured_flops,
+            flops_per_batch=flops_per_batch,
             lengths=total_lengths,
         )
         if iter_num % log_interval == 0:
             fabric.print(
-                f"iter {iter_num} step {step_count}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
+                f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
+                f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
+                f" Batch shape: {input_ids.shape}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:
@@ -212,81 +207,6 @@ def train(
         if not is_accumulating and step_count % save_interval == 0:
             checkpoint_path = out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_adapter_v2_checkpoint(fabric, model, checkpoint_path)
-
-
-@torch.no_grad()
-def validate(
-    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, longest_seq_length: int
-) -> torch.Tensor:
-    fabric.print("Validating ...")
-    model.eval()
-    losses = torch.zeros(eval_iters)
-    for k in range(eval_iters):
-        input_ids, targets = get_batch(fabric, val_data, longest_seq_length)
-        logits = model(input_ids)
-        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
-        losses[k] = loss.item()
-    val_loss = losses.mean()
-
-    # produce an example:
-    instruction = "Recommend a movie for me to watch during the weekend and explain the reason."
-    fabric.print(instruction)
-    sample = {"instruction": instruction, "input": ""}
-    prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
-    output = tokenizer.decode(output)
-    fabric.print(output)
-
-    model.reset_cache()
-
-    model.train()
-    return val_loss.item()
-
-
-def get_batch(
-    fabric: L.Fabric, data: List[Dict], longest_seq_length: int, longest_seq_ix: Optional[int] = None
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    ix = torch.randint(len(data), (micro_batch_size,))
-    if longest_seq_ix is not None:
-        # force the longest sample at the beginning so potential OOMs happen right away
-        ix[0] = longest_seq_ix
-
-    input_ids = [data[i]["input_ids"].type(torch.int64) for i in ix]
-    labels = [data[i]["labels"].type(torch.int64) for i in ix]
-
-    # it's better to pad to a fixed seq length with XLA to avoid recompilation
-    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else longest_seq_length
-
-    def pad_right(x, pad_id):
-        # pad right based on the longest sequence
-        n = max_len - len(x)
-        return torch.cat((x, torch.full((n,), pad_id, dtype=x.dtype)))
-
-    x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
-    y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
-
-    if fabric.device.type == "cuda" and x.device.type == "cpu":
-        x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
-    else:
-        x, y = fabric.to_device((x, y))
-    return x, y
-
-
-def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
-    # find out the minimum max_seq_length required during fine-tuning (saves memory!)
-    lengths = [len(d["input_ids"]) for d in data]
-    max_seq_length = max(lengths)
-    longest_seq_ix = lengths.index(max_seq_length)
-    # support easy override at the top of the file
-    return (
-        override_max_seq_length if isinstance(override_max_seq_length, int) else max_seq_length,
-        max_seq_length,
-        longest_seq_ix,
-    )
 
 
 def save_adapter_v2_checkpoint(fabric, model, file_path: Path):

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -213,9 +213,10 @@ def train(
             save_adapter_v2_checkpoint(fabric, model, checkpoint_path)
 
 
-def save_adapter_v2_checkpoint(fabric, model, file_path: Path):
-    fabric.print(f"Saving adapter v2 weights to {str(file_path)!r}")
-    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
+    with torch.device("meta"):
+        x = torch.randint(0, 1, batch_shape)
+        return measure_flops(meta_model, x)
 
 
 @torch.no_grad()
@@ -293,10 +294,9 @@ def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
     )
 
 
-def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
-    with torch.device("meta"):
-        x = torch.randint(0, 1, batch_shape)
-        return measure_flops(meta_model, x)
+def save_adapter_v2_checkpoint(fabric, model, file_path: Path):
+    fabric.print(f"Saving adapter v2 weights to {str(file_path)!r}")
+    fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
 if __name__ == "__main__":

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -2,17 +2,20 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
 from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
 
+from generate.base import generate
+from scripts.prepare_alpaca import generate_prompt
+
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from finetune.adapter import measured_flops, get_max_seq_length, validate, get_batch
+from finetune.adapter import get_batch, get_max_seq_length, measured_flops, validate
 from lit_gpt.adapter import GPT, Block, Config
 from lit_gpt.adapter_v2 import (
     adapter_filter,
@@ -20,6 +23,7 @@ from lit_gpt.adapter_v2 import (
     mark_only_adapter_v2_as_trainable,
 )
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 
@@ -212,6 +216,87 @@ def train(
 def save_adapter_v2_checkpoint(fabric, model, file_path: Path):
     fabric.print(f"Saving adapter v2 weights to {str(file_path)!r}")
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
+
+
+@torch.no_grad()
+def validate(
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, longest_seq_length: int
+) -> torch.Tensor:
+    fabric.print("Validating ...")
+    model.eval()
+    losses = torch.zeros(eval_iters)
+    for k in range(eval_iters):
+        input_ids, targets = get_batch(fabric, val_data, longest_seq_length)
+        logits = model(input_ids)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
+        losses[k] = loss.item()
+    val_loss = losses.mean()
+
+    # produce an example:
+    instruction = "Recommend a movie for me to watch during the weekend and explain the reason."
+    fabric.print(instruction)
+    sample = {"instruction": instruction, "input": ""}
+    prompt = generate_prompt(sample)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
+    max_returned_tokens = len(encoded) + 100
+    output = generate(
+        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
+    )
+    output = tokenizer.decode(output)
+    fabric.print(output)
+
+    model.reset_cache()
+
+    model.train()
+    return val_loss.item()
+
+
+def get_batch(
+    fabric: L.Fabric, data: List[Dict], longest_seq_length: int, longest_seq_ix: Optional[int] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    ix = torch.randint(len(data), (micro_batch_size,))
+    if longest_seq_ix is not None:
+        # force the longest sample at the beginning so potential OOMs happen right away
+        ix[0] = longest_seq_ix
+
+    input_ids = [data[i]["input_ids"].type(torch.int64) for i in ix]
+    labels = [data[i]["labels"].type(torch.int64) for i in ix]
+
+    # it's better to pad to a fixed seq length with XLA to avoid recompilation
+    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else longest_seq_length
+
+    def pad_right(x, pad_id):
+        # pad right based on the longest sequence
+        n = max_len - len(x)
+        return torch.cat((x, torch.full((n,), pad_id, dtype=x.dtype)))
+
+    x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
+    y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
+
+    if fabric.device.type == "cuda" and x.device.type == "cpu":
+        x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
+    else:
+        x, y = fabric.to_device((x, y))
+    return x, y
+
+
+def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
+    # find out the minimum max_seq_length required during fine-tuning (saves memory!)
+    lengths = [len(d["input_ids"]) for d in data]
+    max_seq_length = max(lengths)
+    longest_seq_ix = lengths.index(max_seq_length)
+    # support easy override at the top of the file
+    return (
+        override_max_seq_length if isinstance(override_max_seq_length, int) else max_seq_length,
+        max_seq_length,
+        longest_seq_ix,
+    )
+
+
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
+    with torch.device("meta"):
+        x = torch.randint(0, 1, batch_shape)
+        return measure_flops(meta_model, x)
 
 
 if __name__ == "__main__":

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -182,7 +182,7 @@ def train(
                 f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
                 f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
                 f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
-                f" Batch shape: {input_ids.shape}"
+                f" Batch shape: {tuple(input_ids.shape)}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -2,20 +2,23 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
 from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
 
+from generate.base import generate
+from scripts.prepare_alpaca import generate_prompt
+
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from finetune.adapter import get_max_seq_length, validate, get_batch, measured_flops
+from finetune.adapter import get_batch, get_max_seq_length, measured_flops, validate
 from lit_gpt.model import GPT, Block, Config
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
-from lit_gpt.speed_monitor import estimate_flops
+from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
 
@@ -200,6 +203,87 @@ def train(
 def save_checkpoint(fabric, model, file_path: Path):
     fabric.print(f"Saving weights to {str(file_path)!r}")
     fabric.save(file_path, {"model": model})
+
+
+@torch.no_grad()
+def validate(
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, longest_seq_length: int
+) -> torch.Tensor:
+    fabric.print("Validating ...")
+    model.eval()
+    losses = torch.zeros(eval_iters)
+    for k in range(eval_iters):
+        input_ids, targets = get_batch(fabric, val_data, longest_seq_length)
+        logits = model(input_ids)
+        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
+        losses[k] = loss.item()
+    val_loss = losses.mean()
+
+    # produce an example:
+    instruction = "Recommend a movie for me to watch during the weekend and explain the reason."
+    fabric.print(instruction)
+    sample = {"instruction": instruction, "input": ""}
+    prompt = generate_prompt(sample)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
+    max_returned_tokens = len(encoded) + 100
+    output = generate(
+        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
+    )
+    output = tokenizer.decode(output)
+    fabric.print(output)
+
+    model.reset_cache()
+
+    model.train()
+    return val_loss.item()
+
+
+def get_batch(
+    fabric: L.Fabric, data: List[Dict], longest_seq_length: int, longest_seq_ix: Optional[int] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    ix = torch.randint(len(data), (micro_batch_size,))
+    if longest_seq_ix is not None:
+        # force the longest sample at the beginning so potential OOMs happen right away
+        ix[0] = longest_seq_ix
+
+    input_ids = [data[i]["input_ids"].type(torch.int64) for i in ix]
+    labels = [data[i]["labels"].type(torch.int64) for i in ix]
+
+    # it's better to pad to a fixed seq length with XLA to avoid recompilation
+    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else longest_seq_length
+
+    def pad_right(x, pad_id):
+        # pad right based on the longest sequence
+        n = max_len - len(x)
+        return torch.cat((x, torch.full((n,), pad_id, dtype=x.dtype)))
+
+    x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
+    y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
+
+    if fabric.device.type == "cuda" and x.device.type == "cpu":
+        x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
+    else:
+        x, y = fabric.to_device((x, y))
+    return x, y
+
+
+def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
+    # find out the minimum max_seq_length required during fine-tuning (saves memory!)
+    lengths = [len(d["input_ids"]) for d in data]
+    max_seq_length = max(lengths)
+    longest_seq_ix = lengths.index(max_seq_length)
+    # support easy override at the top of the file
+    return (
+        override_max_seq_length if isinstance(override_max_seq_length, int) else max_seq_length,
+        max_seq_length,
+        longest_seq_ix,
+    )
+
+
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
+    with torch.device("meta"):
+        x = torch.randint(0, 1, batch_shape)
+        return measure_flops(meta_model, x)
 
 
 if __name__ == "__main__":

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -200,9 +200,10 @@ def train(
             save_checkpoint(fabric, model, checkpoint_path)
 
 
-def save_checkpoint(fabric, model, file_path: Path):
-    fabric.print(f"Saving weights to {str(file_path)!r}")
-    fabric.save(file_path, {"model": model})
+def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
+    with torch.device("meta"):
+        x = torch.randint(0, 1, batch_shape)
+        return measure_flops(meta_model, x)
 
 
 @torch.no_grad()
@@ -280,10 +281,9 @@ def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
     )
 
 
-def measured_flops(meta_model: GPT, batch_shape: torch.Size) -> int:
-    with torch.device("meta"):
-        x = torch.randint(0, 1, batch_shape)
-        return measure_flops(meta_model, x)
+def save_checkpoint(fabric, model, file_path: Path):
+    fabric.print(f"Saving weights to {str(file_path)!r}")
+    fabric.save(file_path, {"model": model})
 
 
 if __name__ == "__main__":

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import lightning as L
 import torch
@@ -12,13 +12,12 @@ from lightning.fabric.strategies import FSDPStrategy, XLAStrategy
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from generate.base import generate
+from finetune.adapter import get_max_seq_length, validate, get_batch, measured_flops
 from lit_gpt.model import GPT, Block, Config
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
-from lit_gpt.speed_monitor import estimate_flops, measure_flops
+from lit_gpt.speed_monitor import estimate_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
-from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
 save_interval = 1000
@@ -132,11 +131,6 @@ def train(
         # estimated is too much of an optimistic estimate, left just for reference
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
-        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
-        measured_flops = measure_flops(meta_model, x)
-        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
-        del meta_model, x
 
     step_count = 0
     total_lengths = 0
@@ -175,12 +169,12 @@ def train(
 
         t1 = time.perf_counter()
         total_lengths += input_ids.size(1)
+        flops_per_batch = measured_flops(meta_model, input_ids.shape)
         speed_monitor.on_train_batch_end(
             (iter_num + 1) * micro_batch_size,
             t1 - total_t0,
-            # this assumes that device FLOPs are the same and that all devices have the same batch size
             fabric.world_size,
-            flops_per_batch=measured_flops,
+            flops_per_batch=flops_per_batch,
             lengths=total_lengths,
         )
         if iter_num % log_interval == 0:
@@ -193,87 +187,12 @@ def train(
             t0 = time.perf_counter()
             val_loss = validate(fabric, model, val_data, tokenizer, longest_seq_length)
             t1 = time.perf_counter() - t0
-            speed_monitor.eval_end(t1)
+            speed_monitor.eval_end(ts1)
             fabric.print(f"step {iter_num}: val loss {val_loss:.4f}, val time: {t1 * 1000:.2f}ms")
             fabric.barrier()
         if not is_accumulating and step_count % save_interval == 0:
             checkpoint_path = out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_checkpoint(fabric, model, checkpoint_path)
-
-
-@torch.no_grad()
-def validate(
-    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, longest_seq_length: int
-) -> torch.Tensor:
-    fabric.print("Validating ...")
-    model.eval()
-    losses = torch.zeros(eval_iters)
-    for k in range(eval_iters):
-        input_ids, targets = get_batch(fabric, val_data, longest_seq_length)
-        logits = model(input_ids)
-        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
-        losses[k] = loss.item()
-    val_loss = losses.mean()
-
-    # produce an example:
-    instruction = "Recommend a movie for me to watch during the weekend and explain the reason."
-    fabric.print(instruction)
-    sample = {"instruction": instruction, "input": ""}
-    prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
-    output = tokenizer.decode(output)
-    fabric.print(output)
-
-    model.reset_cache()
-
-    model.train()
-    return val_loss.item()
-
-
-def get_batch(
-    fabric: L.Fabric, data: List[Dict], longest_seq_length: int, longest_seq_ix: Optional[int] = None
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    ix = torch.randint(len(data), (micro_batch_size,))
-    if longest_seq_ix is not None:
-        # force the longest sample at the beginning so potential OOMs happen right away
-        ix[0] = longest_seq_ix
-
-    input_ids = [data[i]["input_ids"].type(torch.int64) for i in ix]
-    labels = [data[i]["labels"].type(torch.int64) for i in ix]
-
-    # it's better to pad to a fixed seq length with XLA to avoid recompilation
-    max_len = max(len(s) for s in input_ids) if fabric.device.type != "xla" else longest_seq_length
-
-    def pad_right(x, pad_id):
-        # pad right based on the longest sequence
-        n = max_len - len(x)
-        return torch.cat((x, torch.full((n,), pad_id, dtype=x.dtype)))
-
-    x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
-    y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
-
-    if fabric.device.type == "cuda" and x.device.type == "cpu":
-        x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
-    else:
-        x, y = fabric.to_device((x, y))
-    return x, y
-
-
-def get_max_seq_length(data: List[Dict]) -> Tuple[int, int, int]:
-    # find out the minimum max_seq_length required during fine-tuning (saves memory!)
-    lengths = [len(d["input_ids"]) for d in data]
-    max_seq_length = max(lengths)
-    longest_seq_ix = lengths.index(max_seq_length)
-    # support easy override at the top of the file
-    return (
-        override_max_seq_length if isinstance(override_max_seq_length, int) else max_seq_length,
-        max_seq_length,
-        longest_seq_ix,
-    )
 
 
 def save_checkpoint(fabric, model, file_path: Path):

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -179,15 +179,17 @@ def train(
         )
         if iter_num % log_interval == 0:
             fabric.print(
-                f"iter {iter_num} step {step_count}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
+                f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
+                f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
+                f" Batch shape: {input_ids.shape}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:
             t0 = time.perf_counter()
             val_loss = validate(fabric, model, val_data, tokenizer, longest_seq_length)
             t1 = time.perf_counter() - t0
-            speed_monitor.eval_end(ts1)
+            speed_monitor.eval_end(t1)
             fabric.print(f"step {iter_num}: val loss {val_loss:.4f}, val time: {t1 * 1000:.2f}ms")
             fabric.barrier()
         if not is_accumulating and step_count % save_interval == 0:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -206,7 +206,7 @@ def train(
                 f"iter {iter_num} step {step_count}: loss {loss.item():.4f},"
                 f" iter_time: {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''},"
                 f" TFLOPs/device: {flops_per_batch / 1e12:.2f},"
-                f" Batch shape: {input_ids.shape}"
+                f" Batch shape: {tuple(input_ids.shape)}"
             )
 
         if not is_accumulating and step_count % eval_interval == 0:


### PR DESCRIPTION
- Changes the finetune scripts to compute per-batch FLOPs to account for varying sequence lengths. Pretraining doesn't need it.

  This has some cost, using this script

	```python
	from lit_gpt import GPT
	import torch
	import time
	
	name = "pythia-2.8b"
	
	torch.set_default_dtype(torch.bfloat16)
	
	t0 = time.perf_counter()
	with torch.device("cuda"):
	    model = GPT.from_name(name)
	    x = torch.randint(0, 1, (1, model.config.block_size))
	    model(x).sum().backward()
	t1 = time.perf_counter()
	print(t1 - t0)
	
	t0 = time.perf_counter()
	with torch.device("meta"):
	    model = GPT.from_name(name)
	    x = torch.randint(0, 1, (1, model.config.block_size))
	    model(x).sum().backward()
	t1 = time.perf_counter()
	print(t1 - t0)
	```
	
	```bash
	$ command time -v python script.py
	1.3730567982420325  # cuda time
	0.4068741509690881  # meta time
    Maximum resident set size (kbytes) goes from `924320` (just CUDA) to `926400` (CUDA + meta)
	```
	
	However, the FLOPs time cost is not included in the speed monitor time measures.

- Adds TFLOPs/device and associated batch shape to the printed logs as this is not included in the SpeedMonitor's CSV.