### PR TITLE
Avoid in-place operations in LoRA forward

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -380,8 +380,6 @@ class LoRAQKVLinear(LoRALinear):
         # For F.conv1d:
         # ⚬ input: input tensor of shape (mini-batch, in_channels, iW)
         # ⚬ weight: filters of shape (out_channels, in_channels/groups, kW)
-        # ⚬ groups: split input into groups, in_channels should be divisible by the number of groups. Default: 1
-        # presumably iW - sequence width/length, kW - kernel width
         after_B = self.conv1d(
             after_A.transpose(-2, -1),  # (64, 64, 4) -> (64, 4, 64)
             self.lora_B.unsqueeze(-1),  # (256, 2) -> (256, 2, 1)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -331,7 +331,7 @@ def test_lora_qkv_linear_compare_conv1d(n_head, enable_lora):
     assert torch.allclose(conv1d_pytorch, conv1d_custom_forced)
 
 
-@pytest.mark.parametrize(("rank", "expected_merged"), ((-1, False), (0, False), (1, True)))
+@pytest.mark.parametrize(("rank", "expected_merged"), ((0, False), (1, True)))
 def test_lora_linear_weights_merged_status(rank, expected_merged):
     from lit_gpt.lora import LoRALinear
 
@@ -343,7 +343,7 @@ def test_lora_linear_weights_merged_status(rank, expected_merged):
 
 @pytest.mark.parametrize(
     ("rank", "enable_lora", "expected_merged"),
-    ((-1, True, False), (0, True, False), (1, True, True), (-1, False, False), (0, False, False), (1, False, False)),
+    ((0, True, False), (1, True, True), (0, False, False), (1, False, False)),
 )
 def test_lora_qkv_linear_weights_merged_status(rank, enable_lora, expected_merged):
     from lit_gpt.lora import LoRAQKVLinear


### PR DESCRIPTION
Unblocks https://github.com/Lightning-AI/lit-gpt/pull/275 by avoiding https://github.com/Lightning-AI/lit-gpt/pull/275#issuecomment-1677703307

I haven't noticed an increase in peak memory usage
