### PR TITLE
Fix `tokens_per_sec`  calculation in `SpeedMonitor`

### DIFF
--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -239,10 +239,11 @@ class SpeedMonitorBase:
             # Assumes no padding.
             if lengths is not None:
                 elapsed_lengths = int(self.history_lengths[-1]) - int(self.history_lengths[0])
+                avg_length = elapsed_lengths / elapsed_batches
                 metrics.update(
                     {
-                        "throughput/tokens_per_sec": samples_per_sec * elapsed_lengths,
-                        "throughput/device/tokens_per_sec": dev_samples_per_sec * elapsed_lengths,
+                        "throughput/tokens_per_sec": samples_per_sec * avg_length,
+                        "throughput/device/tokens_per_sec": dev_samples_per_sec * avg_length,
                     }
                 )
 


### PR DESCRIPTION
The calculations for `tokens_per_sec` (and `device/tokens_per_sec`) in `SpeedMonitor` are wrong, specifically an overestimation by a factor of `window_size` (default to 100). To fix, we need multiply `samples_per_second` by the mean number of tokens per sample (instead of multiplying by the **sum** of of number of tokens per sample over the last `window_size` batches, which is done currently).

For comparison, see the reference implementation:
```python
# Compute token stats if dataloader.dataset has max_seq_len. Assumes no padding.
try:
    max_seq_len = state.dataloader.dataset.max_seq_len  # type: ignore
    # Only applicable to seq data / models
    logger.log_metrics({'throughput/tokens_per_sec': samples_per_sec * max_seq_len})
    logger.log_metrics({'throughput/device/tokens_per_sec': dev_samples_per_sec * max_seq_len})
```
https://github.com/mosaicml/composer/blob/f2a2dc820cb75023b9eb7c46fdfd25273712abd0/composer/callbacks/speed_monitor.py#L279-L284
