### PR TITLE
Use bf16 as default only if supported

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -14,7 +14,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 
 
 @torch.no_grad()
@@ -139,11 +139,7 @@ def main(
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     check_valid_checkpoint_dir(checkpoint_dir)
 

--- a/chat/base.py
+++ b/chat/base.py
@@ -123,7 +123,7 @@ def main(
     temperature: float = 0.8,
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
 ) -> None:
     """Starts a conversation with a tuned GPT model.
 
@@ -139,6 +139,12 @@ def main(
             for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     check_valid_checkpoint_dir(checkpoint_dir)
 
     with open(checkpoint_dir / "lit_config.json") as fp:

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -204,7 +204,7 @@ class EvalHarnessBase(BaseLM):
 
 def run_eval_harness(
     checkpoint_dir: str = "",
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
     batch_size=1,
     eval_tasks: Optional[List[str]] = None,
     num_fewshot=0,
@@ -216,6 +216,12 @@ def run_eval_harness(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     save_filepath: Optional[str] = None,
 ):
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     eval_harness = EvalHarnessBase(
         checkpoint_dir=checkpoint_dir,
         precision=precision,

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -18,7 +18,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 
 
 class EvalHarnessBase(BaseLM):
@@ -216,11 +216,7 @@ def run_eval_harness(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     save_filepath: Optional[str] = None,
 ):
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     eval_harness = EvalHarnessBase(
         checkpoint_dir=checkpoint_dir,

--- a/eval/lm_eval_harness_lora.py
+++ b/eval/lm_eval_harness_lora.py
@@ -18,7 +18,7 @@ from lm_eval_harness import EvalHarnessAdapter
 
 from lit_gpt import Tokenizer
 from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -130,11 +130,7 @@ def run_eval_harness(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     save_filepath: Optional[str] = None,
 ):
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     eval_harness = EvalHarnessLoRA(
         lora_path=lora_path,

--- a/eval/lm_eval_harness_lora.py
+++ b/eval/lm_eval_harness_lora.py
@@ -118,7 +118,7 @@ def run_eval_harness(
     lora_path: str = "",
     checkpoint_dir: str = "",
     input: str = "",
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
     batch_size=1,
     eval_tasks: Optional[List[str]] = None,
     num_fewshot=0,
@@ -130,6 +130,12 @@ def run_eval_harness(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     save_filepath: Optional[str] = None,
 ):
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     eval_harness = EvalHarnessLoRA(
         lora_path=lora_path,
         checkpoint_dir=checkpoint_dir,

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -17,7 +17,14 @@ from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapte
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import (
+    check_valid_checkpoint_dir,
+    chunked_cross_entropy,
+    get_default_supported_precision,
+    lazy_load,
+    num_parameters,
+    step_csv_logger,
+)
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -51,7 +51,13 @@ def setup(
     tpu: bool = False,
 ):
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     fabric_devices = devices
     if fabric_devices > 1:
         if tpu:

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -17,7 +17,7 @@ from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapte
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
@@ -50,13 +50,7 @@ def setup(
     precision: Optional[str] = None,
     tpu: bool = False,
 ):
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     fabric_devices = devices
     if fabric_devices > 1:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -56,7 +56,13 @@ def setup(
     tpu: bool = False,
 ):
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     fabric_devices = devices
     if fabric_devices > 1:
         if tpu:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -17,7 +17,7 @@ from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_ada
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
@@ -50,13 +50,7 @@ def setup(
     precision: Optional[str] = None,
     tpu: bool = False,
 ):
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     fabric_devices = devices
     if fabric_devices > 1:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -17,7 +17,14 @@ from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_ada
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import (
+    check_valid_checkpoint_dir,
+    chunked_cross_entropy,
+    get_default_supported_precision,
+    lazy_load,
+    num_parameters,
+    step_csv_logger,
+)
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -17,7 +17,14 @@ from lit_gpt.model import GPT, Block, Config
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import (
+    check_valid_checkpoint_dir,
+    chunked_cross_entropy,
+    get_default_supported_precision,
+    lazy_load,
+    num_parameters,
+    step_csv_logger,
+)
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -51,7 +51,13 @@ def setup(
     tpu: bool = False,
 ):
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     fabric_devices = devices
     if fabric_devices > 1:
         if tpu:

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -17,7 +17,7 @@ from lit_gpt.model import GPT, Block, Config
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 600
@@ -50,13 +50,7 @@ def setup(
     precision: Optional[str] = None,
     tpu: bool = False,
 ):
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     fabric_devices = devices
     if fabric_devices > 1:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -17,7 +17,7 @@ from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trai
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 100
@@ -57,13 +57,7 @@ def setup(
     precision: Optional[str] = None,
     tpu: bool = False,
 ):
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     fabric_devices = devices
     if fabric_devices > 1:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -17,7 +17,14 @@ from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trai
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, get_default_supported_precision, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import (
+    check_valid_checkpoint_dir,
+    chunked_cross_entropy,
+    get_default_supported_precision,
+    lazy_load,
+    num_parameters,
+    step_csv_logger,
+)
 from scripts.prepare_alpaca import generate_prompt
 
 eval_interval = 100

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -58,7 +58,13 @@ def setup(
     tpu: bool = False,
 ):
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     fabric_devices = devices
     if fabric_devices > 1:
         if tpu:

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.adapter import GPT, Block, Config
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -56,11 +56,7 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -31,7 +31,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = "bf16-true",
+    precision: str = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT-Adapter model.
@@ -56,6 +56,12 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
     fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -31,7 +31,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = None,
+    precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT-Adapter model.

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.adapter_v2 import GPT, Block, Config
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -56,11 +56,7 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -32,7 +32,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT-AdapterV2 model.
@@ -57,6 +57,12 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
     fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)

--- a/generate/base.py
+++ b/generate/base.py
@@ -15,7 +15,7 @@ sys.path.append(str(wd))
 
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 
 
 @torch.no_grad()
@@ -120,11 +120,7 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)

--- a/generate/base.py
+++ b/generate/base.py
@@ -99,7 +99,7 @@ def main(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = "bf16-true",
+    precision: str = None,
 ) -> None:
     """Generates text samples based on a pre-trained model and tokenizer.
 
@@ -120,6 +120,12 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
     fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)

--- a/generate/base.py
+++ b/generate/base.py
@@ -99,7 +99,7 @@ def main(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = None,
+    precision: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained model and tokenizer.
 

--- a/generate/full.py
+++ b/generate/full.py
@@ -31,7 +31,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = "bf16-true",
+    precision: str = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT model.
@@ -56,6 +56,12 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
     fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)

--- a/generate/full.py
+++ b/generate/full.py
@@ -31,7 +31,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = None,
+    precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT model.

--- a/generate/full.py
+++ b/generate/full.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -56,11 +56,7 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load, quantization
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -66,11 +66,7 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -41,7 +41,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = "bf16-true",
+    precision: str = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT-LoRA model.
@@ -66,6 +66,12 @@ def main(
         devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if strategy == "fsdp":
         strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
     fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -41,7 +41,7 @@ def main(
     temperature: float = 0.8,
     strategy: str = "auto",
     devices: int = 1,
-    precision: str = None,
+    precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
     This script will only work with checkpoints from the instruction-tuned GPT-LoRA model.

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -479,7 +479,7 @@ def chunked_cross_entropy(
     return torch.cat(loss_chunks).mean()
 
 
-def get_default_supported_precision(training: bool, tpu: bool = False):
+def get_default_supported_precision(training: bool, tpu: bool = False) -> str:
     """Return default precision that is supported by the hardware.
 
     Args:

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -477,3 +477,20 @@ def chunked_cross_entropy(
         for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
     ]
     return torch.cat(loss_chunks).mean()
+
+
+def get_default_supported_precision(training: bool, tpu: bool = False):
+    """Return default precision that is supported by the hardware.
+
+    Args:
+        training: `-mixed` or `-true` version of the precision to use
+        tpu: whether TPU device is used
+
+    Returns:
+        default precision that is suitable for the task and is supported by the hardware
+    """
+    if tpu:
+        return "32-true"
+    if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+        return "bf16-mixed" if training else "bf16-true"
+    return "16-mixed" if training else "16-true"

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -53,7 +53,13 @@ def setup(
     devices: int = 1, precision: Optional[str] = None, tpu: bool = False, resume: Union[bool, Path] = False
 ) -> None:
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     if devices > 1:
         if tpu:
             # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -18,7 +18,7 @@ from lit_gpt import Config
 from lit_gpt.model import GPT, Block
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, num_parameters, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters, step_csv_logger
 
 model_name = "pythia-70m"
 name = "openwebtext"
@@ -52,13 +52,7 @@ logger = step_csv_logger("out", name, flush_logs_every_n_steps=log_interval)
 def setup(
     devices: int = 1, precision: Optional[str] = None, tpu: bool = False, resume: Union[bool, Path] = False
 ) -> None:
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     if devices > 1:
         if tpu:

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -100,7 +100,13 @@ class LightningGPTModule(L.LightningModule):
 
 def main(devices: int = 1, precision: Optional[str] = None, tpu: bool = False) -> None:
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     if devices > 1:
         if tpu:
             # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -19,7 +19,7 @@ sys.path.append(str(wd))
 from lit_gpt import Config
 from lit_gpt.model import GPT, Block
 from lit_gpt.speed_monitor import SpeedMonitorCallback, estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, step_csv_logger
 
 model_name = "pythia-70m"
 name = "openwebtext"
@@ -99,13 +99,7 @@ class LightningGPTModule(L.LightningModule):
 
 
 def main(devices: int = 1, precision: Optional[str] = None, tpu: bool = False) -> None:
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     if devices > 1:
         if tpu:

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -69,7 +69,13 @@ def setup(
     resume: Union[bool, Path] = False,
 ) -> None:
     if precision is None:
-        precision = "32-true" if tpu else "bf16-mixed"
+        if tpu:
+            precision = "32-true"
+        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-mixed"
+        else:
+            precision = "16-mixed"
+
     if devices > 1:
         if tpu:
             # For multi-host TPU training, the device count for Fabric is limited to the count on a single host.

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -18,7 +18,7 @@ from lit_gpt.model import GPT, Block, Config
 from lit_gpt.packed_dataset import CombinedDataset, PackedDataset
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, num_parameters, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters, step_csv_logger
 
 model_name = "pythia-70m"
 name = "redpajama"
@@ -68,13 +68,7 @@ def setup(
     tpu: bool = False,
     resume: Union[bool, Path] = False,
 ) -> None:
-    if precision is None:
-        if tpu:
-            precision = "32-true"
-        elif not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-mixed"
-        else:
-            precision = "16-mixed"
+    precision = precision or get_default_supported_precision(training=True, tpu=tpu)
 
     if devices > 1:
         if tpu:

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -19,7 +19,7 @@ sys.path.append(str(wd))
 from lightning_utilities.core.imports import RequirementCache
 
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, lazy_load
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 
 _TRITON_AVAILABLE = RequirementCache("triton")
 if _TRITON_AVAILABLE:
@@ -587,11 +587,7 @@ def main(
         n_samples: Number of example inputs to use for statistics (default: 128)
         precision: The precision to use to load the model.
     """
-    if not precision:
-        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-            precision = "bf16-true"
-        else:
-            precision = "16-true"
+    precision = precision or get_default_supported_precision(training=False)
 
     if output_path is None:
         output_path = checkpoint_dir / "lit_model_gptq.4bit.pth"

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -577,7 +577,7 @@ def main(
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     output_path: Optional[Path] = None,
     n_samples: int = 128,
-    precision: str = "bf16-true",
+    precision: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLM and tokenizer.
 
@@ -587,6 +587,12 @@ def main(
         n_samples: Number of example inputs to use for statistics (default: 128)
         precision: The precision to use to load the model.
     """
+    if not precision:
+        if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
+            precision = "bf16-true"
+        else:
+            precision = "16-true"
+
     if output_path is None:
         output_path = checkpoint_dir / "lit_model_gptq.4bit.pth"
     check_valid_checkpoint_dir(checkpoint_dir)


### PR DESCRIPTION
Hi there 👋 

This PR addresses the issue when `bf16-true` is used by default even for cards that don't support it: Nvidia T4 and V100 for example (which are quite popular).

Why for the training `bf16-mixed` is used and not `bf16-true` you may ask?
As @carmocca stated:
> there's many results across tutorials and blogposts that use the current default, so changing this will invalidate them if they weren't explicitly specifying the precision

---

Tested on T4 and A10G: `16-true/mixed` and `bf16-true/mixed` respectively are applied by default.
CPU also by default uses `bf16` precision.

Fixes #327 