### PR TITLE
Support converting the checkpoint dtype

### DIFF
--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -183,10 +183,9 @@ def load_param(param: Union[torch.Tensor, NotYetLoadedTensor], name: str, dtype:
         # support tensors loaded via `lazy_load()`
         print(f"Loading {name} into RAM")
         param = param._load_tensor()
-    if dtype is not None:
-        if dtype != param.dtype:
-            print(f"Converting {name} from {param.dtype} to {dtype}")
-            param = param.to(dtype)
+    if dtype != param.dtype:
+        print(f"Converting {name} from {param.dtype} to {dtype}")
+        param = param.to(dtype)
     return param
 
 

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -20,6 +20,7 @@ def copy_weights_gpt_neox(
     state_dict: Dict[str, torch.Tensor],
     hf_weights: Dict[str, Union[torch.Tensor, NotYetLoadedTensor]],
     saver: Optional[incremental_save] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> None:
     weight_map = {
         "gpt_neox.embed_in.weight": "transformer.wte.weight",
@@ -52,7 +53,7 @@ def copy_weights_gpt_neox(
             to_name = to_name.format(number)
         else:
             to_name = weight_map[name]
-        param = load_param(param)
+        param = load_param(param, name, dtype)
         if saver is not None:
             param = saver.store_early(param)
         state_dict[to_name] = param
@@ -63,6 +64,7 @@ def copy_weights_falcon(
     state_dict: Dict[str, torch.Tensor],
     hf_weights: Dict[str, Union[torch.Tensor, NotYetLoadedTensor]],
     saver: Optional[incremental_save] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> None:
     weight_map = {
         "transformer.word_embeddings.weight": "transformer.wte.weight",
@@ -100,7 +102,7 @@ def copy_weights_falcon(
             to_name = weight_map[from_name].format(number)
         else:
             to_name = weight_map[name]
-        param = load_param(param)
+        param = load_param(param, name, dtype)
         if saver is not None:
             param = saver.store_early(param)
         state_dict[to_name] = param
@@ -112,6 +114,7 @@ def copy_weights_hf_llama(
     state_dict: Dict[str, torch.Tensor],
     hf_weights: Dict[str, Union[torch.Tensor, NotYetLoadedTensor]],
     saver: Optional[incremental_save] = None,
+    dtype: Optional[torch.dtype] = None,
 ) -> None:
     weight_map = {
         "model.embed_tokens.weight": "transformer.wte.weight",
@@ -145,7 +148,7 @@ def copy_weights_hf_llama(
             to_name = to_name.format(number)
         else:
             to_name = weight_map[name]
-        param = load_param(param)
+        param = load_param(param, name, param)
         if saver is not None:
             param = saver.store_early(param)
         state_dict[to_name] = param
@@ -154,9 +157,9 @@ def copy_weights_hf_llama(
         if q is None or k is None or v is None:
             # split across different .bin files
             continue
-        q = load_param(q)
-        k = load_param(k)
-        v = load_param(v)
+        q = load_param(q, f"layer {i} q", dtype)
+        k = load_param(k, f"layer {i} k", dtype)
+        v = load_param(v, f"layer {i} v", dtype)
         q_per_kv = config.n_head // config.n_query_groups
         qs = torch.split(q, config.head_size * q_per_kv)
         ks = torch.split(k, config.head_size)
@@ -175,19 +178,27 @@ def layer_template(layer_name: str, idx: int) -> Tuple[str, int]:
     return from_name, number
 
 
-def load_param(param: Union[torch.Tensor, NotYetLoadedTensor]) -> torch.Tensor:
+def load_param(param: Union[torch.Tensor, NotYetLoadedTensor], name: str, dtype: Optional[torch.dtype]) -> torch.Tensor:
     if hasattr(param, "_load_tensor"):
         # support tensors loaded via `lazy_load()`
-        return param._load_tensor()
+        print(f"Loading {name} into RAM")
+        param = param._load_tensor()
+    if dtype is not None:
+        if dtype != param.dtype:
+            print(f"Converting {name} from {param.dtype} to {dtype}")
+            param = param.to(dtype)
     return param
 
 
 @torch.inference_mode()
 def convert_hf_checkpoint(
-    *, checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"), model_name: Optional[str] = None
+    *, checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"), model_name: Optional[str] = None, dtype: Optional[str] = None
 ) -> None:
     if model_name is None:
         model_name = checkpoint_dir.name
+    if dtype is not None:
+        dtype = getattr(torch, dtype)
+
     config = Config.from_name(model_name)
     print(f"Model config {config.__dict__}")
     with open(checkpoint_dir / "lit_config.json", "w") as json_config:
@@ -223,8 +234,9 @@ def convert_hf_checkpoint(
             for bin_file in sorted(bin_files):
                 print("Processing", bin_file)
                 hf_weights = stack.enter_context(lazy_load(bin_file))
-                copy_fn(sd, hf_weights, saver=saver)
+                copy_fn(sd, hf_weights, saver=saver, dtype=dtype)
             gc.collect()
+        print("Saving converted checkpoint")
         saver.save(sd)
 
 

--- a/tutorials/download_falcon.md
+++ b/tutorials/download_falcon.md
@@ -31,6 +31,9 @@ python scripts/download.py --repo_id tiiuae/falcon-7b
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_freewilly_2.md
+++ b/tutorials/download_freewilly_2.md
@@ -13,6 +13,9 @@ python scripts/download.py --repo_id stabilityai/FreeWilly2
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/stabilityai/FreeWilly2
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_llama_2.md
+++ b/tutorials/download_llama_2.md
@@ -40,6 +40,9 @@ python scripts/download.py --repo_id meta-llama/Llama-2-7b-chat-hf --token your_
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/meta-llama/Llama-2-7b-chat-hf
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_longchat.md
+++ b/tutorials/download_longchat.md
@@ -26,6 +26,9 @@ python scripts/download.py --repo_id lmsys/longchat-7b-16k
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/lmsys/longchat-7b-16k
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_openllama.md
+++ b/tutorials/download_openllama.md
@@ -28,6 +28,9 @@ python scripts/download.py --repo_id openlm-research/open_llama_3b
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/openlm-research/open_llama_3b
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_pythia.md
+++ b/tutorials/download_pythia.md
@@ -42,6 +42,9 @@ python scripts/download.py --repo_id EleutherAI/pythia-1b
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/EleutherAI/pythia-1b
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_redpajama_incite.md
+++ b/tutorials/download_redpajama_incite.md
@@ -34,6 +34,9 @@ python scripts/download.py --repo_id togethercomputer/RedPajama-INCITE-Base-3B-v
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/togethercomputer/RedPajama-INCITE-Base-3B-v1
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_stablelm.md
+++ b/tutorials/download_stablelm.md
@@ -29,6 +29,9 @@ python scripts/download.py --repo_id stabilityai/stablelm-base-alpha-3b
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash

--- a/tutorials/download_vicuna.md
+++ b/tutorials/download_vicuna.md
@@ -26,6 +26,9 @@ python scripts/download.py --repo_id lmsys/vicuna-7b-v1.3
 python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/lmsys/vicuna-7b-v1.3
 ```
 
+By default, the convert_hf_checkpoint step will use the data type of the HF checkpoint's parameters. In cases where RAM
+or disk size is constrained, it might be useful to pass `--dtype bfloat16` to convert all parameters into this smaller precision before continuing.
+
 You're done! To execute the model just run:
 
 ```bash


### PR DESCRIPTION
This is useful for cloud machines with limited system memory (RAM) where you know you'll be loading into a specific dtype before conversion.

Also to avoid this FSDP error:

```python
  File "/home/carlos/lit-parrot/finetune/lora.py", line 126, in main
    model = fabric.setup_module(model)
  File "/home/carlos/venv/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 282, in setup_module
    module = self._strategy.setup_module(module)
  File "/home/carlos/venv/lib/python3.10/site-packages/lightning/fabric/strategies/fsdp.py", line 279, in setup_module
    module = FullyShardedDataParallel(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 456, in __init__
    _auto_wrap(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/_wrap_utils.py", line 72, in _auto_wrap
    _post_order_apply(root_module, wrap_fn)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 79, in _post_order_apply
    _post_order_apply_inner(root_module, "", None)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 63, in _post_order_apply_inner
    _post_order_apply_inner(child_module, child_module_name, module)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 63, in _post_order_apply_inner
    _post_order_apply_inner(child_module, child_module_name, module)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 63, in _post_order_apply_inner
    _post_order_apply_inner(child_module, child_module_name, module)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 64, in _post_order_apply_inner
    optional_module = fn(module)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/wrap.py", line 98, in fn
    return fsdp_fn(module, **kwargs)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 480, in __init__
    _init_param_handle_from_module(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/_init_utils.py", line 519, in _init_param_handle_from_module
    _init_param_handle_from_params(state, managed_params, fully_sharded_module)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/_init_utils.py", line 531, in _init_param_handle_from_params
    handle = FlatParamHandle(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/flat_param.py", line 537, in __init__
    self._init_flat_param_and_metadata(
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/flat_param.py", line 585, in _init_flat_param_and_metadata
    ) = self._validate_tensors_to_flatten(params)
  File "/home/carlos/venv/lib/python3.10/site-packages/torch/distributed/fsdp/flat_param.py", line 722, in _validate_tensors_to_flatten
    raise ValueError(
ValueError: Must flatten tensors with uniform dtype but got torch.float32 and torch.bfloat16
```

Some prints were added for a nicer user experience