### PR TITLE
Add compatibility for previous adapter v2 checkpoints

### DIFF
--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -259,6 +259,7 @@ class GptNeoxMLP(lit_gpt.model.GptNeoxMLP):
         state_dict = map_old_state_dict_weights(state_dict, mapping, prefix)
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
+
 class LLaMAMLP(lit_gpt.model.LLaMAMLP):
     def __init__(self, config: Config) -> None:
         nn.Module.__init__(self)

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -8,7 +8,7 @@ from functools import partial
 from io import BytesIO
 from pathlib import Path
 from types import MethodType
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union
 
 import torch
 import torch.nn as nn
@@ -477,3 +477,12 @@ def chunked_cross_entropy(
         for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
     ]
     return torch.cat(loss_chunks).mean()
+
+
+def map_old_state_dict_weights(state_dict: Dict, mapping: Mapping, prefix: str) -> Dict:
+    for checkpoint_name, attribute_name in mapping.items():
+        full_checkpoint_name = prefix + checkpoint_name
+        if full_checkpoint_name in state_dict:
+            full_attribute_name = prefix + attribute_name
+            state_dict[full_attribute_name] = state_dict.pop(full_checkpoint_name)
+    return state_dict

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -31,37 +31,29 @@ def test_adapter_v2_filter(tmp_path):
     saved = torch.load(save_path)["model"]
 
     expected = {
-        'lm_head.adapter_bias',
-        'lm_head.adapter_scale',
-        'transformer.h.0.attn.attn.adapter_bias',
-        'transformer.h.0.attn.attn.adapter_scale',
-        'transformer.h.0.attn.proj.adapter_bias',
-        'transformer.h.0.attn.proj.adapter_scale',
-        'transformer.h.0.norm_1.bias',
-        'transformer.h.0.norm_1.weight',
-        'transformer.h.0.norm_2.bias',
-        'transformer.h.0.norm_2.weight',
-        'transformer.h.1.attn.attn.adapter_bias',
-        'transformer.h.1.attn.attn.adapter_scale',
-        'transformer.h.1.attn.proj.adapter_bias',
-        'transformer.h.1.attn.proj.adapter_scale',
-        'transformer.h.1.norm_1.bias',
-        'transformer.h.1.norm_1.weight',
-        'transformer.h.1.norm_2.bias',
-        'transformer.h.1.norm_2.weight',
-        'transformer.h.2.attn.adapter_wte.weight',
-        'transformer.h.2.attn.attn.adapter_bias',
-        'transformer.h.2.attn.attn.adapter_scale',
-        'transformer.h.2.attn.gating_factor',
-        'transformer.h.2.attn.proj.adapter_bias',
-        'transformer.h.2.attn.proj.adapter_scale',
-        'transformer.h.2.norm_1.bias',
-        'transformer.h.2.norm_1.weight',
-        'transformer.h.2.norm_2.bias',
-        'transformer.h.2.norm_2.weight',
-        'transformer.ln_f.bias',
-        'transformer.ln_f.weight'
+        "lm_head.adapter_bias",
+        "lm_head.adapter_scale",
+        "transformer.ln_f.bias",
+        "transformer.ln_f.weight",
+        "transformer.h.2.attn.adapter_wte.weight",
+        "transformer.h.2.attn.gating_factor",
     }
+    for layer in range(3):
+        for param in (
+            "attn.attn.adapter_bias",
+            "attn.attn.adapter_scale",
+            "attn.proj.adapter_bias",
+            "attn.proj.adapter_scale",
+            "mlp.fc.adapter_bias",
+            "mlp.fc.adapter_scale",
+            "mlp.proj.adapter_bias",
+            "mlp.proj.adapter_scale",
+            "norm_1.bias",
+            "norm_1.weight",
+            "norm_2.bias",
+            "norm_2.weight",
+        ):
+            expected.add(f"transformer.h.{layer}.{param}")
     assert set(saved) == expected
 
 


### PR DESCRIPTION
Follow-up to https://github.com/Lightning-AI/lit-gpt/pull/414

Tested with

generate_old.py
```python
import rich
import torch

from lit_gpt.adapter import GPT
from lit_gpt.adapter_v2 import add_adapter_v2_parameters_to_linear_layers

m = GPT.from_name("pythia-70m")
add_adapter_v2_parameters_to_linear_layers(m)
print(m)
sd = m.state_dict()
rich.print(sorted(sd))
torch.save(sd, "old_adapter_v2_ckpt")
```

load_old.py
```python
import rich
import torch

from lit_gpt.adapter_v2 import GPT

sd = torch.load("old_adapter_v2_ckpt")
rich.print(sorted(sd))
m = GPT.from_name("pythia-70m")
print(m)
m.load_state_dict(sd)
```

```shell
git checkout fdc142b0a9940aa1741bbaaca9883eddf09a2c94
python generate_old.py
git checkout carmocca/add-compatibility-for-older-adapter-v2-checkpoints
python load_old.py
```