### PR TITLE
Add support for estimated flops with frozen parameters

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -141,6 +141,7 @@ def train(
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
         # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
+        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -139,10 +139,10 @@ def train(
         mark_only_adapter_as_trainable(meta_model)
         # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that all samples have a fixed length equal to the longest sequence length
+        # this assumes that all samples have a fixed length equal to the longest sequence length
         # which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -142,7 +142,8 @@ def train(
         # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        # TODO: this assumes that all samples have a fixed length equal to the longest sequence length
+        # which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_adapter_v2_as_trainable
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, estimate_flops
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
@@ -136,8 +136,12 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated flops doesn't account for frozen weights, so it's not reported
         mark_only_adapter_v2_as_trainable(meta_model)
+        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        estimated_flops = estimate_flops(meta_model) * micro_batch_size
+        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -139,10 +139,11 @@ def train(
         mark_only_adapter_v2_as_trainable(meta_model)
         # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        # this assumes that all samples have a fixed length equal to the longest sequence length
+        # which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -133,10 +133,11 @@ def train(
         meta_model = GPT(model.config)
         # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        # this assumes that all samples have a fixed length equal to the longest sequence length
+        # which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -131,7 +131,9 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
+        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         # TODO: this assumes that samples have a fixed length which is most likely false during finetuning

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -158,10 +158,11 @@ def train(
         mark_only_lora_as_trainable(meta_model)
         # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
+        # this assumes that all samples have a fixed length equal to the longest sequence length
+        # which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trainable
-from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
+from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor, estimate_flops
 from lit_gpt.speed_monitor import measure_flops
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
@@ -155,8 +155,12 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated flops doesn't account for frozen weights, so it's not reported
         mark_only_lora_as_trainable(meta_model)
+        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+        # consider passing `estimated_flops` to `SpeedMonitor(flops_per_batch=...)` instead
+        estimated_flops = estimate_flops(meta_model) * micro_batch_size
+        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         # TODO: this assumes that samples have a fixed length which is most likely false during finetuning
         x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
         measured_flops = measure_flops(meta_model, x)

--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -347,13 +347,19 @@ class SpeedMonitorCallback(Callback):
 
 def flops_per_param(config: Config, n_params: int) -> int:
     flops_per_token = 2 * n_params  # each parameter is used for a MAC (2 FLOPS) per network operation
+    # TODO: this assumes that all samples have a fixed length equal to the block size
     flops_per_seq = flops_per_token * config.block_size
     attn_flops_per_seq = config.n_layer * 2 * 2 * (config.n_embd * (config.block_size**2))
     return flops_per_seq + attn_flops_per_seq
 
 
 def estimate_flops(model: GPT) -> int:
-    """Measures estimated FLOPs for MFU: https://arxiv.org/abs/2205.05198"""
+    """Measures estimated FLOPs for MFU.
+
+    Refs:
+        * https://ar5iv.labs.arxiv.org/html/2205.05198#A1
+        * https://ar5iv.labs.arxiv.org/html/2204.02311#A2
+    """
     # using all parameters for this is a naive over estimation because not all model parameters actually contribute to
     # this FLOP computation (e.g. embedding, norm). For this reason, the result will be higher by a fixed percentage
     # (~10%) compared to the measured FLOPs, making those lower but more realistic.

--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -167,11 +167,11 @@ class SpeedMonitorBase:
     Notes:
         - The implementation assumes that devices are homogeneous as it normalizes by the world size.
         - Tokens/sec, flops/sec and MFU do not account for padding tokens if present. We suggest using samples/sec or
-            batches/sec to measure throughput under this circumstance.
+          batches/sec to measure throughput under this circumstance.
         - Be careful when comparing MFU numbers across projects, as this will highly depend on the ``flops_per_batch``.
-            There is no widespread, realistic, and reliable implementation to compute them.
-            We suggest using our ``measure_flops`` function, but many other works will use ``estimated_flops`` which
-            will almost always be an overestimate when compared to the true value.
+          There is no widespread, realistic, and reliable implementation to compute them.
+          We suggest using our ``measure_flops`` function, but many other works will use ``estimated_flops`` which
+          will almost always be an overestimate when compared to the true value.
 
     Args:
         window_size (int, optional): Number of batches to use for a rolling average of throughput.

--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -347,7 +347,8 @@ class SpeedMonitorCallback(Callback):
 
 def flops_per_param(config: Config, n_params: int) -> int:
     flops_per_token = 2 * n_params  # each parameter is used for a MAC (2 FLOPS) per network operation
-    # TODO: this assumes that all samples have a fixed length equal to the block size
+    # this assumes that all samples have a fixed length equal to the block size
+    # which is most likely false during finetuning
     flops_per_seq = flops_per_token * config.block_size
     attn_flops_per_seq = config.n_layer * 2 * 2 * (config.n_embd * (config.block_size**2))
     return flops_per_seq + attn_flops_per_seq

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -127,7 +127,9 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
+        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -68,7 +68,9 @@ class LightningGPTModule(L.LightningModule):
         trainer = self.trainer
         with torch.device("meta"):
             meta_model = GPT(self.module.config)
-            # estimated is too much of an optimistic estimate, left just for reference
+            # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+            # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+            # consider setting `self.measured_flops = estimated_flops` instead
             estimated_flops = estimate_flops(meta_model) * micro_batch_size
             self.print(f"Estimated TFLOPs: {estimated_flops * trainer.world_size / 1e12:.2f}")
             x = torch.randint(0, 1, (micro_batch_size, meta_model.config.block_size))

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -153,7 +153,9 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        # estimated is too much of an optimistic estimate, left just for reference
+        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
+        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
+        # consider passing `SpeedMonitor(flops_per_batch=estimated_flops)` instead
         estimated_flops = estimate_flops(meta_model) * micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
         x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))


### PR DESCRIPTION
Can be tested with

```python
from lit_gpt.adapter import GPT, mark_only_adapter_as_trainable
from lit_gpt.speed_monitor import measure_flops, estimate_flops
import torch

micro_batch_size = 2

with torch.device("meta"):
    model = GPT.from_name("falcon-40b")
    mark_only_adapter_as_trainable(model)

    estimated_flops = estimate_flops(model) * micro_batch_size
    print(f"Estimated TFLOPs: {estimated_flops * 1 / 1e12:.2f}")

    x = torch.randint(0, 1, (micro_batch_size, model.config.block_size))
    measured_flops = measure_flops(model, x)
    print(f"Measured TFLOPs: {measured_flops * 1 / 1e12:.2f}")
```


Before:
```text
Estimated TFLOPs: 1077.76
Measured TFLOPs: 708.77
```

After:
```text
Estimated TFLOPs: 768.02
Measured TFLOPs: 708.77
```

The discrepancy after is within the 10% as described in https://github.com/Lightning-AI/lit-gpt/pull/170