### PR TITLE
Training loop optimizations with XLA

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -202,8 +202,8 @@ def train(
         if iter_num % log_interval == 0:
             fabric.print(
                 f"iter {iter_num} step {step_count}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -154,8 +154,10 @@ def train(
     step_count = 0
     total_lengths = 0
     total_t0 = time.perf_counter()
+    tpu = fabric.device.type == "xla"
+    world_size = fabric.world_size
 
-    if fabric.device.type == "xla":
+    if tpu:
         import torch_xla.core.xla_model as xm
 
         xm.mark_step()
@@ -184,7 +186,7 @@ def train(
             optimizer.step()
             optimizer.zero_grad()
             step_count += 1
-        elif fabric.device.type == "xla":
+        elif tpu:
             xm.mark_step()
 
         t1 = time.perf_counter()
@@ -193,14 +195,16 @@ def train(
             (iter_num + 1) * micro_batch_size,
             t1 - total_t0,
             # this assumes that device FLOPs are the same and that all devices have the same batch size
-            fabric.world_size,
+            world_size,
             flops_per_batch=measured_flops,
             lengths=total_lengths,
         )
         if iter_num % log_interval == 0:
             fabric.print(
-                f"iter {iter_num} step {step_count}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {iter_num} step {step_count}:"
+                + (f" loss {loss.item():.4f}," if not tpu else "") +
+                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (" (optimizer.step)" if not is_accumulating else "")
             )
 
         if not is_accumulating and step_count % eval_interval == 0:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -202,8 +202,8 @@ def train(
         if iter_num % log_interval == 0:
             fabric.print(
                 f"iter {iter_num} step {step_count}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -154,8 +154,10 @@ def train(
     step_count = 0
     total_lengths = 0
     total_t0 = time.perf_counter()
+    tpu = fabric.device.type == "xla"
+    world_size = fabric.world_size
 
-    if fabric.device.type == "xla":
+    if tpu:
         import torch_xla.core.xla_model as xm
 
         xm.mark_step()
@@ -184,7 +186,7 @@ def train(
             optimizer.step()
             optimizer.zero_grad()
             step_count += 1
-        elif fabric.device.type == "xla":
+        elif tpu:
             xm.mark_step()
 
         t1 = time.perf_counter()
@@ -193,14 +195,16 @@ def train(
             (iter_num + 1) * micro_batch_size,
             t1 - total_t0,
             # this assumes that device FLOPs are the same and that all devices have the same batch size
-            fabric.world_size,
+            world_size,
             flops_per_batch=measured_flops,
             lengths=total_lengths,
         )
         if iter_num % log_interval == 0:
             fabric.print(
-                f"iter {iter_num} step {step_count}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {iter_num} step {step_count}:"
+                + (f" loss {loss.item():.4f}," if not tpu else "") +
+                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (" (optimizer.step)" if not is_accumulating else "")
             )
 
         if not is_accumulating and step_count % eval_interval == 0:

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -197,8 +197,8 @@ def train(
         if iter_num % log_interval == 0:
             fabric.print(
                 f"iter {iter_num} step {step_count}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -173,8 +173,10 @@ def train(
     step_count = 0
     total_lengths = 0
     total_t0 = time.perf_counter()
+    tpu = fabric.device.type == "xla"
+    world_size = fabric.world_size
 
-    if fabric.device.type == "xla":
+    if tpu:
         import torch_xla.core.xla_model as xm
 
         xm.mark_step()
@@ -203,7 +205,7 @@ def train(
             optimizer.step()
             optimizer.zero_grad()
             step_count += 1
-        elif fabric.device.type == "xla":
+        elif tpu:
             xm.mark_step()
 
         t1 = time.perf_counter()
@@ -212,14 +214,16 @@ def train(
             (iter_num + 1) * micro_batch_size,
             t1 - total_t0,
             # this assumes that device FLOPs are the same and that all devices have the same batch size
-            fabric.world_size,
+            world_size,
             flops_per_batch=measured_flops,
             lengths=total_lengths,
         )
         if iter_num % log_interval == 0:
             fabric.print(
-                f"iter {iter_num} step {step_count}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {iter_num} step {step_count}:"
+                + (f" loss {loss.item():.4f}," if not tpu else "") +
+                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (" (optimizer.step)" if not is_accumulating else "")
             )
 
         if not is_accumulating and step_count % eval_interval == 0:

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -221,8 +221,8 @@ def train(
         if iter_num % log_interval == 0:
             fabric.print(
                 f"iter {iter_num} step {step_count}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -183,8 +183,8 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
         if state["iter_num"] % log_interval == 0:
             fabric.print(
                 f"iter {state['iter_num']} step {state['step_count']}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -137,14 +137,15 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
 
     total_lengths = 0
     total_t0 = time.perf_counter()
-
-    if fabric.device.type == "xla":
-        import torch_xla.core.xla_model as xm
-
-        xm.mark_step()
+    tpu = fabric.device.type == "xla"
+    world_size = fabric.world_size
 
     train_iter = iter(train_dataloader)
 
+    if tpu:
+        import torch_xla.core.xla_model as xm
+
+        xm.mark_step()
     for state["iter_num"] in range(state["iter_num"], max_iters):
         # determine and set the learning rate for this iteration
         lr = get_lr(state["iter_num"]) if decay_lr else learning_rate
@@ -166,7 +167,7 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
             optimizer.step()
             optimizer.zero_grad()
             state["step_count"] += 1
-        elif fabric.device.type == "xla":
+        elif tpu:
             xm.mark_step()
 
         t1 = time.perf_counter()
@@ -175,14 +176,16 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
             (state["iter_num"] + 1) * micro_batch_size,
             t1 - total_t0,
             # this assumes that device FLOPs are the same and that all devices have the same batch size
-            fabric.world_size,
+            world_size,
             flops_per_batch=measured_flops,
             lengths=total_lengths,
         )
         if state["iter_num"] % log_interval == 0:
             fabric.print(
-                f"iter {state['iter_num']} step {state['step_count']}: loss {loss.item():.4f}, iter time:"
-                f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
+                f"iter {state['iter_num']} step {state['step_count']}:"
+                + (f" loss {loss.item():.4f}," if not tpu else "") +
+                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (" (optimizer.step)" if not is_accumulating else "")
             )
 
         if not is_accumulating and state["step_count"] % eval_interval == 0:

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -211,8 +211,8 @@ def train(fabric, state, train_dataloader, val_dataloader, speed_monitor):
         if state["iter_num"] % log_interval == 0:
             fabric.print(
                 f"iter {state['iter_num']} step {state['step_count']}:"
-                + (f" loss {loss.item():.4f}," if not tpu else "") +
-                f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
+                + (f" loss {loss.item():.4f}," if not tpu else "")
+                + f" iter time: {(t1 - iter_t0) * 1000:.2f}ms"
                 + (" (optimizer.step)" if not is_accumulating else "")
             )
 


### PR DESCRIPTION
- Avoid `loss.item()` which kills the throughput
- Pre-compute `fabric.world_size` (upstream PR: https://github.com/Lightning-AI/lightning/pull/18317)