### PR TITLE
Fix class import in LoRA Eval Harness

### DIFF
--- a/eval/lm_eval_harness_lora.py
+++ b/eval/lm_eval_harness_lora.py
@@ -14,7 +14,7 @@ from lm_eval.base import BaseLM
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
-from lm_eval_harness import EvalHarnessAdapter
+from lm_eval_harness import EvalHarnessBase
 
 from lit_gpt import Tokenizer
 from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
@@ -32,7 +32,7 @@ lora_mlp = False
 lora_head = False
 
 
-class EvalHarnessLoRA(EvalHarnessAdapter):
+class EvalHarnessLoRA(EvalHarnessBase):
     def __init__(
         self,
         lora_path: str = "",


### PR DESCRIPTION
The LoRA version tried to import 

```bash
from lm_eval_harness import EvalHarnessAdapter
```

which does not exist. 

I believe this should have been 

```bash
from lm_eval_harness import EvalHarnessBase
```