### PR TITLE
fix: support transformer-engine (h100 fp8) in speed_monitor

### DIFF
--- a/lit_gpt/speed_monitor.py
+++ b/lit_gpt/speed_monitor.py
@@ -95,6 +95,8 @@ def get_flops_available(device: torch.device, precision: str) -> Optional[float]
 
         if device_name is not None:
             try:
+                if precision == "transformer-engine":
+                    precision = "8-mixed"
                 return int(GPU_AVAILABLE_FLOPS[device_name][precision])
             except KeyError:
                 raise KeyError(


### PR DESCRIPTION
Support FP8/transformer-engine precision as added to lightning in https://github.com/Lightning-AI/lightning/pull/17597