### PR TITLE
Fix incremental_save when using Python attributes to tensors

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -295,10 +295,26 @@ class SavingProxyForStorage:
 class SavingProxyForTensor:
     def __init__(self, tensor, saver, protocol_version=5):
         self.protocol_version = protocol_version
-        self.reduce_ret_fn, (storage, *other_reduce_args) = tensor.__reduce_ex__(protocol_version)
-        assert isinstance(storage, torch.storage.TypedStorage), "Please check for updates"
-        storage_proxy = SavingProxyForStorage(storage, saver, protocol_version=protocol_version)
-        self.reduce_args = (storage_proxy, *other_reduce_args)
+        self.reduce_ret_fn, reduce_args = tensor.__reduce_ex__(protocol_version)
+        if reduce_args[0] == torch._utils._rebuild_tensor_v2:
+            # for Tensors with Python attributes
+            (a0, a1, (storage, *a2_other), *other_reduce_args) = reduce_args
+            assert isinstance(
+                storage, torch.storage.TypedStorage
+            ), "Please check for updates"
+            storage_proxy = SavingProxyForStorage(
+                storage, saver, protocol_version=protocol_version
+            )
+            self.reduce_args = (a0, a1, (storage_proxy, *a2_other), *other_reduce_args)
+        else:
+            (storage, *other_reduce_args) = reduce_args
+            assert isinstance(
+                storage, torch.storage.TypedStorage
+            ), "Please check for updates"
+            storage_proxy = SavingProxyForStorage(
+                storage, saver, protocol_version=protocol_version
+            )
+            self.reduce_args = (storage_proxy, *other_reduce_args)
 
     def __reduce_ex__(self, protocol_version):
         if protocol_version != self.protocol_version:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,7 @@ def test_incremental_write(tmp_path):
     from lit_gpt.utils import incremental_save
 
     sd = {str(k): torch.randn(5, 10) for k in range(3)}
+    sd["0"].someattr = 1
     sd_expected = {k: v.clone() for k, v in sd.items()}
     fn = str(tmp_path / "test.pt")
     with incremental_save(fn) as f:
@@ -125,6 +126,7 @@ def test_incremental_write(tmp_path):
         f.save(sd)
     sd_actual = torch.load(fn)
     assert sd_actual.keys() == sd_expected.keys()
+    assert sd_actual["0"].someattr == 1  # requires PyTorch 2.0+
     for k, v_expected in sd_expected.items():
         v_actual = sd_actual[k]
         torch.testing.assert_close(v_expected, v_actual)


### PR DESCRIPTION
PyTorch 2.0+ allows storing attributes to tensors, but then the return of `__reduce_ex__` changes.

Fixes: #371 

Thank you @MrJungle1 for reporting and @carmocca for flagging this to me with a repro.
