### PR TITLE
Vocab size shouldn't be larger than padded vocab size

### DIFF
--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -56,6 +56,9 @@ class Config:
         # vocab size should be a power of 2 to be optimal on hardware. compute the closest value
         if self.padded_vocab_size is None:
             self.padded_vocab_size = find_multiple(self.vocab_size, self.padding_multiple)
+        else:
+            # vocab size shouldn't be larger than padded vocab size
+            self.vocab_size = min(self.vocab_size, self.padded_vocab_size)
         # compute the number of query groups
         if self.n_query_groups is not None:
             assert self.n_head % self.n_query_groups == 0


### PR DESCRIPTION
Hi there 👋 

I noticed a small inconsistency when `padded_vocab_size` is provided and it's smaller than the value by default for `vocab_size`:

```bash
main ~/repos/lit-gpt python generate/base.py --prompt "Hello, my name is" --checkpoint_dir checkpoints/NousResearch/Nous-Hermes-13b --precision bf16-true --quantize bnb.nf4
Loading model 'checkpoints/NousResearch/Nous-Hermes-13b/lit_model.pth' with 
{
'org': 'NousResearch', 'name': 'Nous-Hermes-13b', 'block_size': 2048, 
---> 'vocab_size': 50254, <---
 'padding_multiple': 512,
---> 'padded_vocab_size': 32001, <---
 'n_layer': 40, 'n_head': 40, 'n_embd': 5120, 'rotary_percentage': 1.0, 'parallel_residual': False, 'bias': False, 'n_query_groups': 40, 'shared_attention_norm': False, '_norm_class': 'RMSNorm', 'norm_eps': 1e-06, '_mlp_class': 'LLaMAMLP', 'intermediate_size': 13824, 'condense_ratio': 1
}
```

it's not the end of the world, but I still think it would be nice to have it fixed.