### PR TITLE
Remove globals that are already exposed in the CLI

### DIFF
--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -14,25 +14,16 @@ sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
 
-DATA_FILE_URL = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json"
-DATA_FILE_NAME = "alpaca_data_cleaned_archive.json"
-DESTINATION_PATH = Path("data/alpaca")
-CHECKPOINT_DIR = Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
-TEST_SPLIT_FRACTION = 0.03865  # to get exactly 2000 test samples
-IGNORE_INDEX = -1
-MASK_INPUTS = False  # as in alpaca-lora
-SEED = 42
-
 
 def prepare(
-    destination_path: Path = DESTINATION_PATH,
-    checkpoint_dir: Path = CHECKPOINT_DIR,
-    test_split_fraction: float = TEST_SPLIT_FRACTION,
-    seed: int = SEED,
-    mask_inputs: bool = MASK_INPUTS,
-    data_file_name: str = DATA_FILE_NAME,
-    data_file_url: str = DATA_FILE_URL,
-    ignore_index: int = IGNORE_INDEX,
+    destination_path: Path = Path("data/alpaca"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    test_split_fraction: float = 0.03865,  # to get exactly 2000 test samples,
+    seed: int = 42,
+    mask_inputs: bool = False,  # as in alpaca-lora
+    data_file_name: str = "alpaca_data_cleaned_archive.json",
+    data_file_url: str = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json",
+    ignore_index: int = -1,
 ) -> None:
     """Prepare the Alpaca dataset for instruction tuning.
 
@@ -97,13 +88,7 @@ def download_if_missing(file_path: Path, file_url: str):
         f.write(requests.get(file_url).text)
 
 
-def prepare_sample(
-    example: dict,
-    tokenizer: Tokenizer,
-    max_length: int,
-    mask_inputs: bool = MASK_INPUTS,
-    ignore_index: int = IGNORE_INDEX,
-):
+def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_inputs: bool, ignore_index: int):
     """Processes a single sample.
 
     Each sample in the dataset consists of:

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -15,27 +15,16 @@ sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
 
-DATA_FILE_URL = (
-    "https://huggingface.co/datasets/databricks/databricks-dolly-15k/resolve/main/databricks-dolly-15k.jsonl"
-)
-DATA_FILE_NAME = "dolly_data_cleaned.json"
-DESTINATION_PATH = Path("data/dolly")
-CHECKPOINT_DIR = Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
-TEST_SPLIT_FRACTION = 0.1
-IGNORE_INDEX = -1
-MASK_INPUTS = False
-SEED = 42
-
 
 def prepare(
-    destination_path: Path = DESTINATION_PATH,
-    checkpoint_dir: Path = CHECKPOINT_DIR,
-    test_split_fraction: float = TEST_SPLIT_FRACTION,
-    seed: int = SEED,
-    mask_inputs: bool = MASK_INPUTS,
-    data_file_name: str = DATA_FILE_NAME,
-    data_file_url: str = DATA_FILE_URL,
-    ignore_index: int = IGNORE_INDEX,
+    destination_path: Path = Path("data/dolly"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    test_split_fraction: float = 0.1,
+    seed: int = 42,
+    mask_inputs: bool = False,
+    data_file_name: str = "dolly_data_cleaned.json",
+    data_file_url: str = "https://huggingface.co/datasets/databricks/databricks-dolly-15k/resolve/main/databricks-dolly-15k.jsonl",
+    ignore_index: int = -1,
 ) -> None:
     """Prepare the Alpaca dataset for instruction tuning.
 
@@ -110,8 +99,8 @@ def prepare_sample(
     example: dict,
     tokenizer: Tokenizer,
     max_length: int,
-    mask_inputs: bool = MASK_INPUTS,
-    ignore_index: int = IGNORE_INDEX,
+    mask_inputs: bool,
+    ignore_index: int,
 ):
     """Processes a single sample.
 

--- a/scripts/prepare_lima.py
+++ b/scripts/prepare_lima.py
@@ -15,25 +15,16 @@ sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
 
-DATA_REPO_ID = "GAIR/lima"
-DATA_FILE_NAME = "lima_data_cleaned_archive.json"
-DESTINATION_PATH = Path("data/lima")
-CHECKPOINT_DIR = Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
-TEST_SPLIT_FRACTION = 0.1
-MASK_INPUTS = False  # as in alpaca-lora
-IGNORE_INDEX = -1
-SEED = 42
-
 
 def prepare(
-    destination_path: Path = DESTINATION_PATH,
-    test_split_fraction: float = TEST_SPLIT_FRACTION,
-    checkpoint_dir: Path = CHECKPOINT_DIR,
-    mask_inputs: bool = MASK_INPUTS,
-    seed: int = SEED,
+    destination_path: Path = Path("data/lima"),
+    test_split_fraction: float = 0.1,
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    mask_inputs: bool = False,  # as in alpaca-lora
+    seed: int = 42,
     include_multiturn_conversations: bool = False,
-    data_repo_id: str = DATA_REPO_ID,
-    ignore_index: int = IGNORE_INDEX,
+    data_repo_id: str = "GAIR/lima",
+    ignore_index: int = -1,
     access_token: Optional[str] = os.getenv("HF_TOKEN"),
 ) -> None:
     """Prepare the LIMA dataset for instruction tuning.
@@ -120,13 +111,7 @@ def format_dataset(dataset_partition, include_multi_turn_conversations):
     return formatted_ds
 
 
-def prepare_sample(
-    example: dict,
-    tokenizer: Tokenizer,
-    max_length: int,
-    mask_inputs: bool = MASK_INPUTS,
-    ignore_index: int = IGNORE_INDEX,
-):
+def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_inputs: bool, ignore_index: int):
     """Processes a single sample.
 
     Each sample in the dataset consists of:


### PR DESCRIPTION
cc @rasbt 

Variables that are exposed in the CLI don't need to be also defined as globals. Users could change the signature default already