### PR TITLE
Merge lora script

### DIFF
--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -1,0 +1,133 @@
+"""This script merges the LoRA weights with the base model"""
+
+import json
+import sys
+import time
+import warnings
+from pathlib import Path
+from typing import Literal, Optional
+
+import lightning as L
+import torch
+from lightning.fabric.strategies import FSDPStrategy
+
+# support running without installing as a package
+wd = Path(__file__).parent.parent.resolve()
+sys.path.append(str(wd))
+
+from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
+from scripts.prepare_alpaca import generate_prompt
+
+
+lora_r = 8
+lora_alpha = 16
+lora_dropout = 0.05
+lora_query = True
+lora_key = False
+lora_value = True
+lora_projection = False
+lora_mlp = False
+lora_head = False
+
+
+def save_checkpoint(fabric, model, file_path: Path):
+    fabric.print(f"Saving weights to {str(file_path)!r}")
+    fabric.save(file_path, {"model": model})
+
+
+def main(
+    lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
+    out_dir: Path = Path("out/lora/checkpoint"),
+    strategy: str = "auto",
+    devices: int = 1,
+    precision: Optional[str] = None,
+) -> None:
+    """Generates a response based on a given instruction and an optional input.
+    This script will only work with checkpoints from the instruction-tuned GPT-LoRA model.
+    See `finetune/lora.py`.
+
+    Args:
+        lora_path: Path to the checkpoint with trained adapter weights, which are the output of
+            `finetune/lora.py`.
+        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
+        out_dir: The path to the merged model that is created by this script.
+        quantize: Whether to quantize the model and using which method:
+            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
+            - bnb.int8: 8-bit quantization from bitsandbytes
+            - gptq.int4: 4-bit quantization from GPTQ
+            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
+        strategy: Indicates the Fabric strategy setting to use.
+        devices: How many devices to use.
+        precision: Indicates the Fabric precision setting to use.
+    """
+    precision = precision or get_default_supported_precision(training=False)
+
+    if strategy == "fsdp":
+        strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
+    fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)
+    fabric.launch()
+
+    check_valid_checkpoint_dir(checkpoint_dir)
+
+    with open(checkpoint_dir / "lit_config.json") as fp:
+        config_params = dict(
+            r=lora_r,
+            alpha=lora_alpha,
+            dropout=lora_dropout,
+            to_query=lora_query,
+            to_key=lora_key,
+            to_value=lora_value,
+            to_projection=lora_projection,
+            to_mlp=lora_mlp,
+            to_head=lora_head,
+        )
+        config_params.update(**json.load(fp))
+        del config_params['condense_ratio'] ## TODO: remove and update
+        config = Config(**config_params)
+
+    if quantize is not None and devices > 1:
+        raise NotImplementedError
+    if quantize == "gptq.int4":
+        model_file = "lit_model_gptq.4bit.pth"
+        if not (checkpoint_dir / model_file).is_file():
+            raise ValueError("Please run `python quantize/gptq.py` first")
+    else:
+        model_file = "lit_model.pth"
+    checkpoint_path = checkpoint_dir / model_file
+
+    fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}", file=sys.stderr)
+    t0 = time.perf_counter()
+    with fabric.init_module(empty_init=True), quantization(quantize):
+        model = GPT(config)
+    fabric.print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.", file=sys.stderr)
+
+    t0 = time.perf_counter()
+    with lazy_load(checkpoint_path) as checkpoint, lazy_load(lora_path) as lora_checkpoint:
+        checkpoint.update(lora_checkpoint.get("model", lora_checkpoint))
+        model.load_state_dict(checkpoint, strict=quantize is None)
+    fabric.print(f"Time to load the model weights: {time.perf_counter() - t0:.02f} seconds.", file=sys.stderr)
+
+    model.eval()
+    merge_lora_weights(model)
+    model = fabric.setup(model)
+
+    model.reset_cache()
+
+    # Save the final checkpoint at the end of training
+    save_path = out_dir / "lit_model.pth"
+    save_checkpoint(fabric, model, save_path)
+
+
+if __name__ == "__main__":
+    from jsonargparse import CLI
+
+    torch.set_float32_matmul_precision("high")
+    warnings.filterwarnings(
+        # Triggered internally at ../aten/src/ATen/EmptyTensor.cpp:31
+        "ignore",
+        message="ComplexHalf support is experimental and many operators don't support it yet",
+    )
+    CLI(main)

--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -1,24 +1,18 @@
 """This script merges the LoRA weights with the base model"""
 
-import json
 import sys
-import time
-import warnings
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import lightning as L
 import torch
-from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load, quantization
-from scripts.prepare_alpaca import generate_prompt
-
+from lit_gpt.lora import GPT, Config, lora_filter, merge_lora_weights
+from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 
 lora_r = 8
 lora_alpha = 16
@@ -31,18 +25,10 @@ lora_mlp = False
 lora_head = False
 
 
-def save_checkpoint(fabric, model, file_path: Path):
-    fabric.print(f"Saving weights to {str(file_path)!r}")
-    fabric.save(file_path, {"model": model})
-
-
-def main(
+def merge_lora(
     lora_path: Path = Path("out/lora/alpaca/lit_model_lora_finetuned.pth"),
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8", "gptq.int4"]] = None,
     out_dir: Path = Path("out/lora/checkpoint"),
-    strategy: str = "auto",
-    devices: int = 1,
     precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
@@ -54,80 +40,43 @@ def main(
             `finetune/lora.py`.
         checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         out_dir: The path to the merged model that is created by this script.
-        quantize: Whether to quantize the model and using which method:
-            - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
-            - bnb.int8: 8-bit quantization from bitsandbytes
-            - gptq.int4: 4-bit quantization from GPTQ
-            for more details, see https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/quantize.md
-        strategy: Indicates the Fabric strategy setting to use.
-        devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
     precision = precision or get_default_supported_precision(training=False)
-
-    if strategy == "fsdp":
-        strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
-    fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy)
-    fabric.launch()
+    fabric = L.Fabric(devices=1, precision=precision)
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    with open(checkpoint_dir / "lit_config.json") as fp:
-        config_params = dict(
-            r=lora_r,
-            alpha=lora_alpha,
-            dropout=lora_dropout,
-            to_query=lora_query,
-            to_key=lora_key,
-            to_value=lora_value,
-            to_projection=lora_projection,
-            to_mlp=lora_mlp,
-            to_head=lora_head,
-        )
-        config_params.update(**json.load(fp))
-        del config_params['condense_ratio'] ## TODO: remove and update
-        config = Config(**config_params)
+    config = Config.from_json(
+        checkpoint_dir / "lit_config.json",
+        r=lora_r,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+        to_query=lora_query,
+        to_key=lora_key,
+        to_value=lora_value,
+        to_projection=lora_projection,
+        to_mlp=lora_mlp,
+        to_head=lora_head,
+    )
 
-    if quantize is not None and devices > 1:
-        raise NotImplementedError
-    if quantize == "gptq.int4":
-        model_file = "lit_model_gptq.4bit.pth"
-        if not (checkpoint_dir / model_file).is_file():
-            raise ValueError("Please run `python quantize/gptq.py` first")
-    else:
-        model_file = "lit_model.pth"
-    checkpoint_path = checkpoint_dir / model_file
-
-    fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}", file=sys.stderr)
-    t0 = time.perf_counter()
-    with fabric.init_module(empty_init=True), quantization(quantize):
+    with fabric.init_module(empty_init=True):
         model = GPT(config)
-    fabric.print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.", file=sys.stderr)
-
-    t0 = time.perf_counter()
+    checkpoint_path = checkpoint_dir / "lit_model.pth"
     with lazy_load(checkpoint_path) as checkpoint, lazy_load(lora_path) as lora_checkpoint:
         checkpoint.update(lora_checkpoint.get("model", lora_checkpoint))
-        model.load_state_dict(checkpoint, strict=quantize is None)
-    fabric.print(f"Time to load the model weights: {time.perf_counter() - t0:.02f} seconds.", file=sys.stderr)
+        model.load_state_dict(checkpoint)
 
-    model.eval()
     merge_lora_weights(model)
-    model = fabric.setup(model)
 
-    model.reset_cache()
-
-    # Save the final checkpoint at the end of training
     save_path = out_dir / "lit_model.pth"
-    save_checkpoint(fabric, model, save_path)
+    fabric.print(f"Saving weights to {str(save_path)!r}")
+    # remove lora parameters and the lora linear substring
+    state_dict = {k.replace("linear.", ""): v for k, v in model.state_dict().items() if not lora_filter(k, v)}
+    torch.save(state_dict, save_path)
 
 
 if __name__ == "__main__":
     from jsonargparse import CLI
 
-    torch.set_float32_matmul_precision("high")
-    warnings.filterwarnings(
-        # Triggered internally at ../aten/src/ATen/EmptyTensor.cpp:31
-        "ignore",
-        message="ComplexHalf support is experimental and many operators don't support it yet",
-    )
-    CLI(main)
+    CLI(merge_lora)

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+import torch
+
+from lit_gpt.lora import lora_filter
+
+
+def test_merge_lora(tmp_path, fake_checkpoint_dir):
+    from lit_gpt.lora import GPT as LoRAGPT
+    from lit_gpt.model import GPT
+    from scripts.merge_lora import merge_lora
+
+    # create fake data
+    config = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
+    # json
+    with open(fake_checkpoint_dir / "lit_config.json", "w") as fp:
+        json.dump(config, fp)
+    base_model = GPT.from_name("pythia-70m", **config)
+    state_dict = base_model.state_dict()
+    assert len(state_dict) == 40
+    torch.save(state_dict, fake_checkpoint_dir / "lit_model.pth")
+    # lora model
+    lora_model = LoRAGPT.from_name("pythia-70m", **config, r=8, alpha=16, dropout=0.05, to_query=True, to_value=True)
+    state_dict = {k: v for k, v in lora_model.state_dict().items() if lora_filter(k, v)}
+    assert len(state_dict) == 6
+    lora_path = tmp_path / "lora"
+    torch.save(state_dict, lora_path)
+
+    assert set(os.listdir(tmp_path)) == {"lora", "checkpoints"}
+    merge_lora(lora_path, fake_checkpoint_dir, tmp_path)
+    assert set(os.listdir(tmp_path)) == {"lora", "checkpoints", "lit_model.pth"}
+
+    # assert that the merged weights can be loaded back into the base model
+    merged = torch.load(tmp_path / "lit_model.pth")
+    keys = base_model.load_state_dict(merged, strict=True)
+    assert not keys.missing_keys
+    assert not keys.unexpected_keys

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -3,24 +3,21 @@ import os
 
 import torch
 
-from lit_gpt.lora import lora_filter
-
 
 def test_merge_lora(tmp_path, fake_checkpoint_dir):
     from lit_gpt.lora import GPT as LoRAGPT
+    from lit_gpt.lora import lora_filter
     from lit_gpt.model import GPT
     from scripts.merge_lora import merge_lora
 
     # create fake data
     config = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
-    # json
     with open(fake_checkpoint_dir / "lit_config.json", "w") as fp:
         json.dump(config, fp)
     base_model = GPT.from_name("pythia-70m", **config)
     state_dict = base_model.state_dict()
     assert len(state_dict) == 40
     torch.save(state_dict, fake_checkpoint_dir / "lit_model.pth")
-    # lora model
     lora_model = LoRAGPT.from_name("pythia-70m", **config, r=8, alpha=16, dropout=0.05, to_query=True, to_value=True)
     state_dict = {k: v for k, v in lora_model.state_dict().items() if lora_filter(k, v)}
     assert len(state_dict) == 6

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -3,6 +3,8 @@
 [Low-rank adaption (LoRA)](https://arxiv.org/abs/2106.09685) is a technique to approximate the update to the linear layers in a LLM with a low-rank matrix factorization. This significantly reduces the number of trainable parameters and speeds up training with little impact on the final performance of the model.
 We demonstrate this method by instruction-finetuning Lit-GPT StableLM 3B on the [Alpaca](https://github.com/tatsu-lab/stanford_alpaca) dataset on a **single RTX 3090 (24GB) GPU**.
 
+&nbsp;
+
 ## Preparation
 
 The steps here only need to be done once:
@@ -26,7 +28,9 @@ or [prepare your own dataset](#tune-on-your-dataset).
 
 For more information about dataset preparation, also see the [prepare_dataset.md](./prepare_dataset.md) tutorial.
 
-## Running the finetuning
+&nbsp;
+
+## Running the Finetuning
 
 ```bash
 python finetune/lora.py
@@ -74,7 +78,9 @@ The advantages of QLoRA-style quantization are more pronounced in larger models,
 | --precision "bf16-true"  --quantize "bnb.nf4"       | 13.44 GB         | 1089.79s       | 1.0130 | 4.66 GB          |
 | --precision "bf16-true"  --quantize "bnb.nf4-dq"    | 13.15 GB         | 1135.86s       | 1.0124 | 4.34 GB          |
 
-## Test the model
+&nbsp;
+
+## Test the Model
 
 You can test the finetuned model with your own instructions by running:
 
@@ -90,7 +96,9 @@ I would recommend the movie The Martian (2015). It is a sci-fi movie starring Ma
 
 If your GPU supports `bfloat16`, you can additionally pass `--precision "bf16-true"` to bring the memory consumption down to ~7.6 GB for StableLM-3B (versus ~15.2  GB for `--precision "32-full"`). In addition, you may use quantization methods, for example `--precision "bf16-true" --quantize "bnb.nf4"` brings the memory consumption further down to ~4.4 GB for StableLM-3B.
 
-## Tune on your dataset
+&nbsp;
+
+## Tune on Your Dataset
 
 With only a few modifications, you can prepare and train on your own instruction dataset.
 
@@ -127,6 +135,42 @@ With only a few modifications, you can prepare and train on your own instruction
    ```bash
    python finetune/lora.py --data_dir data/mydata/ --out_dir out/myexperiment
    ```
+
+&nbsp;
+
+## Merging LoRA Weights
+
+By default, the LoRA weights are kept separate from the checkpoint file to save storage space.
+However, you can optionally merge the LoRA weights with the original model checkpoint to create
+a new file to optimize inference speeds. (This will improve inference performance
+because the weights don't have to be added during runtime.)
+
+Let's assume we finetuned a model using LoRA as follows:
+
+```bash
+python finetune/lora.py \
+  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
+  --data_dir "data/alpaca" \
+  --out_dir "out/lora_weights/stablelm-base-alpha-3b/"
+```
+
+Then, we can merge the LoRA weights with the checkpoint model using the `merge_lora.py` script as shown below:
+
+```bash
+python scripts/merge_lora.py \
+  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
+  --lora_path "out/lora_stage_1/stablelm-base-alpha-3b/lit_model_lora_finetuned.pth" \
+  --out_dir "out/lora_merged/stablelm-base-alpha-3b/"
+```
+
+After merging, we can use the `base.py` file for inference using the new checkpoint file:
+
+```bash
+python generate/base.py \
+  --checkpoint_dir "out/lora_merged/stablelm-base-alpha-3b/"
+```
+
+&nbsp;
 
 ## Troubleshooting
 


### PR DESCRIPTION
Provide a script for merging LoRA weights as described in #494. 

Fixes #517

If you think this is a good idea, this PR provides an example of how to implement such a script.

# Example 1: Training on 2 datasets

**Finetune on a dataset as usual:**

```bash
python scripts/download.py --repo_id tiiuae/stablelm-base-alpha-3b
```

```bash
python scripts/prepare_alpaca.py
```

```bash
python finetune/lora.py \
  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
  --data_dir "data/alpaca" \
  --out_dir "out/lora_stage_1/stablelm-base-alpha-3b/"
```

**Merge lora weights with model:**

```bash
python scripts/merge_lora.py \
  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
  --lora_path "out/lora_stage_1/stablelm-base-alpha-3b/lit_model_lora_finetuned.pth" \
  --out_dir "out/lora_stage_1_merged/stablelm-base-alpha-3b/"
```

**Copy .json files and config and tokenizer (there may be a more elegant solution)** 

```bash
scp checkpoints/stabilityai/stablelm-base-alpha-3b/*.json \
out/lora_stage_1_merged/stablelm-base-alpha-3b/
```

**Finetune on 2nd dataset, using the merge model as the base model:**

```bash
python scripts/prepare_dolly.py
```

Update `finetune/lora.py` to use`override_max_seq_length = 2048` and `micro_batch_size=2`.

```bash
python finetune/lora.py \
  --checkpoint_dir "out/lora_stage_1_merged/stablelm-base-alpha-3b/" \
  --data_dir "data/dolly" \
  --out_dir "out/lora_stage_2/stablelm-base-alpha-3b/"
```

# Example 2: Inference

Regular finetuning and lora inference:

```bash
python finetune/lora.py \
  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
  --data_dir "data/alpaca" \
  --out_dir "out/lora_stage_1/stablelm-base-alpha-3b/"
```

```bash
python generate/lora.py \
  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
  --lora_path "out/lora_stage_1/stablelm-base-alpha-3b/lit_model_lora_finetuned.pth"
```

With merged lora weights:

```bash
python scripts/merge_lora.py \
  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
  --lora_path "out/lora_stage_1/stablelm-base-alpha-3b/lit_model_lora_finetuned.pth" \
  --out_dir "out/lora_stage_1_merged/stablelm-base-alpha-3b/"
```

```bash
scp checkpoints/stabilityai/stablelm-base-alpha-3b/*.json \
out/lora_stage_1_merged/stablelm-base-alpha-3b/
```

```bash
python generate/base.py \
  --checkpoint_dir "out/lora_stage_1_merged/stablelm-base-alpha-3b/"
```

----


- [x] figure out why there is an extra "condense_ratio" config key that is not supported by `Config`, then remove line `del config_params['condense_ratio']`
- [x] Figure out why second `finetune/lora.py` causes an out-of-memory error
- [x] Figure out why it doesn't work with `generate/base.py`
- [x] add documentation to lora finetuning tutorial