### PR TITLE
MPS device doesn't support `bf16` precision.

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -497,7 +497,7 @@ def map_old_state_dict_weights(state_dict: Dict, mapping: Mapping, prefix: str) 
 
 
 def get_default_supported_precision(training: bool) -> str:
-    """Return default precision that is supported by the hardware.
+    """Return default precision that is supported by the hardware: either `bf16` or `16`.
 
     Args:
         training: `-mixed` or `-true` version of the precision to use
@@ -505,6 +505,6 @@ def get_default_supported_precision(training: bool) -> str:
     Returns:
         default precision that is suitable for the task and is supported by the hardware
     """
-    if not torch.cuda.is_available() or torch.cuda.is_bf16_supported():
-        return "bf16-mixed" if training else "bf16-true"
-    return "16-mixed" if training else "16-true"
+    if torch.backends.mps.is_available() or (torch.cuda.is_available() and not torch.cuda.is_bf16_supported()):
+        return "16-mixed" if training else "16-true"
+    return "bf16-mixed" if training else "bf16-true"

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -505,6 +505,8 @@ def get_default_supported_precision(training: bool) -> str:
     Returns:
         default precision that is suitable for the task and is supported by the hardware
     """
-    if torch.backends.mps.is_available() or (torch.cuda.is_available() and not torch.cuda.is_bf16_supported()):
+    from lightning.fabric.accelerators import MPSAccelerator
+
+    if MPSAccelerator.is_available() or (torch.cuda.is_available() and not torch.cuda.is_bf16_supported()):
         return "16-mixed" if training else "16-true"
     return "bf16-mixed" if training else "bf16-true"


### PR DESCRIPTION
Hi there 👋 

Didn't know that in Fabric `mps` is not supported with Radeon GPUs, so when I ran the script, and it worked fine, I thought that's all is good. Maybe it is worth to display what precision and device is used in the training/generation log?

Anyway, apparently `mps` doesn't support `bf16` precision and by default exactly this precision was used with this device type.