### PR TITLE
Move KV cache management out of forward

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -169,6 +169,11 @@ def main(
             break
         prompt = system_prompt.format(prompt=prompt)
         encoded_prompt = tokenizer.encode(prompt, device=fabric.device)
+
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+
         y = generate(
             model,
             encoded_prompt,
@@ -182,7 +187,6 @@ def main(
             t0 = time.perf_counter()
             tokens_generated = decode(fabric, tokenizer, y)
             t = time.perf_counter() - t0
-            model.reset_cache()
             fabric.print(
                 f"\nTime for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr
             )

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -229,8 +229,11 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
+    with fabric.init_tensor():
+        # do not set `max_seq_length=max_returned_token` because memory is not a concern here
+        model.set_kv_cache(batch_size=1)
     output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
-    model.reset_cache()
+    model.clear_kv_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
 

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -229,8 +229,11 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
+    with fabric.init_tensor():
+        # do not set `max_seq_length=max_returned_token` because memory is not a concern here
+        model.set_kv_cache(batch_size=1)
     output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
-    model.reset_cache()
+    model.clear_kv_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
 

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -222,8 +222,11 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
+    with fabric.init_tensor():
+        # do not set `max_seq_length=max_returned_token` because memory is not a concern here
+        model.set_kv_cache(batch_size=1)
     output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
-    model.reset_cache()
+    model.clear_kv_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -260,8 +260,11 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
+    with fabric.init_tensor():
+        # do not set `max_seq_length=max_returned_token` because memory is not a concern here
+        model.set_kv_cache(batch_size=1)
     output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
-    model.reset_cache()
+    model.clear_kv_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
 

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -100,12 +100,13 @@ def main(
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
+        # enable the kv cache
+        model.set_kv_cache(batch_size=1)
 
     t0 = time.perf_counter()
     y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     output = tokenizer.decode(y)
     output = output.split("### Response:")[1].strip()
     fabric.print(output)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -100,12 +100,13 @@ def main(
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
+        # enable the kv cache
+        model.set_kv_cache(batch_size=1)
 
     t0 = time.perf_counter()
     y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     output = tokenizer.decode(y)
     output = output.split("### Response:")[1].strip()
     fabric.print(output)

--- a/generate/base.py
+++ b/generate/base.py
@@ -160,11 +160,14 @@ def main(
 
     L.seed_everything(1234)
     for i in range(num_samples):
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+
         t0 = time.perf_counter()
         y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k)
         t = time.perf_counter() - t0
 
-        model.reset_cache()
         fabric.print(tokenizer.decode(y))
         tokens_generated = y.size(0) - prompt_length
         fabric.print(

--- a/generate/full.py
+++ b/generate/full.py
@@ -94,12 +94,13 @@ def main(
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
+        # enable the kv cache
+        model.set_kv_cache(batch_size=1)
 
     t0 = time.perf_counter()
     y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     output = tokenizer.decode(y)
     output = output.split("### Response:")[1].strip()
     fabric.print(output)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -122,12 +122,13 @@ def main(
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
+        # enable the kv cache
+        model.set_kv_cache(batch_size=1)
 
     t0 = time.perf_counter()
     y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     output = tokenizer.decode(y)
     output = output.split("### Response:")[1].strip()
     fabric.print(output)

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -54,14 +54,9 @@ class GPT(BaseModel):
         if input_pos is not None:  # use the kv cache
             cos = self.cos.index_select(0, input_pos)
             sin = self.sin.index_select(0, input_pos)
-            # passing `attn_mask` to SDPA downgrades it to use the inefficient implementation. since we only need the mask
-            # for the kv-cache support (only during inference), we only create it in that situation
-            # this will be resolved by https://github.com/pytorch/pytorch/issues/96099
             if self.mask_cache is None:
-                self.mask_cache = self.build_mask_cache(idx)  # (1, 1, block_size, block_size)
+                raise TypeError("You need to call `gpt.set_kv_cache()`")
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, : self.max_seq_length]
-            self.build_kv_caches(idx, self.max_seq_length, cos.size(-1))
         else:
             cos = self.cos[:T]
             sin = self.sin[:T]

--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -17,7 +17,6 @@ from lit_gpt.adapter import GPT as BaseModel
 from lit_gpt.adapter import Block as BaseBlock
 from lit_gpt.adapter import CausalSelfAttention as BaseCausalSelfAttention
 from lit_gpt.adapter import Config as BaseConfig
-from lit_gpt.model import KVCache
 from lit_gpt.utils import map_old_state_dict_weights
 
 
@@ -122,7 +121,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
         # output projection
         self.proj = AdapterV2Linear(config.n_embd, config.n_embd, bias=config.bias)
         # disabled by default
-        self.kv_cache: Optional[KVCache] = None
+        self.kv_cache = nn.Module()
 
         if block_idx >= config.adapter_start_layer:
             # adapter embedding layer

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -55,7 +55,6 @@ from lit_gpt.config import Config as BaseConfig
 from lit_gpt.model import GPT as BaseModel
 from lit_gpt.model import Block as BaseBlock
 from lit_gpt.model import CausalSelfAttention as BaseCausalSelfAttention
-from lit_gpt.model import KVCache
 from lit_gpt.utils import map_old_state_dict_weights
 
 
@@ -485,14 +484,9 @@ class GPT(BaseModel):
         if input_pos is not None:  # use the kv cache
             cos = self.cos.index_select(0, input_pos)
             sin = self.sin.index_select(0, input_pos)
-            # passing `attn_mask` to SDPA downgrades it to use the inefficient implementation. since we only need the mask
-            # for the kv-cache support (only during inference), we only create it in that situation
-            # this will be resolved by https://github.com/pytorch/pytorch/issues/96099
             if self.mask_cache is None:
-                self.mask_cache = self.build_mask_cache(idx)  # (1, 1, block_size, block_size)
+                raise TypeError("You need to call `gpt.set_kv_cache()`")
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, : self.max_seq_length]
-            self.build_kv_caches(idx, self.max_seq_length, cos.size(-1))
         else:
             cos = self.cos[:T]
             sin = self.sin[:T]
@@ -565,7 +559,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             lora_dropout=config.dropout,
         )
         # disabled by default
-        self.kv_cache: Optional[KVCache] = None
+        self.kv_cache = nn.Module()
 
         self.config = config
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -24,6 +24,7 @@ def test_generate(max_seq_length):
     config = Config(block_size=128, vocab_size=16, n_layer=1, n_head=4, n_embd=8)
     model = GPT(config)
     model.max_seq_length = max_seq_length
+    model.set_kv_cache(batch_size=1)
     max_new_tokens = 20
 
     multinomial_results = []

--- a/xla/finetune/adapter.py
+++ b/xla/finetune/adapter.py
@@ -235,8 +235,11 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
+    with fabric.init_tensor():
+        # do not set `max_seq_length=max_returned_token` because memory is not a concern here
+        model.set_kv_cache(batch_size=1)
     output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
-    model.reset_cache()
+    model.clear_kv_cache()
     output = tokenizer.decode(output)
     rank_print(fabric, output)
 

--- a/xla/generate/adapter.py
+++ b/xla/generate/adapter.py
@@ -92,6 +92,8 @@ def main(
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
+        # enable the kv cache
+        model.set_kv_cache(batch_size=1)
 
     t0 = time.perf_counter()
     y = generate(
@@ -105,7 +107,6 @@ def main(
     )
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     output = tokenizer.decode(y)
     output = output.split("### Response:")[1] if "### Response:" in output else output
     output = output.strip()

--- a/xla/generate/base.py
+++ b/xla/generate/base.py
@@ -158,11 +158,14 @@ def main(
 
     L.seed_everything(1234)
     for i in range(num_samples):
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+
         t0 = time.perf_counter()
         y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k)
         t = time.perf_counter() - t0
 
-        model.reset_cache()
         fabric.print(tokenizer.decode(y))
         tokens_generated = y.size(0) - prompt_length
         rank_print(


### PR DESCRIPTION
Refactors the model definition to move the KV cache and mask creation and management out of `forward`.
This should reduce the risk of recompilation with compilers such as xla or torchdynamo.

The KV cache is now managed with a `nn.Module` to have it registered automatically. This module has no parameters so there shouldn't be any checkpointing issues

credit to @Chillee for the idea