### PR TITLE
Markdown chores: NOTE rendering, trailing spaces and multiple empty lines fix

### DIFF
--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -4,7 +4,7 @@ Several models retrieved from external sources must be reformatted with naming c
 
 The way the script is used depends on the finetuning method. The commands for converting a model back to its original format after using one of the several finetuning methods supported by Lit-GPT are shown below.
 
-> [!NOTE]\
+> [!NOTE]
 > each example shown below uses Falcon-7B please be sure to update --checkpoint_dir accordingly
 
 ### Full Finetuning

--- a/tutorials/download_code_llama.md
+++ b/tutorials/download_code_llama.md
@@ -8,8 +8,7 @@ Code Llama models come in three sizes: 7B, 13B, and 34B parameter models. Furthe
 - Code Llama-Python: The Code Llama model pretrained on 500B tokens, further trained on 100B additional Python code tokens, and then finetuned on 20B tokens.
 - Code Llama-Instruct: The Code Llama model trained on 500B tokens, finetuned on 20B tokens, and instruction-finetuned on additional 5B tokens.
 
-All models were  trained on 16,000 token contexts and support generations with up to 100,000 tokens of context. 
-
+All models were  trained on 16,000 token contexts and support generations with up to 100,000 tokens of context.
 
 To see all the available checkpoints, run:
 

--- a/tutorials/download_freewilly_2.md
+++ b/tutorials/download_freewilly_2.md
@@ -4,7 +4,6 @@
 Stability AI announced FreeWilly inspired by the methodology pioneered by Microsoft in its paper: "Orca: Progressive Learning from Complex Explanation Traces of GPT-4”.
 FreeWilly2 leverages the Llama 2 70B foundation model to reach a performance that compares favorably with GPT-3.5 for some tasks.
 
-
 ```bash
 pip install huggingface_hub
 

--- a/tutorials/evaluation.md
+++ b/tutorials/evaluation.md
@@ -35,8 +35,6 @@ python eval/lm_eval_harness.py \
 
 A list of supported tasks can be found [here](https://github.com/EleutherAI/lm-evaluation-harness/blob/master/docs/task_table.md).
 
-
-
 ### Evaluating LoRA-finetuned LLMs
 
 The above command can be used to evaluate models that are saved via a single checkpoint file. This includes downloaded checkpoints and base models finetuned via the full and adapter finetuning scripts. For LoRA-finetuned models, use the `lm_eval_harness_lora.py` script instead:
@@ -56,6 +54,7 @@ python eval/lm_eval_harness_lora.py \
 * **How do I evaluate on MMLU?**
 
   MMLU is available as with lm-eval harness but the task name is not MMLU. You can use `hendrycksTest*` as regex to evaluate on MMLU.
+
   ```shell
   python eval/lm_eval_harness_lora.py \
           --lora_path "lit_model_lora_finetuned.pth" \
@@ -66,7 +65,6 @@ python eval/lm_eval_harness_lora.py \
           --num_fewshot 5 \
           --save_filepath "results.json"
   ```
-
 
 * **Is Truthful MC is not available in lm-eval?**
 

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -14,7 +14,7 @@ The steps here only need to be done once:
 python scripts/prepare_alpaca.py --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
-or [prepare your own dataset](#tune-on-your-dataset). 
+or [prepare your own dataset](#tune-on-your-dataset).
 
 For more information about dataset preparation, also see the [prepare_dataset.md](./prepare_dataset.md) tutorial.
 

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -36,7 +36,8 @@ The finetuning requires at least one GPU with ~24 GB memory (RTX 3090).
 
 This script will save checkpoints periodically to the folder `out/`.
 
-> [!NOTE]\: LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projection`, `mlp` and classification `head`.
+> [!NOTE]
+> LoRA can be applied to not only `query`, `key` or `value` matrices, but also to `projection`, `mlp` and classification `head`.
 > According to [QLoRA](https://arxiv.org/abs/2305.14314) paper (section 4): "LoRA on all linear transformer block layers are required to match full finetuning performance".
 > By default LoRA is applied only to the `query` and `value` matrices. In order to apply LoRA to other weight matrices - change the variables in `finetune/lora.py` accordingly.
 

--- a/tutorials/neurips_challenge_quickstart.md
+++ b/tutorials/neurips_challenge_quickstart.md
@@ -34,7 +34,7 @@ These don't include models that have been finetuned or otherwise aligned, as per
 | Models in Lit-GPT         | Reference                                                    |
 | ------------------------- | ------------------------------------------------------------ |
 | Meta AI Llama 2 Base      | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)      |
-| TII UAE Falcon Base       | [TII 2023](https://falconllm.tii.ae/)
+| TII UAE Falcon Base       | [TII 2023](https://falconllm.tii.ae/)                        |
 | OpenLM Research OpenLLaMA | [Geng & Liu 2023](https://github.com/openlm-research/open_llama) |
 | EleutherAI Pythia         | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)     |
 | StabilityAI StableLM Base | [Stability AI 2023](https://github.com/Stability-AI/StableLM) |

--- a/tutorials/neurips_challenge_quickstart.md
+++ b/tutorials/neurips_challenge_quickstart.md
@@ -4,7 +4,7 @@
 
 The [NeurIPS 2023 Efficiency Challenge](https://llm-efficiency-challenge.github.io/) is a competition focused on training **1 LLM for 24 hours on 1 GPU** – the team with the best LLM gets to present their results at NeurIPS 2023.
 
-This quick start guide is a short starter guide illustrating the main steps to get started with Lit-GPT, which was selected as the competition's official starter kit. 
+This quick start guide is a short starter guide illustrating the main steps to get started with Lit-GPT, which was selected as the competition's official starter kit.
 
 
 
@@ -34,7 +34,7 @@ These don't include models that have been finetuned or otherwise aligned, as per
 | Models in Lit-GPT         | Reference                                                    |
 | ------------------------- | ------------------------------------------------------------ |
 | Meta AI Llama 2 Base      | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)      |
-| TII UAE Falcon Base       | [TII 2023](https://falconllm.tii.ae/)     
+| TII UAE Falcon Base       | [TII 2023](https://falconllm.tii.ae/)
 | OpenLM Research OpenLLaMA | [Geng & Liu 2023](https://github.com/openlm-research/open_llama) |
 | EleutherAI Pythia         | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)     |
 | StabilityAI StableLM Base | [Stability AI 2023](https://github.com/Stability-AI/StableLM) |
@@ -51,12 +51,12 @@ Examples of permitted datasets are the following:
 - [OpenAssistant Conversations Dataset (oasst1)](https://huggingface.co/datasets/OpenAssistant/oasst1)
 - [The Flan Collection](https://github.com/google-research/FLAN/tree/main/flan/v2)
 
-You are allowed to create your own datasets if they are made 
+You are allowed to create your own datasets if they are made
 publicly accessible under an open-source license, and they are not generated from other LLMs (even open-source ones).
 
 Helpful competition rules relevant to the dataset choice:
 
-- The maximum prompt/completion length the models are expected to handle is 2048 tokens. 
+- The maximum prompt/completion length the models are expected to handle is 2048 tokens.
 - The evaluation will be on English texts only.
 
 &nbsp;
@@ -112,7 +112,7 @@ python scripts/convert_hf_checkpoint.py \
 
 While StableLM 3B Base is useful as a first starter model to set things up, you may want to use the more capable Falcon 7B or Llama 2 7B/13B models later. See the [`download_*`](https://github.com/Lightning-AI/lit-gpt/tree/main/tutorials) tutorials in Lit-GPT to download other model checkpoints.
 
-After downloading and converting the model checkpoint, you can test the model via the following command: 
+After downloading and converting the model checkpoint, you can test the model via the following command:
 
 ```bash
 python generate/base.py \
@@ -122,7 +122,7 @@ python generate/base.py \
 
 &nbsp;
 
-## Downloading and Preparing Datasets 
+## Downloading and Preparing Datasets
 
 The following command will download and preprocess the Dolly15k dataset for the StableLM 3B Base model:
 
@@ -139,7 +139,7 @@ python scripts/prepare_dolly.py \
 
 ## Finetuning
 
-[Low-rank Adaptation (LoRA)](https://lightning.ai/pages/community/tutorial/lora-llm/) is a good choice for a first finetuning run. The Dolly dataset has ~15k samples, and the finetuning might take half an hour. 
+[Low-rank Adaptation (LoRA)](https://lightning.ai/pages/community/tutorial/lora-llm/) is a good choice for a first finetuning run. The Dolly dataset has ~15k samples, and the finetuning might take half an hour.
 
 To accelerate this for testing purposes, edit the [./finetune/lora.py](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py) script and change `max_iters = 50000` to `max_iters = 500` at the top of the file.
 
@@ -168,7 +168,7 @@ If you are using an RTX 4090, change `micro_batch_size=4` to `micro_batch_size=1
 
 The official Lit-GPT competition will use a small subset of HELM tasks for model evaluation, which includes BigBench (general), MMLU (knowledge), TruthfulQA (knowledge and harm in a multiple choice format), CNN/DailyMail (news summarization), GSM8K (math), and BBQ (bias).
 
-HELM is currently also being integrated into Lit-GPT to evaluate LLMs before submission. 
+HELM is currently also being integrated into Lit-GPT to evaluate LLMs before submission.
 
 However, a tool with a more convenient interface is Eleuther AI's [Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness), which contains some tasks, for example, BigBench, TruthfulQA, and GSM8k, that overlap with HELM. We can set up the Evaluation Harness as follows:
 
@@ -180,7 +180,7 @@ pip install -e .
 cd ../lit-gpt
 ```
 
-And then we can use it via the following command: 
+And then we can use it via the following command:
 
 ```bash
 python eval/lm_eval_harness.py \

--- a/tutorials/oom.md
+++ b/tutorials/oom.md
@@ -3,7 +3,7 @@
 If you got this error while running a script
 
 ```bash
-OutOfMemoryError: CUDA out of memory. Tried to allocate 2.22 GiB. GPU 0 has a total capacty of 79.15 GiB of which 228.38 MiB is free. Including non-PyTorch memory, this process
+OutOfMemoryError: CUDA out of memory. Tried to allocate 2.22 GiB. GPU 0 has a total capacity of 79.15 GiB of which 228.38 MiB is free. Including non-PyTorch memory, this process
 has 78.93 GiB memory in use. Of the allocated memory 76.28 GiB is allocated by PyTorch, and 2.14 GiB is reserved by PyTorch but unallocated. If reserved but unallocated memory
 is large try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
 ```

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -20,7 +20,7 @@ Note that the dataset needs to be prepared separately for each type of model sin
 
 For the following examples, we will use a Falcon 7B model. However, the same methods are compatible with all other models as well.
 
-The steps here only need to be done once before preparing the finetuning datasets in the following subsections: 
+The steps here only need to be done once before preparing the finetuning datasets in the following subsections:
 
 1. Follow the instructions in the [README](../README.md) to install the dependencies.
 2. Download and convert the weights following our [guide](download_falcon.md).
@@ -87,8 +87,8 @@ python scripts/prepare_lima.py \
  --access_token "insert_your_token_here"
 ```
 
-LIMA contains a handful of multiturn conversations. By default, only the first instruction-response pairs from 
-each of these multiturn conversations are included. If you want to override this behavior and include the follow up instructions 
+LIMA contains a handful of multiturn conversations. By default, only the first instruction-response pairs from
+each of these multiturn conversations are included. If you want to override this behavior and include the follow up instructions
 and responses, set `--include_multiturn_conversations True`.
 
 
@@ -111,7 +111,7 @@ Please read the [tutorials/finetune_*.md](../tutorials) documents for more infor
 > Make sure that the `prepare_*.py` and `finetune/*.py` scripts use the same model checkpoint specified via `--checkpoint_dir`.
 
 > [!IMPORTANT]
-> By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,  
+> By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,
 > you can try to lower the context length by editing the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
 
 &nbsp;
@@ -122,4 +122,3 @@ In addition to the finetuning dataset described above, Lit-GPT also supports sev
 
 - [Pretrain Llama 2 on OpenWebText](./pretrain_openwebtext.md)
 - [Pretrain Llama 2 on RedPajama](./pretrain_redpajama.md)
-

--- a/tutorials/pretrain_redpajama.md
+++ b/tutorials/pretrain_redpajama.md
@@ -91,12 +91,12 @@ model_name = "Llama-2-7b-hf"
 
 at the top of this script.
 
-The currently supported model names are contained in the [config.py](https://github.com/Lightning-AI/lit-gpt/lit_gpt/config.py) file. 
-You can 
+The currently supported model names are contained in the [config.py](https://github.com/Lightning-AI/lit-gpt/lit_gpt/config.py) file.
+You can
 
 1) either search this file for lines containing "name =",
 2) run `python scripts/download.py` without additional command line arguments,
-3) or 
+3) or
 
 ```python
 from lit_gpt.config import configs

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -28,7 +28,7 @@ python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --precisio
 ...
 Time for inference 1: 9.76 sec total, 26.23 tokens/sec.
 Memory used: 14.51 GB
-````
+```
 
 To reduce the memory requirements further, Lit-GPT supports several quantization techniques, which are shown below.
 

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -4,9 +4,8 @@ This document provides different strategies for quantizing the various models av
 
 **All the examples below were run on an A100 40GB GPU.**
 
-> [!NOTE]\:
+> [!NOTE]
 > Quantization also supports finetuning via [QLoRA](finetune_lora.md)
-
 
 ## Baseline
 
@@ -33,14 +32,15 @@ Memory used: 14.51 GB
 
 To reduce the memory requirements further, Lit-GPT supports several quantization techniques, which are shown below.
 
-> [!NOTE]\:
+> [!NOTE]
 > Most quantization examples below also use the `--precision bf16-true` setting explained above. If your GPU does not support the bfloat-format, you can change it to `--precision 16-true`.
 
 ## `bnb.nf4`
 
 Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check out the [paper](https://arxiv.org/abs/2305.14314v1) to learn more about how it works.
 
-> [!NOTE]\: `bitsandbytes` only supports `CUDA` devices and the `Linux` operating system.
+> [!NOTE]
+> `bitsandbytes` only supports `CUDA` devices and the `Linux` operating system.
 > Windows users should use [WSL2](https://learn.microsoft.com/en-us/windows/ai/directml/gpu-cuda-in-wsl).
 
 Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" based on the paper's experimental results and theoretical analysis.

--- a/xla/README.md
+++ b/xla/README.md
@@ -16,7 +16,7 @@ You can also choose a different TPU type. To do so, change the `version`, `accel
 
 <details>
 <summary>Multihost caveats</summary>
-  
+
 TPU v4-8 uses a single host. SSH'ing into the machine and running commands manually will only work when using a single host (1 slice in the TPU pod).
 In multi-host environments, such as larger TPU pod slices, it's necessary to launch all commands on all hosts simultaneously to avoid hangs.
 For local development, it is advisable to upload a zip file containing all your current changes and execute it inside the VM from your personal computer:
@@ -74,7 +74,7 @@ export ALLOW_MULTIPLE_LIBTPU_LOAD=1
 export PJRT_DEVICE=TPU
 ```
 
-> [!NOTE]\
+> [!NOTE]
 > An extensive guide on setup and available options can be found [here](https://cloud.google.com/tpu/docs/v4-users-guide).
 
 Since a new machine was created, you may need to download pretrained weights.
@@ -87,7 +87,6 @@ Persistent disks can still be useful in read-only mode to load pretrained weight
 In multihost settings, FSDP will save checkpoint shards per host and consolidate them into a single checkpoint.
 For safekeeping, it is recommended to upload the consolidated checkpoints to a Google Cloud bucket.
 Alternatively, you can use the `scp` command to transfer these checkpoints from the TPU VM periodically, although this is not implemented in our scripts.
-
 
 ## Inference
 
@@ -113,7 +112,7 @@ python3 xla/finetune/adapter.py --checkpoint_dir checkpoints/tiiuae/falcon-7b --
 
 <details>
 <summary>Multihost caveats</summary>
-  
+
 This script is configured to save "full" checkpoints, which isn't possible on multihost TPU VMs.
 Here's how you can consolidate them together into a single one after training with `state_dict_type="sharded"`:
 


### PR DESCRIPTION
Hi there 👋 

I've noticed that in some markdown files [!NOTE] label is not rendered correctly because of the appended characters.
Also, I standardized all "note" labels to be only [!NOTE] and not [!NOTE]\\.
Fixed trailing white spaces and removed unnecessary empty lines except those that Sebastian added lately: don't understand why he likes so much that many empty spaces but feel like if I delete them - something is gonna happen to me 😆 🙀.

---- 

@rasbt if you're reading this, in VSCode: 	
```text
"files.trimTrailingWhitespace": true,
```
😉😉 