### PR TITLE
Add paragraph space

### DIFF
--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -114,6 +114,7 @@ Please read the [tutorials/finetune_*.md](../tutorials) documents for more infor
 > By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,
 > you can try to lower the context length by editing the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
 
+&nbsp;
 
 ## Preparing Custom Datasets for Instruction Finetuning
 


### PR DESCRIPTION
Sorry, this is a tiny PR, but it fixes the paragraph spacing before the newly added headline to make it consistent with the rest of the article (and to make it more legible).