### PR TITLE
Manage the `max_seq_length` through a property

### DIFF
--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -124,13 +124,7 @@ class EvalHarnessBase(BaseLM):
     def _model_generate(self, context, max_length, eos_token_id):
         assert context.shape[0] == 1
         out = generate(
-            model=self.model,
-            idx=context[0],
-            max_new_tokens=max_length,
-            max_seq_length=self.model.config.block_size,
-            temperature=self.temperature,
-            top_k=None,
-            eos_id=eos_token_id,
+            self.model, context[0], max_length, temperature=self.temperature, top_k=None, eos_id=eos_token_id
         )
 
         return self.tokenizer.decode(out)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -30,6 +30,7 @@ from scripts.prepare_alpaca import generate_prompt
 eval_interval = 600
 save_interval = 1000
 eval_iters = 100
+eval_max_new_tokens = 100
 log_interval = 1
 devices = 1
 # change this value to force a maximum sequence length
@@ -132,6 +133,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     max_seq_length, longest_seq_length, longest_seq_ix = get_max_seq_length(train_data)
+    model.max_seq_length = max_seq_length
 
     validate(fabric, model, val_data, tokenizer, longest_seq_length)  # sanity check
 
@@ -169,7 +171,7 @@ def train(
 
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
-            logits = model(input_ids, max_seq_length=max_seq_length, lm_head_chunk_size=128)
+            logits = model(input_ids, lm_head_chunk_size=128)
             # shift the targets such that output n predicts token n+1
             logits[-1] = logits[-1][..., :-1, :]
             loss = chunked_cross_entropy(logits, targets[..., 1:])
@@ -227,14 +229,10 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
+    output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
+    model.reset_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
-
-    model.reset_cache()
 
     model.train()
     return val_loss

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -30,6 +30,7 @@ from scripts.prepare_alpaca import generate_prompt
 eval_interval = 600
 save_interval = 1000
 eval_iters = 100
+eval_max_new_tokens = 100
 log_interval = 1
 devices = 1
 # change this value to force a maximum sequence length
@@ -132,6 +133,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     max_seq_length, longest_seq_length, longest_seq_ix = get_max_seq_length(train_data)
+    model.max_seq_length = max_seq_length
 
     validate(fabric, model, val_data, tokenizer, longest_seq_length)  # sanity check
 
@@ -169,7 +171,7 @@ def train(
 
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
-            logits = model(input_ids, max_seq_length=max_seq_length, lm_head_chunk_size=128)
+            logits = model(input_ids, lm_head_chunk_size=128)
             # shift the targets such that output n predicts token n+1
             logits[-1] = logits[-1][..., :-1, :]
             loss = chunked_cross_entropy(logits, targets[..., 1:])
@@ -227,14 +229,10 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
+    output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
+    model.reset_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
-
-    model.reset_cache()
 
     model.train()
     return val_loss

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -30,6 +30,7 @@ from scripts.prepare_alpaca import generate_prompt
 eval_interval = 600
 save_interval = 1000
 eval_iters = 100
+eval_max_new_tokens = 100
 log_interval = 1
 devices = 1
 # change this value to force a maximum sequence length
@@ -127,6 +128,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     max_seq_length, longest_seq_length, longest_seq_ix = get_max_seq_length(train_data)
+    model.max_seq_length = max_seq_length
 
     validate(fabric, model, val_data, tokenizer, longest_seq_length)  # sanity check
 
@@ -163,7 +165,7 @@ def train(
 
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
-            logits = model(input_ids, max_seq_length=max_seq_length)
+            logits = model(input_ids)
             # shift the targets such that output n predicts token n+1
             loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
             fabric.backward(loss / gradient_accumulation_iters)
@@ -220,14 +222,10 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
+    output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
+    model.reset_cache()
     output = tokenizer.decode(output)
     fabric.print(output)
-
-    model.reset_cache()
 
     model.train()
     return val_loss

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -97,16 +97,12 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
+
     t0 = time.perf_counter()
-    y = generate(
-        model,
-        encoded,
-        max_returned_tokens,
-        max_seq_length=max_returned_tokens,
-        temperature=temperature,
-        top_k=top_k,
-        eos_id=tokenizer.eos_id,
-    )
+    y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
     model.reset_cache()

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -97,16 +97,12 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
+
     t0 = time.perf_counter()
-    y = generate(
-        model,
-        encoded,
-        max_returned_tokens,
-        max_seq_length=max_returned_tokens,
-        temperature=temperature,
-        top_k=top_k,
-        eos_id=tokenizer.eos_id,
-    )
+    y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
     model.reset_cache()

--- a/generate/base.py
+++ b/generate/base.py
@@ -21,7 +21,6 @@ def generate(
     model: GPT,
     idx: torch.Tensor,
     max_returned_tokens: int,
-    max_seq_length: int,
     *,
     temperature: float = 1.0,
     top_k: Optional[int] = None,
@@ -35,18 +34,17 @@ def generate(
         model: The model to use.
         idx: Tensor of shape (T) with indices of the prompt sequence.
         max_returned_tokens: The maximum number of tokens to return (given plus generated).
-        max_seq_length: The maximum sequence length allowed. Should be less or equal than the block size.
         temperature: Scales the predicted logits by 1 / temperature.
         top_k: If specified, only sample among the tokens with the k highest probabilities.
         eos_id: If specified, stop generating any more token once the <eos> token is triggered.
     """
     T = idx.size(0)
     assert max_returned_tokens > T
-    if max_seq_length < max_returned_tokens - 1:
+    if model.max_seq_length < max_returned_tokens - 1:
         # rolling the kv cache based on the `input_pos` value would be necessary. However, doing so would introduce a
         # data dependency on the `input_pos` tensor and impact model compilation. Since this setting is uncommon, we do
         # not support it to avoid negatively impacting the overall speed
-        raise NotImplementedError
+        raise NotImplementedError(f"max_seq_length {model.max_seq_length} needs to be < {max_returned_tokens - 1}")
 
     device, dtype = idx.device, idx.dtype
     # create an empty tensor of the expected final shape and fill in the current tokens
@@ -60,7 +58,7 @@ def generate(
         x = idx.index_select(0, input_pos).view(1, -1)
 
         # forward
-        logits = model(x, max_seq_length, input_pos)
+        logits = model(x, input_pos)
         logits = logits[0, -1] / temperature
 
         # optionally crop the logits to only the top k options
@@ -155,22 +153,15 @@ def main(
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
-    assert max_returned_tokens <= model.config.block_size, (
-        max_returned_tokens,
-        model.config.block_size,
-    )  # maximum rope cache length
+
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
 
     L.seed_everything(1234)
     for i in range(num_samples):
         t0 = time.perf_counter()
-        y = generate(
-            model,
-            encoded,
-            max_returned_tokens,
-            max_seq_length=max_returned_tokens,
-            temperature=temperature,
-            top_k=top_k,
-        )
+        y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k)
         t = time.perf_counter() - t0
 
         model.reset_cache()

--- a/generate/full.py
+++ b/generate/full.py
@@ -91,16 +91,12 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
+
     t0 = time.perf_counter()
-    y = generate(
-        model,
-        encoded,
-        max_returned_tokens,
-        max_seq_length=max_returned_tokens,
-        temperature=temperature,
-        top_k=top_k,
-        eos_id=tokenizer.eos_id,
-    )
+    y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
     model.reset_cache()

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -119,16 +119,12 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
+
     t0 = time.perf_counter()
-    y = generate(
-        model,
-        encoded,
-        max_returned_tokens,
-        max_seq_length=max_returned_tokens,
-        temperature=temperature,
-        top_k=top_k,
-        eos_id=tokenizer.eos_id,
-    )
+    y = generate(model, encoded, max_returned_tokens, temperature=temperature, top_k=top_k, eos_id=tokenizer.eos_id)
     t = time.perf_counter() - t0
 
     model.reset_cache()

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -41,8 +41,7 @@ class GPT(BaseModel):
                 ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
             )
         )
-
-        self.rope_cache: Optional[RoPECache] = None
+        self.max_seq_length = self.config.block_size
         self.mask_cache: Optional[torch.Tensor] = None
         self.kv_caches: List[KVCache] = []
         self.adapter_kv_caches: List[KVCache] = []
@@ -54,25 +53,14 @@ class GPT(BaseModel):
     def forward(
         self,
         idx: torch.Tensor,
-        max_seq_length: Optional[int] = None,
         input_pos: Optional[torch.Tensor] = None,
         lm_head_chunk_size: int = 0,
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        B, T = idx.size()
+        T = idx.size(1)
         use_kv_cache = input_pos is not None
-
         block_size = self.config.block_size
-        if max_seq_length is None:
-            max_seq_length = block_size
-        if use_kv_cache:  # not relevant otherwise
-            assert (
-                max_seq_length >= T
-            ), f"Cannot forward sequence of length {T}, max seq length is only {max_seq_length}"
-        assert max_seq_length <= block_size, f"Cannot attend to {max_seq_length}, block size is only {block_size}"
         assert block_size >= T, f"Cannot forward sequence of length {T}, block size is only {block_size}"
 
-        if self.rope_cache is None:
-            self.rope_cache = self.build_rope_cache(idx)
         # passing `attn_mask` to SDPA downgrades it to use the inefficient implementation. since we only need the mask
         # for the kv-cache support (only during inference), we only create it in that situation
         # this will be resolved by https://github.com/pytorch/pytorch/issues/96099
@@ -84,7 +72,7 @@ class GPT(BaseModel):
             cos = cos.index_select(0, input_pos)
             sin = sin.index_select(0, input_pos)
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, :max_seq_length]
+            mask = mask[:, :, :, :self.max_seq_length]
         else:
             cos = cos[:T]
             sin = sin[:T]
@@ -95,13 +83,13 @@ class GPT(BaseModel):
 
         if not use_kv_cache:
             for block in self.transformer.h:
-                x, *_ = block(x, (cos, sin), max_seq_length)
+                x, *_ = block(x, (cos, sin))
         else:
-            self.kv_caches = self.kv_caches or self.build_kv_caches(x, max_seq_length, cos.size(-1))
+            self.kv_caches = self.kv_caches or self.build_kv_caches(x, self.max_seq_length, cos.size(-1))
             self.adapter_kv_caches = self.adapter_kv_caches or [None for _ in range(self.config.n_layer)]
             for i, block in enumerate(self.transformer.h):
                 x, self.kv_caches[i], self.adapter_kv_caches[i] = block(
-                    x, (cos, sin), max_seq_length, mask, input_pos, self.kv_caches[i], self.adapter_kv_caches[i]
+                    x, (cos, sin), mask, input_pos, self.kv_caches[i], self.adapter_kv_caches[i]
                 )
 
         x = self.transformer.ln_f(x)
@@ -140,7 +128,6 @@ class Block(nn.Module):
         self,
         x: torch.Tensor,
         rope: RoPECache,
-        max_seq_length: int,
         mask: Optional[torch.Tensor] = None,
         input_pos: Optional[torch.Tensor] = None,
         kv_cache: Optional[KVCache] = None,
@@ -148,7 +135,7 @@ class Block(nn.Module):
     ) -> Tuple[torch.Tensor, Optional[KVCache], Optional[KVCache]]:
         n_1 = self.norm_1(x)
         h, new_kv_cache, new_adapter_kv_cache = self.attn(
-            n_1, rope, max_seq_length, mask, input_pos, kv_cache, adapter_kv_cache
+            n_1, rope, mask, input_pos, kv_cache, adapter_kv_cache
         )
         if self.config.parallel_residual:
             n_2 = n_1 if self.config.shared_attention_norm else self.norm_2(x)
@@ -182,7 +169,6 @@ class CausalSelfAttention(BaseCausalSelfAttention):
         self,
         x: torch.Tensor,
         rope: RoPECache,
-        max_seq_length: int,
         mask: Optional[torch.Tensor] = None,
         input_pos: Optional[torch.Tensor] = None,
         kv_cache: Optional[KVCache] = None,

--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -76,8 +76,7 @@ class GPT(BaseModel):
                 ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
             )
         )
-
-        self.rope_cache: Optional[RoPECache] = None
+        self.max_seq_length = self.config.block_size
         self.mask_cache: Optional[torch.Tensor] = None
         self.kv_caches: List[KVCache] = []
         self.adapter_kv_caches: List[KVCache] = []
@@ -146,7 +145,6 @@ class CausalSelfAttention(BaseCausalSelfAttention):
         self,
         x: torch.Tensor,
         rope: RoPECache,
-        max_seq_length: int,
         mask: Optional[torch.Tensor] = None,
         input_pos: Optional[torch.Tensor] = None,
         kv_cache: Optional[KVCache] = None,

--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -174,10 +174,10 @@ class CausalSelfAttention(BaseCausalSelfAttention):
         v = v.reshape(B, -1, T, self.config.head_size)  # (B, nh_v, T, hs)
 
         cos, sin = rope
-        q_roped = apply_rope(q[..., :self.config.rope_n_elem], cos, sin)
-        k_roped = apply_rope(k[..., :self.config.rope_n_elem], cos, sin)
-        q = torch.cat((q_roped, q[..., self.config.rope_n_elem:]), dim=-1)
-        k = torch.cat((k_roped, k[..., self.config.rope_n_elem:]), dim=-1)
+        q_roped = apply_rope(q[..., : self.config.rope_n_elem], cos, sin)
+        k_roped = apply_rope(k[..., : self.config.rope_n_elem], cos, sin)
+        q = torch.cat((q_roped, q[..., self.config.rope_n_elem :]), dim=-1)
+        k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
 
         if kv_cache is not None:
             cache_k, cache_v = kv_cache

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -473,33 +473,21 @@ class GPT(BaseModel):
                 ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
             )
         )
-
-        self.rope_cache: Optional[RoPECache] = None
+        self.max_seq_length = self.config.block_size
         self.mask_cache: Optional[torch.Tensor] = None
         self.kv_caches: List[KVCache] = []
 
     def forward(
         self,
         idx: torch.Tensor,
-        max_seq_length: Optional[int] = None,
         input_pos: Optional[torch.Tensor] = None,
         lm_head_chunk_size: int = 0,
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        B, T = idx.size()
+        T = idx.size(1)
         use_kv_cache = input_pos is not None
-
         block_size = self.config.block_size
-        if max_seq_length is None:
-            max_seq_length = block_size
-        if use_kv_cache:  # not relevant otherwise
-            assert (
-                max_seq_length >= T
-            ), f"Cannot forward sequence of length {T}, max seq length is only {max_seq_length}"
-        assert max_seq_length <= block_size, f"Cannot attend to {max_seq_length}, block size is only {block_size}"
         assert block_size >= T, f"Cannot forward sequence of length {T}, block size is only {block_size}"
 
-        if self.rope_cache is None:
-            self.rope_cache = self.build_rope_cache(idx)  # 2 * (block_size, head_size * rotary_percentage)
         # passing `attn_mask` to SDPA downgrades it to use the inefficient implementation. since we only need the mask
         # for the kv-cache support (only during inference), we only create it in that situation
         # this will be resolved by https://github.com/pytorch/pytorch/issues/96099
@@ -511,7 +499,7 @@ class GPT(BaseModel):
             cos = cos.index_select(0, input_pos)
             sin = sin.index_select(0, input_pos)
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, :max_seq_length]
+            mask = mask[:, :, :, :self.max_seq_length]
         else:
             cos = cos[:T]
             sin = sin[:T]
@@ -522,11 +510,11 @@ class GPT(BaseModel):
 
         if not use_kv_cache:
             for block in self.transformer.h:
-                x, *_ = block(x, (cos, sin), max_seq_length)
+                x, *_ = block(x, (cos, sin))
         else:
-            self.kv_caches = self.kv_caches or self.build_kv_caches(x, max_seq_length, cos.size(-1))
+            self.kv_caches = self.kv_caches or self.build_kv_caches(x, self.max_seq_length, cos.size(-1))
             for i, block in enumerate(self.transformer.h):
-                x, self.kv_caches[i] = block(x, (cos, sin), max_seq_length, mask, input_pos, self.kv_caches[i])
+                x, self.kv_caches[i] = block(x, (cos, sin), mask, input_pos, self.kv_caches[i])
 
         x = self.transformer.ln_f(x)
 

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -55,7 +55,7 @@ from lit_gpt.config import Config as BaseConfig
 from lit_gpt.model import GPT as BaseModel
 from lit_gpt.model import Block as BaseBlock
 from lit_gpt.model import CausalSelfAttention as BaseCausalSelfAttention
-from lit_gpt.model import KVCache, RoPECache
+from lit_gpt.model import KVCache
 from lit_gpt.utils import map_old_state_dict_weights
 
 
@@ -478,10 +478,7 @@ class GPT(BaseModel):
         self.kv_caches: List[KVCache] = []
 
     def forward(
-        self,
-        idx: torch.Tensor,
-        input_pos: Optional[torch.Tensor] = None,
-        lm_head_chunk_size: int = 0,
+        self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None, lm_head_chunk_size: int = 0
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
         T = idx.size(1)
         use_kv_cache = input_pos is not None
@@ -499,7 +496,7 @@ class GPT(BaseModel):
             cos = cos.index_select(0, input_pos)
             sin = sin.index_select(0, input_pos)
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, :self.max_seq_length]
+            mask = mask[:, :, :, : self.max_seq_length]
         else:
             cos = cos[:T]
             sin = sin[:T]

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -73,9 +73,7 @@ class GPT(nn.Module):
             self.rope_cache = None
             self.mask_cache = None
 
-    def forward(
-        self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None
-    ) -> torch.Tensor:
+    def forward(self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None) -> torch.Tensor:
         T = idx.size(1)
         use_kv_cache = input_pos is not None
         block_size = self.config.block_size
@@ -92,7 +90,7 @@ class GPT(nn.Module):
             cos = cos.index_select(0, input_pos)
             sin = sin.index_select(0, input_pos)
             mask = self.mask_cache.index_select(2, input_pos)
-            mask = mask[:, :, :, :self.max_seq_length]
+            mask = mask[:, :, :, : self.max_seq_length]
         else:
             cos = cos[:T]
             sin = sin[:T]
@@ -226,10 +224,10 @@ class CausalSelfAttention(nn.Module):
         v = v.reshape(B, -1, T, self.config.head_size)  # (B, nh_v, T, hs)
 
         cos, sin = rope
-        q_roped = apply_rope(q[..., :self.config.rope_n_elem], cos, sin)
-        k_roped = apply_rope(k[..., :self.config.rope_n_elem], cos, sin)
-        q = torch.cat((q_roped, q[..., self.config.rope_n_elem:]), dim=-1)
-        k = torch.cat((k_roped, k[..., self.config.rope_n_elem:]), dim=-1)
+        q_roped = apply_rope(q[..., : self.config.rope_n_elem], cos, sin)
+        k_roped = apply_rope(k[..., : self.config.rope_n_elem], cos, sin)
+        q = torch.cat((q_roped, q[..., self.config.rope_n_elem :]), dim=-1)
+        k = torch.cat((k_roped, k[..., self.config.rope_n_elem :]), dim=-1)
 
         if kv_cache is not None:
             cache_k, cache_v = kv_cache

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -49,6 +49,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     module.save_interval = 2
     module.eval_interval = 2
     module.eval_iters = 2
+    module.eval_max_new_tokens = 1
     module.max_iters = 6
 
     data = [

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -64,6 +64,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     module.save_interval = 2
     module.eval_interval = 2
     module.eval_iters = 2
+    module.eval_max_new_tokens = 1
     module.max_iters = 6
 
     data = [

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -24,6 +24,7 @@ def test_generate(generated, stop_tokens, expected):
     max_returned_tokens = len(input_idx) + 8
     model = MagicMock()
     model.config.block_size = 100
+    model.max_seq_length = 100
 
     original_multinomial = torch.multinomial
     it = iter(generated)
@@ -33,7 +34,7 @@ def test_generate(generated, stop_tokens, expected):
         return torch.tensor([out])
 
     chat.torch.multinomial = multinomial
-    actual = chat.generate(model, input_idx, max_returned_tokens, max_returned_tokens, stop_tokens=stop_tokens)
+    actual = chat.generate(model, input_idx, max_returned_tokens, stop_tokens=stop_tokens)
     actual = list(actual)
     chat.torch.multinomial = original_multinomial
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -12,6 +12,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     module.save_interval = 2
     module.eval_interval = 2
     module.eval_iters = 2
+    module.eval_max_new_tokens = 1
     module.max_iters = 6
 
     data = [

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -23,6 +23,7 @@ def test_generate(max_seq_length):
 
     config = Config(block_size=128, vocab_size=16, n_layer=1, n_head=4, n_embd=8)
     model = GPT(config)
+    model.max_seq_length = max_seq_length
     max_new_tokens = 20
 
     multinomial_results = []
@@ -34,7 +35,7 @@ def test_generate(max_seq_length):
         return out
 
     with mock.patch("torch.multinomial", multinomial):
-        out = generate.generate(model, input_idx, T + max_new_tokens, max_seq_length=max_seq_length, top_k=4)
+        out = generate.generate(model, input_idx, T + max_new_tokens, top_k=4)
 
     assert out.size(0) == T + max_new_tokens
     multinomial_results = torch.hstack(multinomial_results)
@@ -72,7 +73,7 @@ def test_main(fake_checkpoint_dir, monkeypatch):
 
     assert len(tokenizer_mock.return_value.decode.mock_calls) == num_samples
     assert torch.allclose(tokenizer_mock.return_value.decode.call_args[0][0], generate_mock.return_value)
-    assert generate_mock.mock_calls == [call(ANY, ANY, 53, max_seq_length=53, temperature=2.0, top_k=2)] * num_samples
+    assert generate_mock.mock_calls == [call(ANY, ANY, 53, temperature=2.0, top_k=2)] * num_samples
     # only the generated result is printed to stdout
     assert out.getvalue() == "foo bar baz\n" * num_samples
 

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -18,7 +18,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, version):
         import generate.adapter_v2 as generate
 
     config_path = fake_checkpoint_dir / "lit_config.json"
-    config = {"block_size": 16, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
+    config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
     config_path.write_text(json.dumps(config))
 
     load_mock = Mock()
@@ -41,10 +41,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, version):
 
     assert len(tokenizer_mock.return_value.decode.mock_calls) == num_samples
     assert torch.allclose(tokenizer_mock.return_value.decode.call_args[0][0], generate_mock.return_value)
-    assert (
-        generate_mock.mock_calls
-        == [call(ANY, ANY, ANY, max_seq_length=101, temperature=2.0, top_k=2, eos_id=ANY)] * num_samples
-    )
+    assert generate_mock.mock_calls == [call(ANY, ANY, 101, temperature=2.0, top_k=2, eos_id=ANY)] * num_samples
     # only the generated result is printed to stdout
     assert out.getvalue() == "foo bar baz\n" * num_samples
 

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -14,7 +14,7 @@ def test_main(fake_checkpoint_dir, monkeypatch):
 
     config_path = fake_checkpoint_dir / "lit_config.json"
     config = {
-        "block_size": 16,
+        "block_size": 128,
         "vocab_size": 50,
         "n_layer": 2,
         "n_head": 4,
@@ -46,10 +46,7 @@ def test_main(fake_checkpoint_dir, monkeypatch):
 
     assert len(tokenizer_mock.return_value.decode.mock_calls) == num_samples
     assert torch.allclose(tokenizer_mock.return_value.decode.call_args[0][0], generate_mock.return_value)
-    assert (
-        generate_mock.mock_calls
-        == [call(ANY, ANY, ANY, max_seq_length=101, temperature=2.0, top_k=2, eos_id=ANY)] * num_samples
-    )
+    assert generate_mock.mock_calls == [call(ANY, ANY, 101, temperature=2.0, top_k=2, eos_id=ANY)] * num_samples
     # only the generated result is printed to stdout
     assert out.getvalue() == "foo bar baz\n" * num_samples
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -145,6 +145,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     module.save_interval = 2
     module.eval_interval = 2
     module.eval_iters = 2
+    module.eval_max_new_tokens = 1
     module.max_iters = 6
 
     data = [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -67,7 +67,7 @@ def test_against_hf_model(rotary_pct, batch_size, n_embd, parallel_residual, kv_
     ours_embed = ours_model.transformer.wte(token_sample)
     torch.testing.assert_close(ours_embed, theirs_embed)
 
-    rope = ours_model.build_rope_cache(token_sample)
+    rope = ours_model.build_rope_cache()
     mask = ours_model.build_mask_cache(token_sample)
     position_ids = torch.arange(block_size).unsqueeze(0)
     if kv_cache:
@@ -79,13 +79,13 @@ def test_against_hf_model(rotary_pct, batch_size, n_embd, parallel_residual, kv_
         v_cache_shape = (batch_size, n_head, block_size, head_size)
         ours_kv_cache = torch.zeros(k_cache_shape), torch.zeros(v_cache_shape)
         (ours_block_out, ours_kv_cache) = ours_model.transformer.h[0](
-            ours_embed, rope, block_size, mask, torch.arange(block_size), ours_kv_cache
+            ours_embed, rope, mask, torch.arange(block_size), ours_kv_cache
         )
         for ours_cache, theirs_cache in zip(ours_kv_cache, theirs_kv_cache):
             torch.testing.assert_close(ours_cache, theirs_cache)
     else:
         (theirs_block_out,) = theirs_model.gpt_neox.layers[0](theirs_embed, position_ids=position_ids)
-        ours_block_out, _ = ours_model.transformer.h[0](ours_embed, rope, block_size, mask)
+        ours_block_out, _ = ours_model.transformer.h[0](ours_embed, rope, mask)
     torch.testing.assert_close(ours_block_out, theirs_block_out)
 
     theirs = theirs_model(token_sample)["logits"]
@@ -152,7 +152,7 @@ def test_against_original_open_llama_3b():
 
     # test rope
     x = torch.randn(2, T, ours_config.n_embd)  # B, T, n_embd
-    ours_cos, ours_sin = ours_model.build_rope_cache(x)
+    ours_cos, ours_sin = ours_model.build_rope_cache()
     ours_cos, ours_sin = ours_cos[:T], ours_sin[:T]  # this is done in our model forward
     theirs_cos, theirs_sin = theirs_model.model.layers[0].self_attn.rotary_emb(x, T)
     torch.testing.assert_close(ours_cos, theirs_cos.squeeze())
@@ -231,7 +231,6 @@ def test_model_compile():
 
     config = lit_gpt.Config(block_size=8, vocab_size=8, n_layer=2, n_head=2, n_embd=4)
     model = lit_gpt.GPT(config)
-    model.apply(model._init_weights)
 
     model = torch.compile(model)
 
@@ -252,6 +251,7 @@ def test_kv_cache(max_seq_length):
     model = GPT(config)
     idx = torch.randint(0, model.config.padded_vocab_size, (1, 5))
     max_new_tokens = 20
+    model.max_seq_length = max_seq_length
 
     def generate(logits):
         logits = logits[:, -1:]
@@ -262,14 +262,14 @@ def test_kv_cache(max_seq_length):
     x_cache = idx
     input_pos = torch.arange(0, 5)
     for _ in range(max_new_tokens):
-        logits_no_cache = model(x_no_cache, max_seq_length)
+        logits_no_cache = model(x_no_cache[:, -max_seq_length:])
         out_no_cache = generate(logits_no_cache)
 
-        logits_cache = model(x_cache, max_seq_length, input_pos)
+        logits_cache = model(x_cache, input_pos)
         out_cache = generate(logits_cache)
 
         torch.testing.assert_close(out_no_cache, out_cache, rtol=0, atol=0)
 
         x_no_cache = torch.cat((x_no_cache, out_no_cache), dim=1)
         x_cache = out_cache
-        input_pos = torch.tensor([input_pos[-1] + 1])
+        input_pos = input_pos[-1:] + 1

--- a/xla/finetune/adapter.py
+++ b/xla/finetune/adapter.py
@@ -26,6 +26,7 @@ from xla.utils import rank_print, sequential_load_and_fsdp_wrap
 eval_interval = 200
 save_interval = 200
 eval_iters = 100
+eval_max_new_tokens = 100
 log_interval = 1
 devices = XLAAccelerator.auto_device_count()
 # change this value to force a maximum sequence length
@@ -167,7 +168,7 @@ def train(
 
         is_accumulating = (iter_num + 1) % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
-            logits = model(input_ids, max_seq_length=max_seq_length, lm_head_chunk_size=128)
+            logits = model(input_ids, lm_head_chunk_size=128)
             xm.mark_step()
             # shift the targets such that output n predicts token n+1
             logits[-1] = logits[-1][..., :-1, :]
@@ -234,14 +235,10 @@ def validate(
     sample = {"instruction": instruction, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, device=fabric.device)
-    max_returned_tokens = len(encoded) + 100
-    output = generate(
-        model, idx=encoded, max_returned_tokens=max_returned_tokens, max_seq_length=max_returned_tokens, temperature=0.8
-    )
+    output = generate(model, encoded, max_returned_tokens=len(encoded) + eval_max_new_tokens, temperature=0.8)
+    model.reset_cache()
     output = tokenizer.decode(output)
     rank_print(fabric, output)
-
-    model.reset_cache()
 
     model.train()
     return val_loss

--- a/xla/generate/adapter.py
+++ b/xla/generate/adapter.py
@@ -89,6 +89,10 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    with fabric.init_tensor():
+        # set the max_seq_length to limit the memory usage to what we need
+        model.max_seq_length = max_returned_tokens
+
     t0 = time.perf_counter()
     y = generate(
         model,


### PR DESCRIPTION
Advantages:
- removes the `rope_cache` instantiation from `forward`
- One less argument that is passed through the models
- The rope cache now uses the `max_seq_length` for the length, instead of `block_size`. Saving memory if the former is smaller