### PR TITLE
ci: labels PR conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,22 @@
+name: Label conflicts
+
+on:
+  push:
+    branches: ["main"]
+  pull_request_target:
+    types: ["synchronize", "reopened", "opened"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  triage-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@8c6faa8a252e35ba5e15703b3d747bf726cdb95c  # Oct 25, 2021
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 3
+          WAIT_MS: 5000


### PR DESCRIPTION
Allowing to see that PR even with 💚 checks can't be merged, especially useful with 10+ ope PEr you do not need to open all PRs and check one by one...