### PR TITLE
FSDP meta-init for full and LoRA finetuning 

### DIFF
--- a/finetune/full.py
+++ b/finetune/full.py
@@ -21,6 +21,7 @@ from lit_gpt.utils import (
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
+    load_checkpoint,
     num_parameters,
     step_csv_logger,
 )
@@ -101,7 +102,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
     optimizer = fabric.setup_optimizers(optimizer)
 
-    fabric.load_raw(checkpoint_path, model)
+    load_checkpoint(fabric, model, checkpoint_path)
 
     fabric.seed_everything(1337 + fabric.global_rank)
 

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -21,7 +21,6 @@ from lit_gpt.utils import (
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
-    lazy_load,
     num_parameters,
     step_csv_logger,
 )
@@ -93,15 +92,16 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path):
     config = Config.from_name(name=checkpoint_dir.name)
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
-    with fabric.init_module(empty_init=False):
+    with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
-    with lazy_load(checkpoint_path) as checkpoint:
-        model.load_state_dict(checkpoint)
 
     fabric.print(f"Number of trainable parameters: {num_parameters(model, requires_grad=True):,}")
 
+    model = fabric.setup_module(model)
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
-    model, optimizer = fabric.setup(model, optimizer)
+    optimizer = fabric.setup_optimizers(optimizer)
+
+    fabric.load_raw(checkpoint_path, model)
 
     fabric.seed_everything(1337 + fabric.global_rank)
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -21,6 +21,7 @@ from lit_gpt.utils import (
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
+    load_checkpoint,
     num_parameters,
     quantization,
     step_csv_logger,
@@ -127,7 +128,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path, 
 
     if quantize:
         # for quantization, need to load before moving to device
-        fabric.load_raw(checkpoint_path, model, strict=False)
+        load_checkpoint(fabric, model, checkpoint_path, strict=False)
 
     model = fabric.setup_module(model)
 
@@ -142,7 +143,7 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path, 
     
     if not quantize:
         # strict=False because missing keys due to LoRA weights not contained in state dict
-        fabric.load_raw(checkpoint_path, model, strict=False)
+        load_checkpoint(fabric, model, checkpoint_path, strict=False)
 
     fabric.seed_everything(1337 + fabric.global_rank)
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -21,7 +21,6 @@ from lit_gpt.utils import (
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
-    lazy_load,
     num_parameters,
     quantization,
     step_csv_logger,
@@ -119,25 +118,31 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path, 
     )
     checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
-    with fabric.init_module(empty_init=False), quantization(quantize):
+    with fabric.init_module(empty_init=(devices > 1)), quantization(quantize):
         model = GPT(config)
-    with lazy_load(checkpoint_path) as checkpoint:
-        # strict=False because missing keys due to LoRA weights not contained in state dict
-        model.load_state_dict(checkpoint, strict=False)
-
     mark_only_lora_as_trainable(model)
 
     fabric.print(f"Number of trainable parameters: {num_parameters(model, requires_grad=True):,}")
     fabric.print(f"Number of non trainable parameters: {num_parameters(model, requires_grad=False):,}")
-    trainable_params = [p for p in model.parameters() if p.requires_grad]
 
+    if quantize:
+        # for quantization, need to load before moving to device
+        fabric.load_raw(checkpoint_path, model, strict=False)
+
+    model = fabric.setup_module(model)
+
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
     if quantize and quantize.startswith("bnb."):
         import bitsandbytes as bnb
 
         optimizer = bnb.optim.PagedAdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
     else:
         optimizer = torch.optim.AdamW(trainable_params, lr=learning_rate, weight_decay=weight_decay)
-    model, optimizer = fabric.setup(model, optimizer)
+    optimizer = fabric.setup_optimizers(optimizer)
+    
+    if not quantize:
+        # strict=False because missing keys due to LoRA weights not contained in state dict
+        fabric.load_raw(checkpoint_path, model, strict=False)
 
     fabric.seed_everything(1337 + fabric.global_rank)
 

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -93,7 +93,7 @@ def main(
     tokenizer = Tokenizer(checkpoint_dir)
     sample = {"instruction": prompt, "input": input}
     prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=model.device)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -93,7 +93,7 @@ def main(
     tokenizer = Tokenizer(checkpoint_dir)
     sample = {"instruction": prompt, "input": input}
     prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=model.device)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 

--- a/generate/full.py
+++ b/generate/full.py
@@ -87,7 +87,7 @@ def main(
     tokenizer = Tokenizer(checkpoint_dir)
     sample = {"instruction": prompt, "input": input}
     prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=model.device)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -115,7 +115,7 @@ def main(
     tokenizer = Tokenizer(checkpoint_dir)
     sample = {"instruction": prompt, "input": input}
     prompt = generate_prompt(sample)
-    encoded = tokenizer.encode(prompt, device=model.device)
+    encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -57,6 +57,10 @@ class GPT(nn.Module):
         # the mask and kv cache size will get updated on `set_kv_cache`. we cannot update it here because we don't know
         # if the kv cache is expected
 
+    def reset_parameters(self) -> None:
+        # Trigger resetting the rope-cache
+        self.max_seq_length = self.config.block_size
+
     def _init_weights(self, module: nn.Module) -> None:
         """Meant to be used with `gpt.apply(gpt._init_weights)`."""
         if isinstance(module, nn.Linear):

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -26,7 +26,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
-    monkeypatch.setattr(module.L.Fabric, "load_raw", Mock())
+    monkeypatch.setattr(module, "load_checkpoint", Mock())
 
     tokenizer_mock = Mock()
     tokenizer_mock.return_value = tokenizer_mock

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -26,12 +26,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
-
-    load_mock = Mock()
-    load_mock.return_value = load_mock
-    load_mock.__enter__ = Mock()
-    load_mock.__exit__ = Mock()
-    monkeypatch.setattr(module, "lazy_load", load_mock)
+    monkeypatch.setattr(module.L.Fabric, "load_raw", Mock())
 
     tokenizer_mock = Mock()
     tokenizer_mock.return_value = tokenizer_mock

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -160,7 +160,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
-    monkeypatch.setattr(module.L.Fabric, "load_raw", Mock())
+    monkeypatch.setattr(module, "load_checkpoint", Mock())
 
     tokenizer_mock = Mock()
     tokenizer_mock.return_value = tokenizer_mock

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -160,12 +160,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
-
-    load_mock = Mock()
-    load_mock.return_value = load_mock
-    load_mock.__enter__ = Mock()
-    load_mock.__exit__ = Mock()
-    monkeypatch.setattr(module, "lazy_load", load_mock)
+    monkeypatch.setattr(module.L.Fabric, "load_raw", Mock())
 
     tokenizer_mock = Mock()
     tokenizer_mock.return_value = tokenizer_mock


### PR DESCRIPTION
I'm resubmitting the previously rejected changes in #351. 


Makes the scripts compatible to run with meta-device init in FSDP via `fabric.init_module(empty_init=True)`. Also enables `fabric.load_raw()` which uses lazy-loading internally. The combined changes make it possible to initialize very large models and load the checkpoint in an efficient way without using up all available CPU RAM.

I tested convergence on both scripts.

