### PR TITLE
Add LongForm dataset (better than Alpaca)

### DIFF
--- a/scripts/prepare_longform.py
+++ b/scripts/prepare_longform.py
@@ -1,0 +1,149 @@
+"""Implementation derived from https://github.com/tloen/alpaca-lora"""
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import requests
+import torch
+from torch.utils.data import random_split
+from tqdm import tqdm
+
+# support running without installing as a package
+wd = Path(__file__).parent.parent.resolve()
+sys.path.append(str(wd))
+
+from lit_gpt.tokenizer import Tokenizer
+
+
+def prepare(
+    destination_path: Path = Path("data/longform"),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    seed: int = 42,
+    mask_inputs: bool = False,  # as in alpaca-lora
+    ignore_index: int = -1,
+    max_seq_length: Optional[int] = None,
+) -> None:
+    """Prepare the Alpaca dataset for instruction tuning.
+
+    The output is a training and test dataset saved as `train.pt` and `test.pt`,
+    which stores the preprocessed and tokenized prompts and labels.
+    """
+    if max_seq_length is None:
+        with open(checkpoint_dir / "lit_config.json", "r", encoding="utf-8") as file:
+            config = json.load(file)
+            max_seq_length = config["block_size"]
+
+    destination_path.mkdir(parents=True, exist_ok=True)
+
+    train_file_name = "train.json"
+    # val_file_name = "val.json"
+    test_file_name = "test.json"
+
+    train_file_url = "https://raw.githubusercontent.com/akoksal/LongForm/main/dataset/train.json"
+    # val_file_url = "https://raw.githubusercontent.com/akoksal/LongForm/main/dataset/val.json"
+    test_file_url = "https://raw.githubusercontent.com/akoksal/LongForm/main/dataset/test.json"
+
+    train_file_path = destination_path / train_file_name
+    print("Loading train data file...")
+    download_if_missing(train_file_path, train_file_url)
+    with open(train_file_path, "r", encoding="utf-8") as file:
+        train_data = json.load(file)
+
+    test_file_path = destination_path / test_file_name
+    print("Loading test data file...")
+    download_if_missing(test_file_path, test_file_url)
+    with open(test_file_path, "r", encoding="utf-8") as file:
+        test_data = json.load(file)
+
+    print("Loading tokenizer...")
+    tokenizer = Tokenizer(checkpoint_dir)
+
+    print(f"train has {len(train_data):,} samples")
+    print(f"test has {len(test_data):,} samples")
+
+    print("Processing train set ...")
+    train_data = [
+        prepare_sample(
+            example=sample,
+            tokenizer=tokenizer,
+            max_length=max_seq_length,
+            mask_inputs=mask_inputs,
+            ignore_index=ignore_index,
+        )
+        for sample in tqdm(train_data)
+    ]
+    torch.save(train_data, destination_path / "train.pt")
+
+    print("Processing test set ...")
+    test_data = [
+        prepare_sample(
+            example=sample,
+            tokenizer=tokenizer,
+            max_length=max_seq_length,
+            mask_inputs=mask_inputs,
+            ignore_index=ignore_index,
+        )
+        for sample in tqdm(test_data)
+    ]
+    torch.save(test_data, destination_path / "test.pt")
+
+
+def download_if_missing(file_path: Path, file_url: str):
+    """Downloads the raw json data file and saves it in the given destination."""
+    if file_path.exists() and file_path.stat().st_size > 0:
+        return
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(requests.get(file_url).text)
+
+
+def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_inputs: bool, ignore_index: int):
+    """Processes a single sample.
+
+    Each sample in the dataset consists of:
+    - instruction: A string describing the task
+    - input: A string holding a special input value for the instruction.
+        This only applies to some samples, and in others this is empty.
+    - output: The response string
+
+    This function processes this data to produce a prompt text and a label for
+    supervised training. The prompt text is formed as a single message including both
+    the instruction and the input. The label/target is the same message but with the
+    response attached.
+
+    Finally, both the prompt and the label get tokenized. If desired, all tokens
+    in the label that correspond to the original input prompt get masked out (default).
+    """
+    full_prompt = generate_prompt(example)
+    full_prompt_and_response = full_prompt + example["output"]
+    encoded_full_prompt = tokenizer.encode(full_prompt, max_length=max_length)
+    encoded_full_prompt_and_response = tokenizer.encode(full_prompt_and_response, eos=True, max_length=max_length)
+
+    # The labels are the full prompt with response, but with the prompt masked out
+    labels = encoded_full_prompt_and_response.clone()
+    if mask_inputs:
+        labels[: len(encoded_full_prompt)] = ignore_index
+
+    return {
+        **example,
+        "input_ids": encoded_full_prompt_and_response,
+        "input_ids_no_response": encoded_full_prompt,
+        "labels": labels,
+    }
+
+
+def generate_prompt(example):
+    """Generates a standardized message to prompt the model with an instruction and a
+    'response' field."""
+
+    return (
+        "Below is an instruction that describes a task, paired with an input that provides further context. "
+        "Write a response that appropriately completes the request.\n\n"
+        f"### Instruction:\n{example['input']}\n\n### Response:"
+    )
+
+
+if __name__ == "__main__":
+    from jsonargparse import CLI
+
+    CLI(prepare)

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -97,7 +97,7 @@ and responses, set `--include_multiturn_conversations True`.
 
 ### LongForm
 
-LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper by Köksal et al.](https://arxiv.org/abs/2304.08460). According to the research paper, a Llama 7B model trained on LongForm achieves substantially better performance than the same Llama model trained on the 2x larger Alpaca dataset.
+LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper](https://arxiv.org/abs/2304.08460) by Köksal et al. According to the research paper, a Llama 7B model trained on LongForm achieves substantially better performance than the same Llama model trained on the 2x larger Alpaca dataset.
 
 LongForm consists of 23,652 training samples, 2,042 validation samples, and 2,045 test samples. (In Lit-GPT, the validation samples are currently not used.)
 

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -74,24 +74,6 @@ python scripts/prepare_dolly.py \
  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
 ```
 
-&nbsp;
-
-### LIMA
-
-The LIMA dataset is a collection of 1,000 carefully curated prompts and responses, as described in the [LIMA: Less Is More for Alignment](https://arxiv.org/abs/2305.11206) paper. The dataset is sourced from three community Q&A websites: Stack Exchange, wikiHow, and the Pushshift Reddit Dataset. In addition, it also contains prompts and answers written and collected by the authors of the LIMA paper.
-
-The usage is similar to the Dolly dataset described above except that it requires an Hugging Face access token that you need to copy & paste from your Hugging Face account. Using Falcon 7b as an example, we can prepare the dataset as follows:
-
-```bash
-python scripts/prepare_lima.py \
- --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
- --access_token "insert_your_token_here"
-```
-
-LIMA contains a handful of multiturn conversations. By default, only the first instruction-response pairs from
-each of these multiturn conversations are included. If you want to override this behavior and include the follow up instructions
-and responses, set `--include_multiturn_conversations True`.
-
 
 &nbsp;
 
@@ -124,7 +106,26 @@ License information is not provided but would depend on the individual subsets l
 
 &nbsp;
 
-## Finetuning After Data Preparation
+### LIMA
+
+The LIMA dataset is a collection of 1,000 carefully curated prompts and responses, as described in the [LIMA: Less Is More for Alignment](https://arxiv.org/abs/2305.11206) paper. The dataset is sourced from three community Q&A websites: Stack Exchange, wikiHow, and the Pushshift Reddit Dataset. In addition, it also contains prompts and answers written and collected by the authors of the LIMA paper.
+
+The usage is similar to the Dolly dataset described above except that it requires an Hugging Face access token that you need to copy & paste from your Hugging Face account. Using Falcon 7b as an example, we can prepare the dataset as follows:
+
+```bash
+python scripts/prepare_lima.py \
+ --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+ --access_token "insert_your_token_here"
+```
+
+LIMA contains a handful of multiturn conversations. By default, only the first instruction-response pairs from
+each of these multiturn conversations are included. If you want to override this behavior and include the follow up instructions
+and responses, set `--include_multiturn_conversations True`.
+
+
+&nbsp;
+
+### Finetuning After Data Preparation
 
 After preparing the dataset, you can finetune the model using the [`finetune/*.py`](../finetune/) scripts, for example,
 
@@ -142,7 +143,100 @@ Please read the [tutorials/finetune_*.md](../tutorials) documents for more infor
 
 > [!IMPORTANT]
 > By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,
-> you can try to lower the context length by editing the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
+> you can try to lower the context length by preparing the dataset with a fixed max length, for example, `python scripts/prepare_lima.py --max_seq_length 2048`. Alternatvively, you can edit the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
+
+&nbsp;
+
+## Preparing Custom Datasets for Instruction Finetuning
+
+The models in Lit-GPT expect datasets for instruction finetuning in the following format:
+
+```
+[
+    {
+        "instruction": "Write a limerick about a
+                        pelican.”,
+        "input": "",
+        "output": "There once was a pelican so fine,
+                   \nHis beak was as colorful as
+                   sunshine,\nHe would fish all day,\nIn
+                   a very unique way,\nThis pelican was
+                   truly divine!\n\n\n"
+    },
+    {
+        "instruction": "Identify the odd one out from
+                        the group.",
+        "input": "Carrot, Apple, Banana, Grape",
+        "output": "Carrot\n\n"
+    },
+]
+```
+(Note that epending on the task, the `"input"` text can be an empty string, as shown above.)
+
+Custom datasets can be prepared by either creating a new `scripts/prepare_dataset.py` script or reading the dataset
+from a CSV file.
+
+&nbsp;
+
+### Preparing Custom Datasets From a CSV File
+
+You can prepare custom dataset using a CSV file with the following columns:
+
+- `instruction`: Column which will describe the task.
+- `input`: A string holding a special input value for the instruction. This applies to some samples, and in others, this is empty (empty string).
+- `output`: The expected response
+
+> If any of the columns is missing, then the script will fail to create the dataset.
+
+Before you finetune, prepare the dataset using the `prepare_csv.py` script:
+
+```bash
+python scripts/prepare_csv.py --csv_path path/to/the/file.csv
+```
+You can also customize the dataset generation by using these additional parameters
+
+- `destination_path`: The folder where the binary data will be saved. By default, it is saved inside `data/csv`
+
+- `checkpoint_dir`: The model checkpoint dir. It will use the model's tokenizer to load and convert the string to input ids. Defaults to `"checkpoints/stabilityai/stablelm-base-alpha-3b"`
+
+- `test_split_fraction`: The fraction of the data to split. Defaults to `0.1`
+
+- `seed`: The seed value to reproduce the same random splits for train and test data.
+
+- `mask_inputs`: Whether we require any masking or not.
+
+- `ignore_index`: Mask out all the tokens after this index when preparing the dataset.
+
+To use the the settings described above, you can add the respective command line arguments when calling `prepare_csv.py` as shown in the example below:
+
+```bash
+python scripts/prepare_csv.py --csv_path test_data.csv \
+--destination_path data/csv \
+--checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
+--test_split_fraction 0.1 \
+--seed 42 \
+--mask_inputs false \
+--ignore_index -1
+```
+Replace `test_data.csv` with your CSV path and the other additional parameters accordingly. Executing the command above will save `train.pt` and `test.pt` on your disk at the `destination_path`. Now you can use the prepared data to [finetune your model](https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/finetune_lora.md#running-the-finetuning).
+
+&nbsp;
+
+### Preparing Custom Datasets Using a Dataset Prepration Script
+
+If you don't have a CSV file following the format described in the previous section, the easiest way to prepare a new dataset is to copy and modify one of the existing dataset preparation scripts:
+
+- [`scripts/prepare_alpaca.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_alpaca.py) (if you plan to load a dataset from a JSON file);
+- [`scripts/prepare_lima.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_lima.py) (if you plan to load a dataset using the `datasets` Python library).
+
+These scripts may look intimidating at first glance since they include code for tokenizing the dataset for a specific LLM that is provided via a checkpoint directory. However, note that you only need to modify a small fraction of the code file, namely the portion that downloads and formats the training data.
+
+In [`scripts/prepare_lima.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_lima.py), the [line 26](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_lima.py#L26) references the HF repo ID, and the lines [50-53](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_lima.py#L50-L53) save the dataset as `train_data`. Here, `train_data` is a list that contains the instruction examples in the format mentioned above.
+
+
+In [`scripts/prepare_alpaca.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_alpaca.py), you only need to modify [lines 24-25](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_alpaca.py#L24-L25) for the file name and URL, assuming the JSON file you are working with has the same format as the [Alpaca JSON file](https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json).
+
+
 
 &nbsp;
 

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -97,7 +97,7 @@ and responses, set `--include_multiturn_conversations True`.
 
 ### LongForm
 
-LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper by Köksal et al.](https://arxiv.org/abs/2304.08460).
+LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper by Köksal et al.](https://arxiv.org/abs/2304.08460). According to the research paper, a Llama 7B model trained on LongForm achieves substantially better performance than the same Llama model trained on the 2x larger Alpaca dataset.
 
 LongForm consists of 23,652 training samples, 2,042 validation samples, and 2,045 test samples. (In Lit-GPT, the validation samples are currently not used.)
 

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -8,6 +8,7 @@ Below is a table of all datasets that are currently supported in Lit-GPT:
 | Alpaca       | Finetuning  | 51,759 samples      | [URL](https://github.com/tatsu-lab/stanford_alpaca)             | [URL](https://crfm.stanford.edu/2023/03/13/alpaca.html)                                                                   | Attribution-NonCommercial 4.0 International, [ URL](https://crfm.stanford.edu/2023/03/13/alpaca.html)                                                                                                            |
 | Alpaca Libre | Finetuning  | 55,370 samples      | [URL](https://github.com/mobarski/alpaca-libre)                 | -                                                                                                                         | CC0/MIT,  [URL](https://github.com/mobarski/alpaca-libre)                                                                                                                                                        |
 | Dolly        | Finetuning  | 15,011 samples      | [URL](https://github.com/databrickslabs/dolly/tree/master/data) | [URL](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm)              | CC-BY-SA, [URL](https://github.com/databrickslabs/dolly#model-overview)                                                                                                                                          |
+| LongForm     | Finetuning  | 23,652 samples      | [URL](https://github.com/akoksal/LongForm)                      | [URL](https://arxiv.org/abs/2304.08460)                                                                                   | No information provided and subset-dependent, [URL](https://github.com/akoksal/LongForm) |
 | LIMA         | Finetuning  | 1,084 samples       | [URL](https://huggingface.co/datasets/GAIR/lima)                | [URL](https://arxiv.org/abs/2305.11206)                                                                                   | "If the source data of LIMA has a stricter license than CC BY-NC-SA, the LIMA dataset follows the same. Otherwise, it follows the CC BY-NC-SA license", [URL](https://huggingface.co/datasets/GAIR/lima#license) |
 | OpenWeb Text | Pretraining | 8,013,769 documents | [URL](https://github.com/jcpeterson/openwebtext)                | [URL](https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf) | Unspecified                                                                                                                                                                                                      |
 | RedPajama    | Pretraining | 1.2 T tokens        | [URL](https://github.com/togethercomputer/RedPajama-Data)       | [URL](https://together.ai/blog/redpajama-models-v1)                                                                       | Subset-dependent, [URL](https://github.com/togethercomputer/RedPajama-Data#license)                                                                                                                              |                                                                     |   |
@@ -94,7 +95,36 @@ and responses, set `--include_multiturn_conversations True`.
 
 &nbsp;
 
-**Finetuning After Data Preparation**
+### LongForm
+
+LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper by Köksal et al.](https://arxiv.org/abs/2304.08460).
+
+LongForm consists of 23,652 training samples, 2,042 validation samples, and 2,045 test samples. (In Lit-GPT, the validation samples are currently not used.)
+
+The more detailed dataset composition is as follows based on a table taken from the [dataset repository](https://github.com/akoksal/LongForm):
+
+| **Type**               | **Source**     | **Number of Examples** |
+|------------------------|----------------|------------------------|
+| **Corpora**            | C4             | 10,000                 |
+|                        | Wikipedia      | 5,000                  |
+| **Structured Corpora** | Stack Exchange | 4,380                  |
+|                        | WikiHow        | 2,500                  |
+| **Tasks**              | NIv2           | 3,684                  |
+|                        | Big Bench      | 600                    |
+|                        | BEA-GEC        | 1,203                  |
+|                        | Enron          | 372                    |
+| **Total**              |                | 27,739                 |
+|  |   |  |
+| **Train**              |                | 23,652                 |
+| **Validation**         |                | 2,042                  |
+| **Test**               |                | 2,045                  |
+
+License information is not provided but would depend on the individual subsets listed above.
+
+
+&nbsp;
+
+## Finetuning After Data Preparation
 
 After preparing the dataset, you can finetune the model using the [`finetune/*.py`](../finetune/) scripts, for example,
 
@@ -112,100 +142,7 @@ Please read the [tutorials/finetune_*.md](../tutorials) documents for more infor
 
 > [!IMPORTANT]
 > By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,
-> you can try to lower the context length by preparing the dataset with a fixed max length, for example, `python scripts/prepare_lima.py --max_seq_length 2048`. Alternatvively, you can edit the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
-
-&nbsp;
-
-## Preparing Custom Datasets for Instruction Finetuning
-
-The models in Lit-GPT expect datasets for instruction finetuning in the following format:
-
-```
-[
-    {
-        "instruction": "Write a limerick about a
-                        pelican.”,
-        "input": "",
-        "output": "There once was a pelican so fine,
-                   \nHis beak was as colorful as
-                   sunshine,\nHe would fish all day,\nIn
-                   a very unique way,\nThis pelican was
-                   truly divine!\n\n\n"
-    },
-    {
-        "instruction": "Identify the odd one out from
-                        the group.",
-        "input": "Carrot, Apple, Banana, Grape",
-        "output": "Carrot\n\n"
-    },
-]
-```
-(Note that epending on the task, the `"input"` text can be an empty string, as shown above.)
-
-Custom datasets can be prepared by either creating a new `scripts/prepare_dataset.py` script or reading the dataset
-from a CSV file.
-
-&nbsp;
-
-### Preparing Custom Datasets From a CSV File
-
-You can prepare custom dataset using a CSV file with the following columns:
-
-- `instruction`: Column which will describe the task.
-- `input`: A string holding a special input value for the instruction. This applies to some samples, and in others, this is empty (empty string).
-- `output`: The expected response
-
-> If any of the columns is missing, then the script will fail to create the dataset.
-
-Before you finetune, prepare the dataset using the `prepare_csv.py` script:
-
-```bash
-python scripts/prepare_csv.py --csv_path path/to/the/file.csv
-```
-You can also customize the dataset generation by using these additional parameters
-
-- `destination_path`: The folder where the binary data will be saved. By default, it is saved inside `data/csv`
-
-- `checkpoint_dir`: The model checkpoint dir. It will use the model's tokenizer to load and convert the string to input ids. Defaults to `"checkpoints/stabilityai/stablelm-base-alpha-3b"`
-
-- `test_split_fraction`: The fraction of the data to split. Defaults to `0.1`
-
-- `seed`: The seed value to reproduce the same random splits for train and test data.
-
-- `mask_inputs`: Whether we require any masking or not.
-
-- `ignore_index`: Mask out all the tokens after this index when preparing the dataset.
-
-To use the the settings described above, you can add the respective command line arguments when calling `prepare_csv.py` as shown in the example below:
-
-```bash
-python scripts/prepare_csv.py --csv_path test_data.csv \
---destination_path data/csv \
---checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
---test_split_fraction 0.1 \
---seed 42 \
---mask_inputs false \
---ignore_index -1
-```
-Replace `test_data.csv` with your CSV path and the other additional parameters accordingly. Executing the command above will save `train.pt` and `test.pt` on your disk at the `destination_path`. Now you can use the prepared data to [finetune your model](https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/finetune_lora.md#running-the-finetuning).
-
-&nbsp;
-
-### Preparing Custom Datasets Using a Dataset Prepration Script
-
-If you don't have a CSV file following the format described in the previous section, the easiest way to prepare a new dataset is to copy and modify one of the existing dataset preparation scripts:
-
-- [`scripts/prepare_alpaca.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_alpaca.py) (if you plan to load a dataset from a JSON file);
-- [`scripts/prepare_lima.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_lima.py) (if you plan to load a dataset using the `datasets` Python library).
-
-These scripts may look intimidating at first glance since they include code for tokenizing the dataset for a specific LLM that is provided via a checkpoint directory. However, note that you only need to modify a small fraction of the code file, namely the portion that downloads and formats the training data.
-
-In [`scripts/prepare_lima.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_lima.py), the [line 26](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_lima.py#L26) references the HF repo ID, and the lines [50-53](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_lima.py#L50-L53) save the dataset as `train_data`. Here, `train_data` is a list that contains the instruction examples in the format mentioned above.
-
-
-In [`scripts/prepare_alpaca.py`](https://github.com/Lightning-AI/lit-gpt/blob/main/scripts/prepare_alpaca.py), you only need to modify [lines 24-25](https://github.com/Lightning-AI/lit-gpt/blob/98fad263a62e5e57821de817bdd5e316abfb34d4/scripts/prepare_alpaca.py#L24-L25) for the file name and URL, assuming the JSON file you are working with has the same format as the [Alpaca JSON file](https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json).
-
-
+> you can try to lower the context length by editing the  [`finetune/lora.py` file](https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L37) and change `override_max_seq_length = None` to `override_max_seq_length = 2048`.
 
 &nbsp;
 


### PR DESCRIPTION
Adds the LongForm dataset.


LongForm is a semi-synthetic dataset based on raw text corpora for which the instructions were generated via an LLM. For more details about the instruction-generation process, please refer to the [LongForm research paper](https://arxiv.org/abs/2304.08460) by Köksal et al. According to the research paper, a Llama 7B model trained on LongForm achieves substantially better performance than the same Llama model trained on the 2x larger Alpaca dataset.

LongForm consists of 23,652 training samples, 2,042 validation samples, and 2,045 test samples. (In Lit-GPT, the validation samples are currently not used.)

The more detailed dataset composition is as follows based on a table taken from the [dataset repository](https://github.com/akoksal/LongForm):

| **Type**               | **Source**     | **Number of Examples** |
|------------------------|----------------|------------------------|
| **Corpora**            | C4             | 10,000                 |
|                        | Wikipedia      | 5,000                  |
| **Structured Corpora** | Stack Exchange | 4,380                  |
|                        | WikiHow        | 2,500                  |
| **Tasks**              | NIv2           | 3,684                  |
|                        | Big Bench      | 600                    |
|                        | BEA-GEC        | 1,203                  |
|                        | Enron          | 372                    |
| **Total**              |                | 27,739                 |
|  |   |  |
| **Train**              |                | 23,652                 |
| **Validation**         |                | 2,042                  |
| **Test**               |                | 2,045                  |

License information is not provided but would depend on the individual subsets listed above.


