### PR TITLE
Drop custom CSV logger implementation

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
@@ -23,7 +24,6 @@ from lit_gpt.utils import (
     get_default_supported_precision,
     lazy_load,
     num_parameters,
-    step_csv_logger,
 )
 from scripts.prepare_alpaca import generate_prompt
 
@@ -69,7 +69,7 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
@@ -23,7 +24,6 @@ from lit_gpt.utils import (
     get_default_supported_precision,
     lazy_load,
     num_parameters,
-    step_csv_logger,
 )
 from scripts.prepare_alpaca import generate_prompt
 
@@ -69,7 +69,7 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import lightning as L
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
@@ -23,7 +24,6 @@ from lit_gpt.utils import (
     get_default_supported_precision,
     load_checkpoint,
     num_parameters,
-    step_csv_logger,
 )
 from scripts.prepare_alpaca import generate_prompt
 
@@ -69,7 +69,7 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Literal, Optional, Tuple
 
 import lightning as L
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
@@ -24,7 +25,6 @@ from lit_gpt.utils import (
     load_checkpoint,
     num_parameters,
     quantization,
-    step_csv_logger,
 )
 from scripts.prepare_alpaca import generate_prompt
 
@@ -82,7 +82,7 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=fabric_devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.print(hparams)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir, quantize)

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -8,7 +8,7 @@ from functools import partial
 from io import BytesIO
 from pathlib import Path
 from types import MethodType
-from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, Set
 
 import torch
 import torch.nn as nn
@@ -411,36 +411,6 @@ class incremental_save:
 
 
 T = TypeVar("T")
-
-
-def step_csv_logger(*args: Any, cls: Type[T] = CSVLogger, **kwargs: Any) -> T:
-    logger = cls(*args, **kwargs)
-
-    def merge_by(dicts, key):
-        from collections import defaultdict
-
-        out = defaultdict(dict)
-        for d in dicts:
-            if key in d:
-                out[d[key]].update(d)
-        return [v for _, v in sorted(out.items())]
-
-    def save(self) -> None:
-        """Overridden to merge CSV by the step number."""
-        import csv
-
-        if not self.metrics:
-            return
-        metrics = merge_by(self.metrics, "step")
-        keys = sorted({k for m in metrics for k in m})
-        with self._fs.open(self.metrics_file_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=keys)
-            writer.writeheader()
-            writer.writerows(metrics)
-
-    logger.experiment.save = MethodType(save, logger.experiment)
-
-    return logger
 
 
 def chunked_cross_entropy(

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -7,13 +7,11 @@ from contextlib import contextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from types import MethodType
-from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, Set
+from typing import Dict, List, Mapping, Optional, TypeVar, Union
 
 import torch
 import torch.nn as nn
 import torch.utils._device
-from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.utilities.load import _lazy_load
 from torch.serialization import normalize_storage_type
 

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 import lightning as L
 import numpy as np
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 from torch.utils.data import DataLoader, IterableDataset
 
@@ -18,7 +19,7 @@ from lit_gpt import Config
 from lit_gpt.model import GPT, Block
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters
 
 model_name = "pythia-70m"
 name = "openwebtext"
@@ -46,7 +47,7 @@ lr_decay_iters = max_iters
 min_lr = 6e-5
 
 hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str)) and not k.startswith("_")}
-logger = step_csv_logger("out", name, flush_logs_every_n_steps=log_interval)
+logger = CSVLogger("out", name, flush_logs_every_n_steps=log_interval)
 
 
 def setup(devices: int = 1, precision: Optional[str] = None, resume: Union[bool, Path] = False) -> None:

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -19,7 +19,7 @@ sys.path.append(str(wd))
 from lit_gpt import Config
 from lit_gpt.model import GPT, Block
 from lit_gpt.speed_monitor import SpeedMonitorCallback, estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision
 
 model_name = "pythia-70m"
 name = "openwebtext"
@@ -115,7 +115,7 @@ def main(devices: int = 1, precision: Optional[str] = None) -> None:
     else:
         strategy = "auto"
 
-    logger = step_csv_logger("out", name, cls=CSVLogger, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger("out", name, flush_logs_every_n_steps=log_interval)
     speed_monitor = SpeedMonitorCallback(
         length_fn=lambda batch: batch[0].size(1), batch_size=micro_batch_size, window_size=50, time_unit="seconds"
     )

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, Union
 
 import lightning as L
 import torch
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import FSDPStrategy
 from torch.utils.data import DataLoader
 
@@ -18,7 +19,7 @@ from lit_gpt.model import GPT, Block, Config
 from lit_gpt.packed_dataset import CombinedDataset, PackedDataset
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
-from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters, step_csv_logger
+from lit_gpt.utils import chunked_cross_entropy, get_default_supported_precision, num_parameters
 
 model_name = "Llama-2-7b-hf"
 name = "redpajama"
@@ -57,7 +58,7 @@ data_config = [
 ]
 
 hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str)) and not k.startswith("_")}
-logger = step_csv_logger("out", name, flush_logs_every_n_steps=log_interval)
+logger = CSVLogger("out", name, flush_logs_every_n_steps=log_interval)
 
 
 def setup(

--- a/xla/finetune/adapter.py
+++ b/xla/finetune/adapter.py
@@ -8,6 +8,7 @@ import lightning as L
 import torch
 import torch_xla.core.xla_model as xm
 from lightning.fabric.accelerators import XLAAccelerator
+from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.strategies import XLAFSDPStrategy
 
 # support running without installing as a package
@@ -18,7 +19,7 @@ from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapte
 from lit_gpt.speed_monitor import SpeedMonitorFabric as SpeedMonitor
 from lit_gpt.speed_monitor import estimate_flops, measure_flops
 from lit_gpt.tokenizer import Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters, step_csv_logger
+from lit_gpt.utils import check_valid_checkpoint_dir, chunked_cross_entropy, lazy_load, num_parameters
 from scripts.prepare_alpaca import generate_prompt
 from xla.generate.base import generate
 from xla.utils import rank_print, sequential_load_and_fsdp_wrap
@@ -64,7 +65,7 @@ def setup(
         )
     else:
         strategy = "auto"
-    logger = step_csv_logger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
     rank_print(fabric, hparams)
     fabric.launch(main, data_dir, checkpoint_dir, out_dir)


### PR DESCRIPTION
The custom implementation in this repo has the issue fixed in https://github.com/Lightning-AI/lightning/pull/18567

Since we no longer keep the full metrics history in memory and write it every time, it's not straightforward to do the aggregation by `step` on the go.

This PR removes it, the csv file can be post-processed after training with something like:

```py
import pandas as pd
df = pd.read_csv('metrics.csv')
combined_df = df.groupby('step').sum()
print(combined_df)
```