### PR TITLE
Remove redundant {}

### DIFF
--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -167,7 +167,7 @@ python scripts/merge_lora.py \
 After merging, we can use the `base.py` file for inference using the new checkpoint file. Note that if your new checkpoint directory is different from the original checkpoint directory, we also have to copy over the tokenizer and config files:
 
 ```bash
-cp checkpoints/stabilityai/stablelm-base-alpha-3b/{*.json} \
+cp checkpoints/stabilityai/stablelm-base-alpha-3b/*.json \
 out/lora_merged/stablelm-base-alpha-3b/
 ```
 


### PR DESCRIPTION
Just saw your comment @carmocca . Yes, that {} is redundant.