### PR TITLE
Mention that the numbers in markdowns were obtained with CUDA 11.8

### DIFF
--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -1,7 +1,7 @@
 # Finetuning with LoRA / QLoRA
 
 [Low-rank adaption (LoRA)](https://arxiv.org/abs/2106.09685) is a technique to approximate the update to the linear layers in a LLM with a low-rank matrix factorization. This significantly reduces the number of trainable parameters and speeds up training with little impact on the final performance of the model.
-We demonstrate this method by instruction-finetuning Lit-GPT StableLM 3B on the [Alpaca](https://github.com/tatsu-lab/stanford_alpaca) dataset on a **single RTX 3090 (24GB) GPU**.
+We demonstrate this method by instruction-finetuning Lit-GPT StableLM 3B on the [Alpaca](https://github.com/tatsu-lab/stanford_alpaca) dataset on a **single RTX 3090 (24GB) GPU** with CUDA 11.8.
 
 &nbsp;
 

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -2,7 +2,7 @@
 
 This document provides different strategies for quantizing the various models available in Lit-GPT to reduce GPU memory usage, which is useful for running larger models on certain GPU hardware.
 
-**All the examples below were run on an A100 40GB GPU.**
+**All the examples below were run on an A100 40GB GPU with CUDA 11.8.**
 
 > [!NOTE]
 > Quantization also supports finetuning via [QLoRA](finetune_lora.md)

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -2,7 +2,7 @@
 
 This document provides different strategies for quantizing the various models available in Lit-GPT to reduce GPU memory usage, which is useful for running larger models on certain GPU hardware.
 
-**All the examples below were run on an A100 40GB GPU with CUDA 11.8.**
+**All the examples below were run on an A100 40GB GPU with CUDA 12.1.**
 
 > [!NOTE]
 > Quantization also supports finetuning via [QLoRA](finetune_lora.md)


### PR DESCRIPTION
Hi there 👋 

Part of #622 

Essentially `tutorials/finetune_lora.md` and `tutorials/quantize.md` contain times required to train and generate respectively, but they were obtained with CUDA v11.8, and the current main installs CUDA v12.1. On the latest version a hardware utilization is better and thus the time to train/generate should be smaller. 

Before the numbers are updated with the latest version of CUDA I think it's important to mention the version on which they were obtained.