### PR TITLE
A badge with supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 -->
 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)
 ![cpu-tests](https://github.com/lightning-AI/lit-stablelm/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/lit-stablelm/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/1077906959069626439?style=plastic)](https://discord.gg/VptPCZkGNa)
 
 <img src="https://pl-public-data.s3.amazonaws.com/assets_lightning/LitStableLM.gif" alt="Lit-GPT and pineapple pizza" width="500px"/>


### PR DESCRIPTION
Hello there 👋 

Part of #511.

### Motivation

Someone might want to use `Lit-GPT` as a part of an existing project. If it's a mature commercial project, then most likely it's using a specific version of Python, which will not be updated any time soon. As a result, it might be helpful for such a person to know what Python versions are supported.

### Solution

For the core functionality, the main restrictor is `Lightning`, so I decided for simplicity to reuse the badge from PyTorch-Lightning repo. 

### Caveats

As seen in [these](https://github.com/Andrei-Aksionov/lit-gpt/actions/runs/6468597163/job/17560942575) GitHub Actions, only 3.9-3.11 are supported.
3.12 is not supported as, for now, it's not possible to install PyTorch with this version of Python. Soon-to-release version of Lightning will support only up to 3.11, so the badge from that repo will fit our needs.

*Now, why 3.8 is not supported?*
This is because of [lm-eval](https://github.com/EleutherAI/lm-evaluation-harness.git@master) repo, that supports 3.9+.

**Since it's an extra package, is it ok to not count it when deciding what Python versions are supported?** 