### PR TITLE
Fix resuming checkpoint path bug

### DIFF
--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -101,7 +101,7 @@ def main(fabric: L.Fabric, resume: Union[bool, Path]) -> None:
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")[1]))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -101,7 +101,7 @@ def main(fabric: L.Fabric, resume: Union[bool, Path]) -> None:
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -101,7 +101,7 @@ def main(fabric: L.Fabric, resume: Union[bool, Path]) -> None:
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")[1]))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -101,7 +101,7 @@ def main(fabric: L.Fabric, resume: Union[bool, Path]) -> None:
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))[-1]
+        resume = max(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -127,7 +127,7 @@ def main(fabric: L.Fabric, train_data_dir: Path, val_data_dir: Path, resume: Uni
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")[1]))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -127,7 +127,7 @@ def main(fabric: L.Fabric, train_data_dir: Path, val_data_dir: Path, resume: Uni
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")[1]))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -127,7 +127,7 @@ def main(fabric: L.Fabric, train_data_dir: Path, val_data_dir: Path, resume: Uni
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"))[-1]
+        resume = sorted(out_dir.glob("*.pth"), key=lambda x: int(x.name.split("-")))[-1]
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -127,7 +127,7 @@ def main(fabric: L.Fabric, train_data_dir: Path, val_data_dir: Path, resume: Uni
     state = {"model": model, "optimizer": optimizer, "hparams": hparams, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = sorted(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))[-1]
+        resume = max(out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)


### PR DESCRIPTION
Minor fix to resuming checkpoint path . Currently, resuming takes the last path of the sorted list. However, the sorted list may not return a list sorted in ascending `iter_num`. For example,

```
from pathlib import Path
out_dir = Path("out") / "openwebtext"
paths = [out_dir / f"iter-{iter_num}-ckpt.pth" for iter_num in range(0, 1100000, 40000)]
print(sorted(paths))
```
returns the following. Note that the list isn't sorted (i.e. `iter-1080000` should be the last, but it isn't). Thus resuming will not take the latest checkpoint in this case.
```
[PosixPath('out/openwebtext/iter-0-ckpt.pth'), PosixPath('out/openwebtext/iter-1000000-ckpt.pth'), PosixPath('out/openwebtext/iter-1040000-ckpt.pth'), PosixPath('out/openwebtext/iter-1080000-ckpt.pth'), PosixPath('out/openwebtext/iter-120000-ckpt.pth'), PosixPath('out/openwebtext/iter-160000-ckpt.pth'), PosixPath('out/openwebtext/iter-200000-ckpt.pth'), PosixPath('out/openwebtext/iter-240000-ckpt.pth'), PosixPath('out/openwebtext/iter-280000-ckpt.pth'), PosixPath('out/openwebtext/iter-320000-ckpt.pth'), PosixPath('out/openwebtext/iter-360000-ckpt.pth'), PosixPath('out/openwebtext/iter-40000-ckpt.pth'), PosixPath('out/openwebtext/iter-400000-ckpt.pth'), PosixPath('out/openwebtext/iter-440000-ckpt.pth'), PosixPath('out/openwebtext/iter-480000-ckpt.pth'), PosixPath('out/openwebtext/iter-520000-ckpt.pth'), PosixPath('out/openwebtext/iter-560000-ckpt.pth'), PosixPath('out/openwebtext/iter-600000-ckpt.pth'), PosixPath('out/openwebtext/iter-640000-ckpt.pth'), PosixPath('out/openwebtext/iter-680000-ckpt.pth'), PosixPath('out/openwebtext/iter-720000-ckpt.pth'), PosixPath('out/openwebtext/iter-760000-ckpt.pth'), PosixPath('out/openwebtext/iter-80000-ckpt.pth'), PosixPath('out/openwebtext/iter-800000-ckpt.pth'), PosixPath('out/openwebtext/iter-840000-ckpt.pth'), PosixPath('out/openwebtext/iter-880000-ckpt.pth'), PosixPath('out/openwebtext/iter-920000-ckpt.pth'), PosixPath('out/openwebtext/iter-960000-ckpt.pth')]
```