### PR TITLE
Drop flash-attn 2 in favor of PyTorch's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ Install with all dependencies (including quantization, sentencepiece, tokenizers
 pip install -r requirements-all.txt
 ```
 
-**(Optional) install Flash Attention 2**
+**(Optional) Use Flash Attention 2 (only available in PyTorch 2.2)**
 
 ```bash
-MAX_JOBS=4 pip install flash-attn --no-build-isolation
+pip uninstall -y torch
+pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
 ```
 
 You are all set! 🎉

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -13,8 +13,6 @@ from typing_extensions import Self
 
 from lit_gpt.config import Config
 
-FlashAttention2Available = bool(RequirementCache("flash-attn>=2.0.0.post1"))
-
 
 class GPT(nn.Module):
     def __init__(self, config: Config) -> None:
@@ -234,19 +232,6 @@ class CausalSelfAttention(nn.Module):
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         scale = 1.0 / math.sqrt(self.config.head_size)
-        if (
-            FlashAttention2Available
-            and mask is None
-            and q.device.type == "cuda"
-            and q.dtype in (torch.float16, torch.bfloat16)
-        ):
-            from flash_attn import flash_attn_func
-
-            # flash-attn requires (B, T, nh, hs)
-            q = q.transpose(1, 2)
-            k = k.transpose(1, 2)
-            v = v.transpose(1, 2)
-            return flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=scale, causal=True)
         y = torch.nn.functional.scaled_dot_product_attention(
             q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
         )

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -8,7 +8,6 @@ from typing import Any, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from lightning_utilities.core.imports import RequirementCache
 from typing_extensions import Self
 
 from lit_gpt.config import Config


### PR DESCRIPTION
Closes #395
Closes #637

For now, the inconvenience of compiling `flash-attn` is not worth it, and there are other speed benefits in using torch 2.2 anyway. This can be re-evaluated in the future if `flash-attn` becomes faster again, or we decide to use a more custom kernel from theirs.