### PR TITLE
Remove FLOPs calculation from finetuning scripts

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -136,23 +136,6 @@ def train(
 
     validate(fabric, model, val_data, tokenizer)  # sanity check
 
-    with torch.device("meta"):
-        meta_model = GPT(model.config)
-        mark_only_adapter_as_trainable(meta_model)
-        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
-        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `flops_per_batch=estimated_flops` instead
-        estimated_flops = estimate_flops(meta_model, training=True) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # this assumes that all samples have a fixed length equal to the longest sequence length
-        # which is most likely false during finetuning
-        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
-        forward_fn = lambda: meta_model(x)
-        loss_fn = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
-        measured_flops = measure_flops(meta_model, forward_fn, loss_fn)
-        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
-        del meta_model, x
-
     throughput = ThroughputMonitor(fabric, window_size=50)
     step_count = 0
     total_lengths = 0
@@ -190,7 +173,6 @@ def train(
                 time=t1 - total_t0,
                 samples=(iter_num + 1) * micro_batch_size,
                 lengths=total_lengths,
-                flops_per_batch=measured_flops,
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -136,23 +136,6 @@ def train(
 
     validate(fabric, model, val_data, tokenizer)  # sanity check
 
-    with torch.device("meta"):
-        meta_model = GPT(model.config)
-        mark_only_adapter_v2_as_trainable(meta_model)
-        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
-        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `flops_per_batch=estimated_flops` instead
-        estimated_flops = estimate_flops(meta_model, training=True) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # this assumes that all samples have a fixed length equal to the longest sequence length
-        # which is most likely false during finetuning
-        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
-        forward_fn = lambda: meta_model(x)
-        loss_fn = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
-        measured_flops = measure_flops(meta_model, forward_fn, loss_fn)
-        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
-        del meta_model, x
-
     throughput = ThroughputMonitor(fabric, window_size=50)
     step_count = 0
     total_lengths = 0
@@ -190,7 +173,6 @@ def train(
                 time=t1 - total_t0,
                 samples=(iter_num + 1) * micro_batch_size,
                 lengths=total_lengths,
-                flops_per_batch=measured_flops,
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -132,22 +132,6 @@ def train(
 
     validate(fabric, model, val_data, tokenizer)  # sanity check
 
-    with torch.device("meta"):
-        meta_model = GPT(model.config)
-        # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
-        # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
-        # consider passing `flops_per_batch=estimated_flops` instead
-        estimated_flops = estimate_flops(meta_model, training=True) * micro_batch_size
-        fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        # this assumes that all samples have a fixed length equal to the longest sequence length
-        # which is most likely false during finetuning
-        x = torch.randint(0, 1, (micro_batch_size, longest_seq_length))
-        forward_fn = lambda: meta_model(x)
-        loss_fn = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
-        measured_flops = measure_flops(meta_model, forward_fn, loss_fn)
-        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
-        del meta_model, x
-
     throughput = ThroughputMonitor(fabric, window_size=50)
     step_count = 0
     total_lengths = 0
@@ -184,7 +168,6 @@ def train(
                 time=t1 - total_t0,
                 samples=(iter_num + 1) * micro_batch_size,
                 lengths=total_lengths,
-                flops_per_batch=measured_flops,
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(


### PR DESCRIPTION
The current FLOPs per batch computation assumes that all batches have a sequence length (`T`) equal to the longest in the dataset.

This is very far from true when using our finetuning datasets and scripts (see the histograms at https://github.com/Lightning-AI/lit-gpt/blob/main/tutorials/prepare_dataset.md). The magnitude of this depends on the `max_seq_length` value used when preparing the dataset.

This default behavior of the dataset preparation scripts results in extremely unrealistic (optimistic) FLOPs and MFU values. This PR removes them to avoid confusion.

An alternative to this solution would be to get the estimated/measured flops per batch, but this would have an overhead per iteration (https://github.com/Lightning-AI/lit-gpt/pull/409 tried this)

The XLA finetuning script is unchanged because it pads the data to the longest length in the dataset.