### PR TITLE
Tokenizer usability improvements

### DIFF
--- a/lit_gpt/tokenizer.py
+++ b/lit_gpt/tokenizer.py
@@ -6,7 +6,11 @@ import torch
 
 
 class Tokenizer:
-    def __init__(self, checkpoint_dir: Path) -> None:
+    def __init__(self, checkpoint_dir: Path | str) -> None:
+        checkpoint_dir = Path(checkpoint_dir)
+        if not checkpoint_dir.exists():
+            raise NotADirectoryError(f"The checkpoint directory does not exist: {str(checkpoint_dir)}")
+
         self.use_bos = self.check_if_bos_token_used(checkpoint_dir)
         self.bos_id = None
         self.eos_id = None

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -70,3 +70,10 @@ def test_tokenizer_against_hf(config):
     expected = theirs.encode(prompt)
     assert actual.tolist() == expected
     assert ours.decode(actual) == theirs.decode(expected, skip_special_tokens=True)
+
+
+def test_tokenizer_input_validation():
+    from lit_gpt.tokenizer import Tokenizer
+
+    with pytest.raises(NotADirectoryError, match="The checkpoint directory does not exist"):
+        Tokenizer("cocofruit")


### PR DESCRIPTION
Two small improvements:

- If the checkpoint directory does not exist, show a meaningful error (instead of the NotImplementedError)
- Allow passing in a string for a path, rather than just pathlib Path


cc @carmocca 