### PR TITLE
RedPajama Pretrain Tutorial: add skipped step with converting HF checkpoint to Lit-GPT format

### DIFF
--- a/tutorials/pretrain_redpajama.md
+++ b/tutorials/pretrain_redpajama.md
@@ -48,7 +48,7 @@ git clone https://huggingface.co/datasets/togethercomputer/RedPajama-Data-1T-Sam
 
 The full dataset consists of 2084 `jsonl` files (the sample dataset contains 11). In order to start pretraining lit-gpt
 on it, you need to read, tokenize, and write the data in binary chunks. This will leverage the `PackedDataset`
-streaming dataset that comes with lit-gpt. You will need to have the tokenizer config available:
+streaming dataset that comes with lit-gpt. You will need to have the tokenizer config available (downloaded and converted to lit-gpt format):
 
 ```bash
 pip install huggingface_hub sentencepiece
@@ -56,6 +56,9 @@ pip install huggingface_hub sentencepiece
 python scripts/download.py \
    --repo_id meta-llama/Llama-2-7b-chat-hf \
    --access_token your_hf_token
+
+python scripts/convert_hf_checkpoint.py \
+    --checkpoint_dir checkpoints/meta-llama/Llama-2-7b-hf/
 ```
 
 Then, run


### PR DESCRIPTION
Hi there 👋 

If someone wants to pretrain the model on RedPajama and uses for it `tutorials/pretrain_redpajama.md`, then he/she might get this error:
> No such file or directory: lit_config.json

As it happened to the user in #718.

The reason that the tutorial tells to download the model and use it right away, but the prepare script is expecting `lit_config.json`
https://github.com/Lightning-AI/lit-gpt/blob/96666c3850741f7182f5c826e1528469d884829a/scripts/prepare_redpajama.py#L150

That's why the conversion code snippet is added to the tutorial.