### PR TITLE
Add flag to download the tokenizer only

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -14,7 +14,10 @@ _SAFETENSORS_AVAILABLE = RequirementCache("safetensors")
 
 
 def download_from_hub(
-    repo_id: Optional[str] = None, access_token: Optional[str] = os.getenv("HF_TOKEN"), from_safetensors: bool = False
+    repo_id: Optional[str] = None,
+    access_token: Optional[str] = os.getenv("HF_TOKEN"),
+    from_safetensors: bool = False,
+    tokenizer_only: bool = True,
 ) -> None:
     if repo_id is None:
         from lit_gpt.config import configs
@@ -34,12 +37,16 @@ def download_from_hub(
         )
 
     download_files = ["tokenizer*", "generation_config.json"]
-    if from_safetensors:
-        if not _SAFETENSORS_AVAILABLE:
-            raise ModuleNotFoundError(str(_SAFETENSORS_AVAILABLE))
-        download_files.append("*.safetensors")
-    else:
-        download_files.append("*.bin*")
+    if not tokenizer_only:
+        if from_safetensors:
+            if not _SAFETENSORS_AVAILABLE:
+                raise ModuleNotFoundError(str(_SAFETENSORS_AVAILABLE))
+            download_files.append("*.safetensors")
+        else:
+            # covers `.bin` files and `.bin.index.json`
+            download_files.append("*.bin*")
+    elif from_safetensors:
+        raise ValueError("`--from_safetensors=True` won't have an effect with `--tokenizer_only=True`")
 
     directory = Path("checkpoints") / repo_id
     snapshot_download(

--- a/tutorials/pretrain_redpajama.md
+++ b/tutorials/pretrain_redpajama.md
@@ -55,7 +55,8 @@ pip install huggingface_hub sentencepiece
 
 python scripts/download.py \
    --repo_id meta-llama/Llama-2-7b-chat-hf \
-   --access_token your_hf_token
+   --access_token your_hf_token \
+   --tokenizer_only true
 ```
 
 Then, run


### PR DESCRIPTION
During pre-training, downloading the full model weights of an existing checkpoint is unnecessary when one only wants the tokenizer to preprocess the dataset.