### PR TITLE
Fix top_k bug with collisions

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -66,8 +66,8 @@ def generate(
 
         # optionally crop the logits to only the top k options
         if top_k is not None:
-            v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-            logits = torch.where(logits < v[[-1]], -float("Inf"), logits)
+            v, i = torch.topk(logits, min(top_k, logits.size(-1)))
+            logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
 
         probs = torch.nn.functional.softmax(logits, dim=-1)
         idx = torch.multinomial(probs, num_samples=1)

--- a/chat/base.py
+++ b/chat/base.py
@@ -67,6 +67,7 @@ def generate(
         # optionally crop the logits to only the top k options
         if top_k is not None:
             v, i = torch.topk(logits, min(top_k, logits.size(-1)))
+            # do not use `torch.where` as in nanogpt because it will repeat top-k collisions
             logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
 
         probs = torch.nn.functional.softmax(logits, dim=-1)

--- a/generate/base.py
+++ b/generate/base.py
@@ -70,6 +70,7 @@ def generate(
         # optionally crop the logits to only the top k options
         if top_k is not None:
             v, i = torch.topk(logits, min(top_k, logits.size(-1)))
+            # do not use `torch.where` as in nanogpt because it will repeat top-k collisions
             logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
 
         probs = torch.nn.functional.softmax(logits, dim=-1)

--- a/generate/base.py
+++ b/generate/base.py
@@ -69,8 +69,8 @@ def generate(
 
         # optionally crop the logits to only the top k options
         if top_k is not None:
-            v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-            logits = torch.where(logits < v[[-1]], -float("Inf"), logits)
+            v, i = torch.topk(logits, min(top_k, logits.size(-1)))
+            logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
 
         probs = torch.nn.functional.softmax(logits, dim=-1)
         idx_next = torch.multinomial(probs, num_samples=1).to(dtype=dtype)


### PR DESCRIPTION
This script shows the issue:

```python
import torch

top_k = 2
for _ in range(10):
    logits = torch.randint(0, 50, (1, 5, 6))
    logits = logits[:, -1]
    top_k = min(top_k, logits.size(-1))
    print(f"{top_k=}")

    print(f"{logits=}")

    v, _ = torch.topk(logits, top_k)
    original = torch.where(logits < v[:, -1:], -999, logits)

    print(f"{original=}")

    v, i = torch.topk(logits, top_k)
    new = torch.full_like(logits, -999).scatter_(-1, i, v)

    print(f"{new}")

    torch.testing.assert_close(original, new)
```

If two or more of the highest k logits have the same value, `torch.where` will return all meaning that sampling is done for more than k elements.

The code should also be faster since we're reusing the top-k indices to scatter the logits

```python
import time

import torch

torch.set_float32_matmul_precision('high')

def bench(f, name=None, iters=100, warmup=10, display=True, profile=False):
    for _ in range(warmup):
        f()
    if profile:
        with torch.profiler.profile() as prof:
            f()
        prof.export_chrome_trace(f"{name if name is not None else 'trace'}.json")

    torch.cuda.synchronize()
    begin = time.time()
    for _ in range(iters):
        f()
    torch.cuda.synchronize()
    us_per_iter = (time.time()-begin)*1e6/iters
    if name is None:
        res = us_per_iter
    else:
        res= f"{name}: {us_per_iter}us"
    if display:
        print(res)
    return res

top_k = 2

def f1(logits):
    v, _ = torch.topk(logits, top_k)
    return torch.where(logits < v[:, -1:], float("-inf"), logits)

def f2(logits):
    v, i = torch.topk(logits, top_k)
    return torch.full_like(logits, float("-inf")).scatter_(-1, i, v)

device = torch.device("cuda")
logits = torch.randn(16, 512, 32000, device=device)[:, -1]

bench(lambda: f1(logits), name="f1")
bench(lambda: f2(logits), name="f2")
# f1: 261.34490966796875us
# f2: 236.01770401000977us
```