### PR TITLE
GPU tests: BNB>=0.41.2 uses quant_state as a class, not as a list

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -1,4 +1,5 @@
 """Utility functions for training and inference."""
+
 import math
 import pickle
 import sys
@@ -57,8 +58,9 @@ def check_valid_checkpoint_dir(checkpoint_dir: Path) -> None:
     files = {
         "lit_model.pth": (checkpoint_dir / "lit_model.pth").is_file(),
         "lit_config.json": (checkpoint_dir / "lit_config.json").is_file(),
-        "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file()
-        or (checkpoint_dir / "tokenizer.model").is_file(),
+        "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file() or (
+            checkpoint_dir / "tokenizer.model"
+        ).is_file(),
         "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
     }
     if checkpoint_dir.is_dir():

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -32,7 +32,7 @@ def num_parameters(module: nn.Module, requires_grad: Optional[bool] = None) -> i
         if requires_grad is None or p.requires_grad == requires_grad:
             if hasattr(p, "quant_state"):
                 # bitsandbytes 4bit layer support
-                total += math.prod(p.quant_state[1])
+                total += math.prod(p.quant_state.shape)
             else:
                 total += p.numel()
     return total
@@ -57,9 +57,8 @@ def check_valid_checkpoint_dir(checkpoint_dir: Path) -> None:
     files = {
         "lit_model.pth": (checkpoint_dir / "lit_model.pth").is_file(),
         "lit_config.json": (checkpoint_dir / "lit_config.json").is_file(),
-        "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file() or (
-            checkpoint_dir / "tokenizer.model"
-        ).is_file(),
+        "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file()
+        or (checkpoint_dir / "tokenizer.model").is_file(),
         "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
     }
     if checkpoint_dir.is_dir():

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-bitsandbytes==0.41.0   # quantization
+bitsandbytes>=0.41.2   # quantization
 scipy          # required by bitsandbytes
 sentencepiece  # pythia, falcon, redpajama
 tokenizers     # llama-based models

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,7 +141,6 @@ def test_num_parameters():
 
 @RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize("mode", ["nf4", "nf4-dq", "fp4", "fp4-dq", "int8", "int8-training"])
-@pytest.mark.skip("To be fixed")
 def test_num_parameters_bitsandbytes(mode):
     from lightning.fabric.plugins import BitsandbytesPrecision
     from lit_gpt import GPT


### PR DESCRIPTION
> [!IMPORTANT]
> It's a duplicate of the same PR #715 to validate GPU tests. Should fail.

Hi there 👋 

Fixes #707 

Bitsandbytes starting from version `0.41.2` uses `quant_state` as a class, not as a list: https://github.com/TimDettmers/bitsandbytes/commit/61a4a20da91b7f780a98d3ff8235f1455835ecf2.

As a result, when trying to access the shape by the index
https://github.com/Lightning-AI/lit-gpt/blob/d9283f420be2ee3b9af77b2e12edf92aa200379e/lit_gpt/utils.py#L35

... we get:
> TypeError: 'QuantState' object is not subscriptable

------

As proposed in #710 maybe we indeed need to pin version of BNB since such breaking changes might appear again?

------

Fixes #736
Fixes #734 ?