### PR TITLE
Bugfix: Corrected loss computation with chunksize > 0

### DIFF
--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -262,7 +262,9 @@ def chunked_cross_entropy(
             torch.nn.functional.cross_entropy(logit_chunk, target_chunk, ignore_index=-1, reduction="none")
             for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
         ]
-        return torch.cat(loss_chunks).mean()
+        non_masked_elems = (targets != -1).sum()
+        mean_loss = torch.cat(loss_chunks).sum() / max(1, non_masked_elems)
+        return mean_loss
 
     # no chunking at all
     logits = logits.reshape(-1, logits.size(-1))
@@ -277,7 +279,9 @@ def chunked_cross_entropy(
         torch.nn.functional.cross_entropy(logit_chunk, target_chunk, ignore_index=-1, reduction="none")
         for logit_chunk, target_chunk in zip(logit_chunks, target_chunks)
     ]
-    return torch.cat(loss_chunks).mean()
+    non_masked_elems = (targets != -1).sum()
+    mean_loss = torch.cat(loss_chunks).sum() / max(1, non_masked_elems)
+    return mean_loss
 
 
 def map_old_state_dict_weights(state_dict: Dict, mapping: Mapping, prefix: str) -> Dict:


### PR DESCRIPTION
This PR resolves an issue in loss computation when chunksize is greater than zero. The correction ensures that only prompts generated by the model contribute to the mean loss computation.

Previously, the mean was calculated across all positions of the sequence, including those within the prompt. In such cases, the loss was automatically set to 0 due to the **correct** use of `torch.nn.functional.cross_entropy` with `ignore_index=-1.` 

However, the subsequent `torch.cat(loss_chunks).mean()` considered all elements of the sequence to compute the mean, leading to an artificial reduction in the loss. This effect becomes more pronounced with longer prompts, as the denominator of the mean increases.