### PR TITLE
Fix seed in all generation scripts.

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -167,6 +167,7 @@ def main(
     tokenizer = Tokenizer(checkpoint_dir)
     system_prompt, stop_tokens = prompt_config(checkpoint_dir, tokenizer)
 
+    L.seed_everything(1234)
     while True:
         try:
             prompt = input(">> Prompt: ")

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -114,6 +114,7 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    L.seed_everything(1234)
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -114,6 +114,7 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    L.seed_everything(1234)
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens

--- a/generate/base.py
+++ b/generate/base.py
@@ -178,11 +178,11 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    L.seed_everything(1234)
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens
 
-    L.seed_everything(1234)
     for i in range(num_samples):
         with fabric.init_tensor():
             # enable the kv cache

--- a/generate/full.py
+++ b/generate/full.py
@@ -110,6 +110,7 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    L.seed_everything(1234)
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -136,6 +136,7 @@ def main(
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens
 
+    L.seed_everything(1234)
     with fabric.init_tensor():
         # set the max_seq_length to limit the memory usage to what we need
         model.max_seq_length = max_returned_tokens


### PR DESCRIPTION
Hi there 👋 

As was asked in #690, a user might expect that the generated text will be consistent from run to tun.
Since the seed was already fixed in `generate/base.py`, this PR extends it to all other generation scripts.