### PR TITLE
Remove code to force `lm_eval` to work under Python 3.8

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -8,6 +8,6 @@ zstandard            # scripts/prepare_redpajama.py, scripts/prepare_starcoder.p
 pandas               # scripts/prepare_csv.py, scripts/prepare_starcoder.py
 pyarrow              # scripts/prepare_starcoder.py
 # eval
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@master; python_version > '3.8'
+git+https://github.com/EleutherAI/lm-evaluation-harness.git@master
 # scripts/prepare_slimpajama.py, scripts/prepare_starcoder.py, pretrain/tinyllama.py
 lightning[data] @ git+https://github.com/Lightning-AI/lightning@4e72dcc8db6a0cbe94042ddbc310340556e8fee7

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -8,6 +8,6 @@ zstandard            # scripts/prepare_redpajama.py, scripts/prepare_starcoder.p
 pandas               # scripts/prepare_csv.py, scripts/prepare_starcoder.py
 pyarrow              # scripts/prepare_starcoder.py
 # eval
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@master
+git+https://github.com/EleutherAI/lm-evaluation-harness.git@115206dc89dad67b8beaa90051fb52db77f0a529
 # scripts/prepare_slimpajama.py, scripts/prepare_starcoder.py, pretrain/tinyllama.py
 lightning[data] @ git+https://github.com/Lightning-AI/lightning@4e72dcc8db6a0cbe94042ddbc310340556e8fee7

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -10,7 +10,6 @@ from conftest import RunIf
 from lightning import Fabric
 
 
-@RunIf(min_python="3.9")
 @pytest.mark.xfail(raises=datasets.builder.DatasetGenerationError, strict=False)  # avoid flakes
 def test_run_eval(tmp_path, float_like):
     from eval.lm_eval_harness import EvalHarnessBase
@@ -52,7 +51,6 @@ def test_run_eval(tmp_path, float_like):
     }
 
 
-@RunIf(min_python="3.9")
 def test_eval_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import eval.lm_eval_harness as module
 
@@ -78,7 +76,6 @@ def test_eval_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     assert (tmp_path / "results.json").read_text() == '{"foo": "test"}'
 
 
-@RunIf(min_python="3.9")
 def test_cli():
     cli_path = Path(__file__).parent.parent / "eval" / "lm_eval_harness.py"
     output = subprocess.check_output([sys.executable, cli_path, "-h"])


### PR DESCRIPTION
Hi there 👋 

Life is interesting.
A couple of days after @carmocca finished [fighting](https://github.com/Lightning-AI/lit-gpt/pull/747) with forcing `lm_eval` to work under Python3.8, the changes [were made](https://github.com/EleutherAI/lm-evaluation-harness/pull/1004) to the 3rd party repo, so now `lm_eval` supports Python3.8 out of-the-box 🎉.

This PR removes specific to that fight changes, as they are no longer needed.