### PR TITLE
Ruff and Black as GitHub workflow.

### DIFF
--- a/.github/workflows/code-style-fix.yml
+++ b/.github/workflows/code-style-fix.yml
@@ -1,0 +1,43 @@
+name: Auto Code-Style Fix
+
+on: [pull_request, pull_request_target]
+
+jobs:
+  code_style_fix:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 🛒️
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.action_secret || secrets.github-token || github.token }}
+
+      - name: Black ◼️
+        uses: psf/black@stable
+        with:
+          options: >
+            --line-length=120
+            --skip-magic-trailing-comma
+            --target-version=py38
+            chat eval finetune generate lit_gpt notebooks pretrain quantize scripts tests xla
+          jupyter: true
+
+      - name: Ruff ®️
+        uses: chartboost/ruff-action@v1
+        with:
+          args: >
+            --select E,W,F,S
+            --extend-select C4,SIM,RET,PT,I001,ANN001,ANN201,ANN205,ANN206,ARG001
+            --ignore E501,E731,S108,S101,S113,S603,PT007,S310,E402,PT004,C408
+            --per-file-ignores "*/**/__init__.py":I001,"tests/*":ANN
+            --line-length 120
+            --target-version py38
+            --fix-only
+
+      - name: Fixing Pull Request 🛠️
+        uses: actions-js/push@v1.4
+        with:
+          branch: ${{ github.head_ref || github.ref_name }}
+          github_token: ${{ secrets.action_secret || secrets.github-token || github.token }}
+          message: "Automated code-style fix."

--- a/.github/workflows/code-style-fix.yml
+++ b/.github/workflows/code-style-fix.yml
@@ -10,8 +10,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.action_secret || secrets.github-token || github.token }}
 
       - name: Black ◼️
         uses: psf/black@stable
@@ -39,5 +37,5 @@ jobs:
         uses: actions-js/push@v1.4
         with:
           branch: ${{ github.head_ref || github.ref_name }}
-          github_token: ${{ secrets.action_secret || secrets.github-token || github.token }}
+          github_token: ${{ secrets.PAT_GHOST }}
           message: "Automated code-style fix."


### PR DESCRIPTION
Hi there 👋 

As discussed in #758.

The objective is to create a github workflow to apply Ruff and Black fixes automatically on each PR and, what's more importantly, without having any config in the root folder (no `.pre-commit-config.yaml` or `pyproject.toml`).

As a baseline I used this [workflow](https://github.com/Lightning-AI/utilities/blob/main/.github/workflows/check-precommit.yml) from the PyTorch-Lightning repo.
With a major change: this PR doesn't use pre-commit whatsoever.

------

The workflow is such:
1. During `Auto Code-Style Fix` workflow Ruff and Black are executed.
2. If any changes are made a new commit is created and pushed.
3. Other workflows either restart and run on the latest commit (after linting) or continue to work in parallel.

-----

Now, step number 3. Why it has two possible outcomes?
That's because of the `github_token`, that is created automatically per each workflow.
And, according to the docs:

> When you use GITHUB_TOKEN in your actions, all of the interactions with the repository are on behalf of the Github-actions bot. The operations act by Github-actions bot cannot trigger a new workflow run.

which means that despite the change in the PR (if Ruff and Black changed files) and `cancel-in-progress` option specified in cpu-tests.yaml, all the remaining workflows will not restart and just continue to work in parallel.

In order to avoid it, we have to use PAT (Personal Access Token) in the workflow.

1. Create a PAT for the repo with “Contents: read and write” permission.
2. Add this PAT to the secrets section of the repo's setting with the name `action-secret`.
3. Add read-write permissions for the bot (repo Settings -> Actions -> General -> Workflow Permissions -> Read and Write permissions).

After that, rerun failed jobs and everything should work. In theory 😊.