### PR TITLE
TinLlama: Update intermediate checkpoint

### DIFF
--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1152,7 +1152,7 @@ for c in mistral:
 tiny_llama = [
     dict(
         name="tiny-llama-1.1b",
-        hf_config=dict(org="PY007", name="TinyLlama-1.1B-intermediate-step-480k-1T"),
+        hf_config=dict(org="TinyLlama", name="TinyLlama-1.1B-intermediate-step-955k-token-2T"),
         block_size=2048,
         vocab_size=32000,
         padding_multiple=64,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,7 @@ def test_from_hf_name():
     # by short-hand name
     config0 = Config.from_name("tiny-llama-1.1b")
     # or by huggingface hub repo name
-    config1 = Config.from_name("TinyLlama-1.1B-intermediate-step-480k-1T")
+    config1 = Config.from_name("TinyLlama-1.1B-intermediate-step-955k-token-2T")
     assert config0 == config1
 
 

--- a/tutorials/download_tinyllama.md
+++ b/tutorials/download_tinyllama.md
@@ -4,16 +4,15 @@
 It is still in development and at the time of writing this, checkpoints for the model trained up to 1T tokens are available.
 The target is to train it for ~3 epochs on 3T tokens total. For more details on the schedule and progress of the pretraining, see the official [README](https://github.com/jzhang38/TinyLlama/tree/main).
 
-
 In order to use the TinyLLama 1.1B model checkpoint, which requires about 5 GB of disk space, download the weights and convert the checkpoint to the lit-gpt format:
 
 ```bash
 pip install huggingface_hub
 
-python scripts/download.py --repo_id PY007/TinyLlama-1.1B-intermediate-step-480k-1T
+python scripts/download.py --repo_id TinyLlama/TinyLlama-1.1B-intermediate-step-955k-token-2T
 
 python scripts/convert_hf_checkpoint.py \
-    --checkpoint_dir checkpoints/PY007/TinyLlama-1.1B-intermediate-step-480k-1T
+    --checkpoint_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-955k-token-2T/
 ```
 
 You're done! To execute the model just run:
@@ -21,5 +20,5 @@ You're done! To execute the model just run:
 ```bash
 pip install sentencepiece
 
-python chat/base.py --checkpoint_dir checkpoints/PY007/TinyLlama-1.1B-intermediate-step-480k-1T
+python chat/base.py --checkpoint_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-955k-token-2T/
 ```


### PR DESCRIPTION
Hi there 👋 

Accidentally noticed that TinyLlama project has a [more recent]() checkpoint available.

In addition, they changed `org name` to a more suitable one.
Though I kinda liked James Bond reference …

Additional question: should we also include `-Chat-v0.x` version? Just don't know why it wasn't added before.