### PR TITLE
Suppress FSDP+dynamo warning

### DIFF
--- a/lit_gpt/__init__.py
+++ b/lit_gpt/__init__.py
@@ -1,3 +1,6 @@
+import re
+import logging
+
 from lit_gpt.model import GPT
 from lit_gpt.config import Config
 from lit_gpt.tokenizer import Tokenizer
@@ -10,6 +13,10 @@ if not bool(_LIGHTNING_AVAILABLE):
         "Lit-GPT requires lightning nightly. Please run:\n"
         f" pip uninstall -y lightning; pip install -r requirements.txt\n{str(_LIGHTNING_AVAILABLE)}"
     )
+
+# Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
+pattern = re.compile(".*Profiler function .* will be ignored")
+logging.getLogger("torch._dynamo.variables.torch").addFilter(lambda record: not pattern.search(record.getMessage()))
 
 
 __all__ = ["GPT", "Config", "Tokenizer"]

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -341,4 +341,11 @@ if __name__ == "__main__":
     if not _TORCH_GREATER_EQUAL_2_2:
         raise ImportError("The tinyllama.py training script requires PyTorch 2.2 (nightly) or higher to run.")
 
+    import re
+    import logging
+
+    # Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
+    pattern = re.compile(".*Profiler function .* will be ignored")
+    logging.getLogger("torch._dynamo.variables.torch").addFilter(lambda record: not pattern.search(record.getMessage()))
+
     CLI(setup)

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -341,11 +341,4 @@ if __name__ == "__main__":
     if not _TORCH_GREATER_EQUAL_2_2:
         raise ImportError("The tinyllama.py training script requires PyTorch 2.2 (nightly) or higher to run.")
 
-    import re
-    import logging
-
-    # Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
-    pattern = re.compile(".*Profiler function .* will be ignored")
-    logging.getLogger("torch._dynamo.variables.torch").addFilter(lambda record: not pattern.search(record.getMessage()))
-
     CLI(setup)


### PR DESCRIPTION
Suppresses an excessive warning triggered in our pretraining script where `torch.compile` and FSDP are used together. See also: https://github.com/pytorch/pytorch/issues/111632