### PR TITLE
Add max_seq_length to optionally allow truncating inputs

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -39,6 +39,7 @@ batch_size = 64 / devices
 micro_batch_size = 4
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
+max_seq_length = 100000  # set to lower to truncate
 epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
@@ -127,7 +128,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = longest_seq_length
+    model.max_seq_length = min(longest_seq_length, max_seq_length)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -150,6 +151,10 @@ def train(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
+
+        # Truncate if needed
+        input_ids = input_ids[:, :model.max_seq_length]
+        targets = targets[:, :model.max_seq_length]
 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -128,10 +128,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = (
-        longest_seq_length if max_seq_length is None
-        else min(longest_seq_length, max_seq_length)
-    )
+    model.max_seq_length = min(longest_seq_length, max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -39,7 +39,7 @@ batch_size = 128 / devices
 micro_batch_size = 2  # set to 2 because this is fit into 12GB Vram
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
-max_seq_length = 100000  # set to lower to truncate
+max_seq_length = None  # assign value to truncate
 epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
@@ -128,7 +128,10 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, max_seq_length)
+    model.max_seq_length = (
+        longest_seq_length if max_seq_length is None
+        else min(longest_seq_length, max_seq_length)
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -151,10 +154,6 @@ def train(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
-
-        # Truncate if needed
-        input_ids = input_ids[:, :model.max_seq_length]
-        targets = targets[:, :model.max_seq_length]
 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
@@ -244,6 +243,11 @@ def get_batch(
 
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
+
+    # Truncate if needed
+    if max_seq_length:
+        x = x[:, :max_seq_length]
+        y = y[:, :max_seq_length]
 
     if fabric.device.type == "cuda" and x.device.type == "cpu":
         x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -128,10 +128,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = (
-        longest_seq_length if max_seq_length is None
-        else min(longest_seq_length, max_seq_length)
-    )
+    model.max_seq_length = min(longest_seq_length, max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -39,7 +39,7 @@ batch_size = 64 / devices
 micro_batch_size = 1
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
-max_seq_length = 100000  # set to lower to truncate
+max_seq_length = None  # assign value to truncate
 epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
@@ -124,7 +124,10 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, max_seq_length)
+    model.max_seq_length = (
+        longest_seq_length if max_seq_length is None
+        else min(longest_seq_length, max_seq_length)
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -148,10 +151,6 @@ def train(
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
 
-        # Truncate if needed
-        input_ids = input_ids[:, :model.max_seq_length]
-        targets = targets[:, :model.max_seq_length]
- 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
@@ -239,6 +238,11 @@ def get_batch(
 
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
+
+    # Truncate if needed
+    if max_seq_length:
+        x = x[:, :max_seq_length]
+        y = y[:, :max_seq_length]
 
     if fabric.device.type == "cuda" and x.device.type == "cpu":
         x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -39,6 +39,7 @@ batch_size = 64 / devices
 micro_batch_size = 1
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
+max_seq_length = 100000  # set to lower to truncate
 epoch_size = 50000  # train dataset size
 num_epochs = 5
 max_iters = num_epochs * (epoch_size // micro_batch_size) // devices
@@ -123,7 +124,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = longest_seq_length
+    model.max_seq_length = min(longest_seq_length, max_seq_length)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -147,6 +148,10 @@ def train(
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
 
+        # Truncate if needed
+        input_ids = input_ids[:, :model.max_seq_length]
+        targets = targets[:, :model.max_seq_length]
+ 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -124,10 +124,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = (
-        longest_seq_length if max_seq_length is None
-        else min(longest_seq_length, max_seq_length)
-    )
+    model.max_seq_length = min(longest_seq_length, max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -170,10 +170,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = (
-        longest_seq_length if max_seq_length is None
-        else min(longest_seq_length, max_seq_length)
-    )
+    model.max_seq_length = min(longest_seq_length, max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -40,6 +40,7 @@ batch_size = 128
 micro_batch_size = 4
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
+max_seq_length = 100000  # set to lower to truncate
 max_iters = 50000  # train dataset size
 weight_decay = 0.01
 lora_r = 8
@@ -169,7 +170,7 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = longest_seq_length
+    model.max_seq_length = min(longest_seq_length, max_seq_length)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -192,6 +193,10 @@ def train(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
+
+        # Truncate if needed
+        input_ids = input_ids[:, :model.max_seq_length]
+        targets = targets[:, :model.max_seq_length]
 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -40,7 +40,7 @@ batch_size = 128
 micro_batch_size = 4
 gradient_accumulation_iters = batch_size // micro_batch_size
 assert gradient_accumulation_iters > 0
-max_seq_length = 100000  # set to lower to truncate
+max_seq_length = None  # assign value to truncate
 max_iters = 50000  # train dataset size
 weight_decay = 0.01
 lora_r = 8
@@ -170,7 +170,10 @@ def train(
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, max_seq_length)
+    model.max_seq_length = (
+        longest_seq_length if max_seq_length is None
+        else min(longest_seq_length, max_seq_length)
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
@@ -193,10 +196,6 @@ def train(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(fabric, train_data, longest_seq_ix if iter_num == 1 else None)
-
-        # Truncate if needed
-        input_ids = input_ids[:, :model.max_seq_length]
-        targets = targets[:, :model.max_seq_length]
 
         is_accumulating = iter_num % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
@@ -288,6 +287,11 @@ def get_batch(
 
     x = torch.stack([pad_right(x, pad_id=0) for x in input_ids])
     y = torch.stack([pad_right(x, pad_id=-1) for x in labels])
+
+    # Truncate if needed
+    if max_seq_length:
+        x = x[:, :max_seq_length]
+        y = y[:, :max_seq_length]
 
     if fabric.device.type == "cuda" and x.device.type == "cpu":
         x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))


### PR DESCRIPTION
Right now we don't allow truncating inputs while fine tuning, the max sequence length is computed from the dataset.

This PR introduces a `max_seq_length` variable that can be used to truncate sequences and avoid OOMs on smaller devices. It is set to a very high number by default.