### PR TITLE
Update download.py - set cache_dir to the same directory as local_dir to prevent potential copying errors

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -53,6 +53,7 @@ def download_from_hub(
     snapshot_download(
         repo_id,
         local_dir=directory,
+        cache_dir=directory,
         local_dir_use_symlinks=False,
         resume_download=True,
         allow_patterns=download_files,


### PR DESCRIPTION
There's a problem when a cache dir is on a different volume than the target dir:

> ‹[1Apytorch_model-00001-of-00002.bin: 100%|----------| 9.94G/9.94G [00:42<00:00, 235MB/s]
> 
> ‹[1AFetching 7 files:  14%|-?        | 1/7 [00:42<04:14, 42.44s/it]
> Traceback (most recent call last):
>   File "/opt/conda/lib/python3.9/shutil.py", line 825, in move
>     os.rename(src, real_dst)
> OSError: [Errno 18] Invalid cross-device link: '/root/.cache/huggingface/hub/models--mistralai--Mistral-7B-Instruct-v0.1/blobs/2f237251ac3ecb3bcbd8978b3eb7b55b5e83c06cd5224b276d2d8462773488c8.incomplete' -> '/pretrained/checkpoints/mistralai/Mistral-7B-Instruct-v0.1/pytorch_model-00001-of-00002.bin'

Setting cache_dir to be equal to the target dir prevents it.