### PR TITLE
Use chunked cross entropy in tinyllama.py

### DIFF
--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -185,7 +185,7 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
         is_accumulating = state["iter_num"] % gradient_accumulation_steps != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
-            loss = chunked_cross_entropy(logits, targets, chunk_size=0)
+            loss = chunked_cross_entropy(logits, targets)
             fabric.backward(loss / gradient_accumulation_steps)
 
         if not is_accumulating:
@@ -256,7 +256,7 @@ def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max
         input_ids = val_data[:, 0 : model.config.block_size].contiguous().long()
         targets = val_data[:, 1 : (model.config.block_size + 1)].contiguous().long()
         logits = model(input_ids)
-        loss = chunked_cross_entropy(logits, targets, chunk_size=0)
+        loss = chunked_cross_entropy(logits, targets)
         losses[k] = loss
 
     model.train()


### PR DESCRIPTION
Results in ~2% peak memory reduction. Measured no noticeable impact on iteration speed.

Note: For execution on meta-device, `chunk_size=0` still needed, otherwise error.