### PR TITLE
Refactor resume logic in tinyllama.py

### DIFF
--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -162,7 +162,7 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
         fabric.barrier()
         fabric.print(
             "Resuming data loader finished."
-            f"Took {time.perf_counter() - resume_t0:.1f} seconds to reach iteration {initial_iter}."
+            f" Took {time.perf_counter() - resume_t0:.1f} seconds to reach iteration {initial_iter}."
         )
 
     total_t0 = time.perf_counter()

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -155,7 +155,7 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
     # drop this once streaming dataset supports proper resuming
     if resume:
         resume_t0 = time.perf_counter()
-        for resume_iter in range(initial_iter + 1):
+        for resume_iter in range(initial_iter):
             next(train_iterator)
             if resume_iter % 1000 == 0:
                 fabric.print(f"Resuming dataset: {resume_iter} / {initial_iter}")


### PR DESCRIPTION
A small refactor to the resume logic, pulling it out of the  main loop. This way, we can compute `total_t0` after the the resuming has finished, and avoiding it to be skewed. 