### PR TITLE
Set `drop_last=True` in tinyllama.py

### DIFF
--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -288,7 +288,7 @@ def create_dataloaders(batch_size: int, block_size: int) -> Tuple[DataLoader, Da
     # Mix SlimPajama data and Starcoder data with these proportions:
     weights = (0.693584, 0.306416)
     combined_dataset = CombinedDataset(datasets=train_datasets, seed=42, weights=weights)
-    train_dataloader = DataLoader(combined_dataset, batch_size=batch_size, pin_memory=True, num_workers=8)
+    train_dataloader = DataLoader(combined_dataset, batch_size=batch_size, pin_memory=True, num_workers=8, drop_last=True)
 
     val_dataset = StreamingDataset(
         input_dir="data/slimpajama/val",
@@ -297,7 +297,7 @@ def create_dataloaders(batch_size: int, block_size: int) -> Tuple[DataLoader, Da
         # Consider setting to False, but we would lose some samples due to truncation when world size > 1
         drop_last=True,
     )
-    val_dataloader = DataLoader(val_dataset, batch_size=batch_size, pin_memory=True, num_workers=8)
+    val_dataloader = DataLoader(val_dataset, batch_size=batch_size, pin_memory=True, num_workers=8, drop_last=True)
     return train_dataloader, val_dataloader
 
 


### PR DESCRIPTION
Setting `drop_last=True` here ensures we get a constant batch size in every iteration. Not doing so could cause the shape to change and triggering torch to recompile the model's forward pass. When recompiling due to changing shapes, the generated kernels will be less specialized, leading to a performance loss in subsequent iterations. 