### PR TITLE
Disable FSDP state-dict profiling warnings

### DIFF
--- a/lit_gpt/__init__.py
+++ b/lit_gpt/__init__.py
@@ -18,5 +18,8 @@ if not bool(_LIGHTNING_AVAILABLE):
 pattern = re.compile(".*Profiler function .* will be ignored")
 logging.getLogger("torch._dynamo.variables.torch").addFilter(lambda record: not pattern.search(record.getMessage()))
 
+# Avoid printing state-dict profiling output at the WARNING level when saving a checkpoint
+logging.getLogger("torch.distributed.fsdp._optim_utils").disabled = True
+logging.getLogger("torch.distributed.fsdp._debug_utils").disabled = True
 
 __all__ = ["GPT", "Config", "Tokenizer"]


### PR DESCRIPTION
Disables a wall of warning text that gets emitted during checkpointing. I propose to remove this because it is kind of annoying. I believe PyTorch should log them at debug-level, not warning level because they are not legit warnings. 

```
 Validating ...
 iter 848000: val loss 2.2185, val time: 12765.29 ms
 Saving checkpoint to '/share/lit-tiny-llama-1.1b/step-00053000.pth'
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] CUDA Memory Summary before calling to _allgather_orig_param_states |===========================================================================|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |                  PyTorch CUDA memory summary, device ID 0                 |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |            CUDA OOMs: 0            |        cudaMalloc retries: 0         |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |===========================================================================|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Allocated memory      |   2053 MiB |  18389 MiB |   5183 TiB |   5183 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18343 MiB |   5174 TiB |   5174 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Active memory         |   2053 MiB |  18389 MiB |   5183 TiB |   5183 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18343 MiB |   5174 TiB |   5174 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Requested memory      |   2053 MiB |  18383 MiB |   5180 TiB |   5180 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18337 MiB |   5171 TiB |   5171 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | GPU reserved memory   |  20750 MiB |  20750 MiB |  20750 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |  20700 MiB |  20700 MiB |  20700 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     50 MiB |     50 MiB |     50 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Non-releasable memory | 438531 KiB |   3190 MiB |   2668 TiB |   2668 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool | 437220 KiB |   3187 MiB |   2658 TiB |   2658 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |   1310 KiB |      6 MiB |      9 TiB |      9 TiB |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Allocations           |     167    |     719    |  186508 K  |  186508 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      73    |     428    |  131562 K  |  131562 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      94    |     293    |   54946 K  |   54946 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Active allocs         |     172    |     722    |  186508 K  |  186508 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      73    |     429    |  131562 K  |  131562 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      99    |     293    |   54946 K  |   54946 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | GPU reserved segments |     312    |     312    |     312    |       0    |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |     287    |     287    |     287    |       0    |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      25    |      25    |      25    |       0    |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Non-releasable allocs |      38    |     172    |   81541 K  |   81541 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      32    |     111    |   53648 K  |   53648 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |       6    |      71    |   27893 K  |   27893 K  |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Oversize allocations  |       0    |       0    |       0    |       0    |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] | Oversize GPU segments |       0    |       0    |       0    |       0    |
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] |===========================================================================|
 [rank0]:[2023-12-08 02:41:10,117] torch.distributed.fsdp._optim_utils: [WARNING] 



... (many more copies from every rank) ...


 [rank0]:[2023-12-08 02:41:12,662] torch.distributed.fsdp._optim_utils: [WARNING] 
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] CUDA Memory Summary before calling to _allgather_orig_param_states |===========================================================================|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |                  PyTorch CUDA memory summary, device ID 0                 |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |            CUDA OOMs: 0            |        cudaMalloc retries: 0         |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |===========================================================================|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Allocated memory      |   2053 MiB |  18389 MiB |   5183 TiB |   5183 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18343 MiB |   5174 TiB |   5174 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Active memory         |   2053 MiB |  18389 MiB |   5183 TiB |   5183 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18343 MiB |   5174 TiB |   5174 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Requested memory      |   2053 MiB |  18383 MiB |   5180 TiB |   5180 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |   2031 MiB |  18337 MiB |   5171 TiB |   5171 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     22 MiB |     47 MiB |      8 TiB |      8 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | GPU reserved memory   |  20750 MiB |  20750 MiB |  20750 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |  20700 MiB |  20700 MiB |  20700 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |     50 MiB |     50 MiB |     50 MiB |      0 B   |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Non-releasable memory | 438521 KiB |   3190 MiB |   2668 TiB |   2668 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool | 437220 KiB |   3187 MiB |   2658 TiB |   2658 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |   1301 KiB |      6 MiB |      9 TiB |      9 TiB |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Allocations           |     167    |     719    |  186508 K  |  186508 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      73    |     428    |  131562 K  |  131562 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      94    |     293    |   54946 K  |   54946 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Active allocs         |     172    |     722    |  186508 K  |  186508 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      73    |     429    |  131562 K  |  131562 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      99    |     293    |   54946 K  |   54946 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | GPU reserved segments |     312    |     312    |     312    |       0    |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |     287    |     287    |     287    |       0    |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |      25    |      25    |      25    |       0    |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Non-releasable allocs |      39    |     172    |   81541 K  |   81541 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from large pool |      32    |     111    |   53648 K  |   53648 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |       from small pool |       7    |      71    |   27893 K  |   27893 K  |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Oversize allocations  |       0    |       0    |       0    |       0    |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |---------------------------------------------------------------------------|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] | Oversize GPU segments |       0    |       0    |       0    |       0    |
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] |===========================================================================|
 [rank0]:[2023-12-08 02:41:12,825] torch.distributed.fsdp._optim_utils: [WARNING] 
 [rank0]:[2023-12-08 02:41:12,993] torch.distributed.fsdp._debug_utils: [WARNING] FSDP _optim_state_dict() profiling:  defaultdict(<class 'float'>, {'preprocessing': 0.013241417000244837, 'preprocessing_with_comm': 0.02368172000569757, <Type.ALLGATHER_OBJ: 'all_gather_object'>: 0.10178080299374415, <Type.ALLGATHER: 'all_gather'>: 0.03262630102108233, <Type.D2H: 'D2H'>: 2.6914712780344416, <Type.RESHARDING: 'resharding'>: 2.8793633109744405, 'state_converting': 2.8822861189983087, <Type.ALL: 'all'>: 2.9208064780032146})

```

