### PR TITLE
Compute running loss in tinyllama.py

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -8,6 +8,7 @@ zstandard               # scripts/prepare_redpajama.py, scripts/prepare_starcode
 pandas                  # scripts/prepare_csv.py, scripts/prepare_starcoder.py
 pyarrow                 # scripts/prepare_starcoder.py
 tensorboard             # pretrain/tinyllama.py
+torchmetrics            # pretrain/tinyllama.py
 # eval
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@115206dc89dad67b8beaa90051fb52db77f0a529
 # scripts/prepare_slimpajama.py, scripts/prepare_starcoder.py, pretrain/tinyllama.py

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -45,7 +45,7 @@ In order to start pretraining lit-gpt on it, you need to read, tokenize, and wri
 First, install additional dependencies for preprocessing:
 
 ```bash
-pip install lightning[data] tensorboard sentencepiece zstandard pandas pyarrow huggingface_hub
+pip install lightning[data] torchmetrics tensorboard sentencepiece zstandard pandas pyarrow huggingface_hub
 ```
 
 You will need to have the tokenizer config available:


### PR DESCRIPTION
The current script logs the instantaneous loss of the last iteration in the accumulation window, it makes the loss curve a bit noisy. This PR adds a running loss over a window the size of the gradient accumulation and logs that.

Note: Instead of using torchmetrics as a dependency, we could also implement a simple RunningMean class here in lit-gpt. Let me know what you prefer.