### PR TITLE
Drop inference with FSDP

### DIFF
--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -6,7 +6,6 @@ from typing import Literal, Optional
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
-from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -14,7 +13,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.adapter import GPT, Block, Config
+from lit_gpt.adapter import GPT, Config
 from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, gptq_quantization, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
@@ -28,8 +27,6 @@ def main(
     max_new_tokens: int = 100,
     top_k: Optional[int] = 200,
     temperature: float = 0.8,
-    strategy: str = "auto",
-    devices: int = 1,
     precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
@@ -51,38 +48,25 @@ def main(
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        strategy: Indicates the Fabric strategy setting to use.
-        devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
-    if quantize is not None:
-        if devices > 1:
-            raise NotImplementedError(
-                "Quantization is currently not supported for multi-GPU training. Please set devices=1 when using the"
-                " --quantize flag."
-            )
-        if quantize.startswith("bnb."):
-            if "mixed" in precision:
-                raise ValueError("Quantization and mixed precision is not supported.")
-            dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
-            plugins = BitsandbytesPrecision(quantize[4:], dtype)
-            precision = None
+    if quantize is not None and quantize.startswith("bnb."):
+        if "mixed" in precision:
+            raise ValueError("Quantization and mixed precision is not supported.")
+        dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
+        plugins = BitsandbytesPrecision(quantize[4:], dtype)
+        precision = None
 
-    if strategy == "fsdp":
-        strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
-
-    fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy, plugins=plugins)
+    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
     config = Config.from_json(checkpoint_dir / "lit_config.json")
 
-    if quantize is not None and devices > 1:
-        raise NotImplementedError
     if quantize == "gptq.int4":
         model_file = "lit_model_gptq.4bit.pth"
         if not (checkpoint_dir / model_file).is_file():

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -6,7 +6,6 @@ from typing import Literal, Optional
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
-from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -14,7 +13,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.adapter_v2 import GPT, Block, Config
+from lit_gpt.adapter_v2 import GPT, Config
 from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, gptq_quantization, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
@@ -28,8 +27,6 @@ def main(
     max_new_tokens: int = 100,
     top_k: Optional[int] = 200,
     temperature: float = 0.8,
-    strategy: str = "auto",
-    devices: int = 1,
     precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
@@ -51,38 +48,25 @@ def main(
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        strategy: Indicates the Fabric strategy setting to use.
-        devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
-    if quantize is not None:
-        if devices > 1:
-            raise NotImplementedError(
-                "Quantization is currently not supported for multi-GPU training. Please set devices=1 when using the"
-                " --quantize flag."
-            )
-        if quantize.startswith("bnb."):
-            if "mixed" in precision:
-                raise ValueError("Quantization and mixed precision is not supported.")
-            dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
-            plugins = BitsandbytesPrecision(quantize[4:], dtype)
-            precision = None
+    if quantize is not None and quantize.startswith("bnb."):
+        if "mixed" in precision:
+            raise ValueError("Quantization and mixed precision is not supported.")
+        dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
+        plugins = BitsandbytesPrecision(quantize[4:], dtype)
+        precision = None
 
-    if strategy == "fsdp":
-        strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
-
-    fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy, plugins=plugins)
+    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
     config = Config.from_json(checkpoint_dir / "lit_config.json")
 
-    if quantize is not None and devices > 1:
-        raise NotImplementedError
     if quantize == "gptq.int4":
         model_file = "lit_model_gptq.4bit.pth"
         if not (checkpoint_dir / model_file).is_file():

--- a/generate/base.py
+++ b/generate/base.py
@@ -47,7 +47,7 @@ def sample(logits: torch.Tensor, temperature: float = 1.0, top_k: Optional[int] 
 def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
     logits = model(x, input_pos)
     next = sample(logits, **kwargs)
-    return next.to(dtype=x.dtype)
+    return next.type_as(x)
 
 
 @torch.inference_mode()

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -6,7 +6,6 @@ from typing import Literal, Optional
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
-from lightning.fabric.strategies import FSDPStrategy
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -14,7 +13,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import Tokenizer
-from lit_gpt.lora import GPT, Block, Config, merge_lora_weights
+from lit_gpt.lora import GPT, Config, merge_lora_weights
 from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, gptq_quantization, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
@@ -38,8 +37,6 @@ def main(
     max_new_tokens: int = 100,
     top_k: Optional[int] = 200,
     temperature: float = 0.8,
-    strategy: str = "auto",
-    devices: int = 1,
     precision: Optional[str] = None,
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
@@ -61,30 +58,19 @@ def main(
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        strategy: Indicates the Fabric strategy setting to use.
-        devices: How many devices to use.
         precision: Indicates the Fabric precision setting to use.
     """
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
-    if quantize is not None:
-        if devices > 1:
-            raise NotImplementedError(
-                "Quantization is currently not supported for multi-GPU training. Please set devices=1 when using the"
-                " --quantize flag."
-            )
-        if quantize.startswith("bnb."):
-            if "mixed" in precision:
-                raise ValueError("Quantization and mixed precision is not supported.")
-            dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
-            plugins = BitsandbytesPrecision(quantize[4:], dtype)
-            precision = None
+    if quantize is not None and quantize.startswith("bnb."):
+        if "mixed" in precision:
+            raise ValueError("Quantization and mixed precision is not supported.")
+        dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
+        plugins = BitsandbytesPrecision(quantize[4:], dtype)
+        precision = None
 
-    if strategy == "fsdp":
-        strategy = FSDPStrategy(auto_wrap_policy={Block}, cpu_offload=False)
-
-    fabric = L.Fabric(devices=devices, precision=precision, strategy=strategy, plugins=plugins)
+    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)
@@ -102,8 +88,6 @@ def main(
         to_head=lora_head,
     )
 
-    if quantize is not None and devices > 1:
-        raise NotImplementedError
     if quantize == "gptq.int4":
         model_file = "lit_model_gptq.4bit.pth"
         if not (checkpoint_dir / model_file).is_file():

--- a/tutorials/inference.md
+++ b/tutorials/inference.md
@@ -33,23 +33,4 @@ Check out our [quantization tutorial](quantize.md).
 
 ## Run a large model on multiple smaller devices
 
-You can also use the Fully-Sharded Data Parallel (FSDP) distributed strategy to leverage multiple devices to perform inference. This will allow you to run models that wouldn't fit in a single card by sharding them across several.
-
-For instance, `falcon-40b` would require ~80 GB of GPU memory to run on a single device. We can instead run it on 4 A100 40GB GPUs:
-
-```shell
-python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-40b --strategy fsdp --devices 4
-```
-
-Which will take ~25 GB of memory, and run at 2.5 tokens/sec.
-
-Or to reduce the memory requirements even further, you can try using CPU offloading. For that, you will need to manually edit the `cpu_offload=False` parameter in the file and set it to `True`.
-
-Now we can run it on just 2 devices.
-
-```shell
-python generate/base.py --checkpoint_dir checkpoints/tiiuae/falcon-40b --strategy fsdp --devices 2
-```
-
-taking ~5 GB of memory but running at 0.23 tokens/sec on 2 A100 40GB GPUs.
-Smaller devices like 3090s (24 GB) can also fit it with this technique.
+Coming soon


### PR DESCRIPTION
Batch size 1 inference with FSDP is highly inefficient because there's a lot of unnecessary communication going on.

Since I'll be adding sequential inference, this fsdp is irrelevant.

Might be added back to a batched generation script, where data parallelism can be beneficial.