### PR TITLE
Remove `input_ids_no_response` from instruction finetuning scripts

### DIFF
--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -121,7 +121,6 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     return {
         **example,
         "input_ids": encoded_full_prompt_and_response,
-        "input_ids_no_response": encoded_full_prompt,
         "labels": labels,
     }
 

--- a/scripts/prepare_csv.py
+++ b/scripts/prepare_csv.py
@@ -116,7 +116,6 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     return {
         **example,
         "input_ids": encoded_full_prompt_and_response,
-        "input_ids_no_response": encoded_full_prompt,
         "labels": labels,
     }
 

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -97,7 +97,7 @@ def download_if_missing(file_path: Path, file_url: str) -> None:
         f.write(requests.get(file_url).text)
 
 
-def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_inputs: bool, ignore_index: int) -> None:
+def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_inputs: bool, ignore_index: int) -> dict:
     """Processes a single sample.
 
     Each sample in the dataset consists of:
@@ -127,7 +127,6 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     return {
         **example,
         "input_ids": encoded_full_prompt_and_response,
-        "input_ids_no_response": encoded_full_prompt,
         "labels": labels,
     }
 

--- a/scripts/prepare_lima.py
+++ b/scripts/prepare_lima.py
@@ -143,7 +143,6 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     return {
         **example,
         "input_ids": encoded_full_prompt_and_response,
-        "input_ids_no_response": encoded_full_prompt,
         "labels": labels,
     }
 

--- a/scripts/prepare_longform.py
+++ b/scripts/prepare_longform.py
@@ -125,7 +125,6 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     return {
         **example,
         "input_ids": encoded_full_prompt_and_response,
-        "input_ids_no_response": encoded_full_prompt,
         "labels": labels,
     }
 

--- a/tests/test_prepare_csv.py
+++ b/tests/test_prepare_csv.py
@@ -39,7 +39,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "2+2",
                 "output": "4",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
             {
@@ -47,7 +46,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "10/2",
                 "output": "5",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
             {
@@ -55,7 +53,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "6*4",
                 "output": "24",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
         ],
@@ -68,7 +65,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "2^3",
                 "output": "8",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
             {
@@ -76,7 +72,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "5-3",
                 "output": "2",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
             {
@@ -84,7 +79,6 @@ def test_prepare_csv(tmp_path, fake_checkpoint_dir):
                 "input": "√9",
                 "output": "3",
                 "input_ids": ANY,
-                "input_ids_no_response": ANY,
                 "labels": ANY,
             },
         ],


### PR DESCRIPTION
Addresses complaints that the unused "input_ids_no_response" in the output causes confusion among users who adopt these scripts (https://github.com/Lightning-AI/lit-gpt/issues/796#issuecomment-1854667341).