### PR TITLE
Apply `inference_mode` where we `kv_cache.reset_parameters`

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -101,6 +101,7 @@ def decode(fabric: L.Fabric, tokenizer: Tokenizer, token_stream: Iterator[torch.
     return tokens_generated
 
 
+@torch.inference_mode()
 def main(
     *,
     top_k: Optional[int] = 200,

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -76,6 +76,7 @@ class EvalHarnessBase(BaseLM):
     def _model_call(self, inps):
         return self.model(inps)
 
+    @torch.inference_mode()
     def _model_generate(self, context, max_length, eos_token_id) -> torch.Tensor:
         # this only supports batch size 1
         assert context.shape[0] == 1

--- a/generate/base.py
+++ b/generate/base.py
@@ -96,6 +96,7 @@ def generate(
     return torch.cat(tokens)
 
 
+@torch.inference_mode()
 def main(
     prompt: str = "What food do llamas eat?",
     *,


### PR DESCRIPTION
The lines

```python
        for block in model.transformer.h:
            block.attn.kv_cache.reset_parameters()
```

can cause issues if not run under `inference_mode`:

```python
    block.attn.kv_cache.reset_parameters()
  File "/home/carlos/lit-parrot/lit_gpt/model.py", line 371, in reset_parameters
    torch.nn.init.zeros_(self.k)
  File "/home/carlos/nightly-env/lib/python3.10/site-packages/torch/nn/init.py", line 247, in zeros_
    return _no_grad_zero_(tensor)
  File "/home/carlos/nightly-env/lib/python3.10/site-packages/torch/nn/init.py", line 65, in _no_grad_zero_
    return tensor.zero_()
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.You can make a clone to get a normal tensor before doing inplace update.See https://github.com/pytorch/rfcs/pull/17 for more details.
```