### PR TITLE
LoRA merge with quantization: optimiziations

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -150,17 +150,13 @@ class LoRALinear(LoRALayer):
                 import bitsandbytes as bnb
 
                 weight = self.linear.weight
-                # capture args like `compress_statistics`, `quant_type` and `quant_state`
-                weight_kwargs = weight.__dict__
-                # dequantize the pretrained weights and sum them with LoRA weights
-                weight_data = (
-                    bnb.functional.dequantize_4bit(weight.data, weight.quant_state).to(lora_data.dtype) + lora_data
-                )
-                # weights are quantized when they are moved to CUDA device,
-                # so we have to first move them to CPU and after - to CUDA
-                self.linear.weight = bnb.nn.Params4bit(weight_data.to("cpu"), requires_grad=False, **weight_kwargs).to(
-                    weight.device
-                )
+                # dequantize the pretrained weights
+                weight_data = bnb.functional.dequantize_4bit(weight.data, weight.quant_state).to(lora_data.dtype)
+                # add pretrained and LoRA weights
+                weight_data += lora_data
+                # assign updated weights and quantize by moving to CUDA device
+                self.linear.weight = bnb.nn.Params4bit(weight_data, requires_grad=False, **weight.__dict__)
+                self.linear.weight.cuda(weight.device)
             else:
                 raise NotImplementedError(
                     f"Cannot merge the pretrained weights of type {pretrained_dtype}"

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -153,7 +153,9 @@ class LoRALinear(LoRALayer):
                 # capture args like `compress_statistics`, `quant_type` and `quant_state`
                 weight_kwargs = weight.__dict__
                 # dequantize the pretrained weights and sum them with LoRA weights
-                weight_data = bnb.functional.dequantize_4bit(weight.data, weight.quant_state) + lora_data
+                weight_data = (
+                    bnb.functional.dequantize_4bit(weight.data, weight.quant_state).to(lora_data.dtype) + lora_data
+                )
                 # weights are quantized when they are moved to CUDA device,
                 # so we have to first move them to CPU and after - to CUDA
                 self.linear.weight = bnb.nn.Params4bit(weight_data.to("cpu"), requires_grad=False, **weight_kwargs).to(


### PR DESCRIPTION
Hi there 👋 

This is a continuation of #771 but with some optimizations:
1. `bnb.functional.dequantize4bit` [always](https://github.com/TimDettmers/bitsandbytes/blob/8a45bfa51c4193e64b1de4424c9af05344f74173/bitsandbytes/nn/modules.py#L168) returns data in `float16` dtype, so if we want to sum it with the data in `bfloat16` dtype - both weights will be cast to `float32` and the resulting tensor also will have this dtype. To avoid it, the output of the dequantization function is cast to the dtype of the second term of the summation. This is similar to how it's [done](https://github.com/TimDettmers/bitsandbytes/blob/8a45bfa51c4193e64b1de4424c9af05344f74173/bitsandbytes/autograd/_functions.py#L516) in BNB.
2. There is no need to move the data to CPU first in order to then quantize the data when we call `.to("cuda")` method - we can directly [call](https://github.com/TimDettmers/bitsandbytes/blob/a06a0f6a08cb23754b110359a109e069fa97ce9e/bitsandbytes/nn/modules.py#L155C28-L155C28) `.cuda` method and thus quantize the data.