### PR TITLE
Fix logic to count devices

### DIFF
--- a/generate/sequentially.py
+++ b/generate/sequentially.py
@@ -159,7 +159,7 @@ def main(
     if devices == "auto":
         total_devices = CUDAAccelerator.auto_device_count()
     else:
-        total_devices = sum(CUDAAccelerator.parse_devices(devices))
+        total_devices = len(CUDAAccelerator.parse_devices(devices))
     print(f"Using {total_devices} devices", file=sys.stderr)
 
     check_valid_checkpoint_dir(checkpoint_dir)


### PR DESCRIPTION
CUDAAccelerator.parse_devices returns a list such as ["0", "1", "2", "3"]. The count of devices is the length of the list and not the sum of the values within the list.