### PR TITLE
Mixtral: LLaMAMoE wrongly inherited from base LLaMAMLP for Adapter_v2 and LoRA

### DIFF
--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -192,7 +192,7 @@ class LLaMAMLP(lit_gpt.model.LLaMAMLP):
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
 
-class LLaMAMoE(lit_gpt.model.LLaMAMLP):
+class LLaMAMoE(lit_gpt.model.LLaMAMoE):
     def __init__(self, config: Config) -> None:
         nn.Module.__init__(self)
         self.gate = AdapterV2Linear(config.n_embd, config.n_expert, bias=False)

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -678,7 +678,7 @@ class LLaMAMLP(lit_gpt.model.LLaMAMLP):
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
 
-class LLaMAMoE(lit_gpt.model.LLaMAMLP):
+class LLaMAMoE(lit_gpt.model.LLaMAMoE):
     def __init__(self, config: Config) -> None:
         nn.Module.__init__(self)
         self.gate = LoRALinear(

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -167,3 +167,53 @@ def test_adapter_v2_compile():
     assert isinstance(explanation, debugging.ExplainOutput)
     assert explanation.graph_count == 1
     assert explanation.graph_break_count == 0
+
+
+@torch.inference_mode()
+def test_against_hf_mixtral():
+    from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
+
+    from lit_gpt.adapter_v2 import GPT, Config
+    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    ours_config = Config.from_name(
+        "Mixtral-8x7B-Instruct-v0.1",
+        padded_vocab_size=10000,
+        n_layer=2,
+        n_embd=32,
+        n_head=8,
+        n_query_groups=2,
+        intermediate_size=86,
+        n_expert=4,
+    )
+    T = 5
+    theirs_config = MixtralConfig(
+        vocab_size=ours_config.padded_vocab_size,
+        hidden_size=ours_config.n_embd,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
+        intermediate_size=ours_config.intermediate_size,
+        max_position_embeddings=T,
+        rms_norm_eps=ours_config.norm_eps,
+        num_key_value_heads=ours_config.n_query_groups,
+        rope_theta=ours_config.rope_base,
+        num_local_experts=ours_config.n_expert,
+    )
+    assert ours_config.intermediate_size == theirs_config.intermediate_size
+
+    theirs_model = MixtralForCausalLM(theirs_config).to(device)
+    theirs_state_dict = theirs_model.state_dict()
+    state_dict = {}
+    copy_weights_hf_llama(ours_config, {}, state_dict, theirs_state_dict)
+    ours_model = GPT(ours_config).to(device)
+    # strict=False because missing keys due to adapter weights not contained in state dict
+    ours_model.load_state_dict(state_dict, strict=False)
+
+    # test end to end
+    x = torch.tensor([[9856, 23, 491, 1536, 304], [23, 345, 65, 123, 321]], dtype=torch.int32, device=device)
+    assert x.size(1) == T
+    ours_y = ours_model(x)
+    theirs_y = theirs_model(x)["logits"].to(dtype)  # HF converts logits to float
+    torch.testing.assert_close(ours_y, theirs_y)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -5,9 +5,8 @@ from unittest import mock
 from unittest.mock import Mock
 
 import torch
-from torch.utils.data import DataLoader
-
 from conftest import RunIf
+from torch.utils.data import DataLoader
 
 
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -49,12 +49,10 @@ def test_replace_device():
     class MyModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.modules = torch.nn.ModuleDict(
-                {
-                    "module1": torch.nn.Linear(1, 1, bias=True, device="meta"),
-                    "module2": torch.nn.Linear(1, 1, bias=False, device="cpu"),
-                }
-            )
+            self.modules = torch.nn.ModuleDict({
+                "module1": torch.nn.Linear(1, 1, bias=True, device="meta"),
+                "module2": torch.nn.Linear(1, 1, bias=False, device="cpu"),
+            })
             self.submodule = Submodule()
 
     model = MyModel()

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -497,3 +497,52 @@ def test_lora_compile():
     assert isinstance(explanation, debugging.ExplainOutput)
     assert explanation.graph_count == 1
     assert explanation.graph_break_count == 0
+
+
+@torch.inference_mode()
+def test_against_hf_mixtral():
+    from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
+
+    from lit_gpt.lora import GPT, Config
+    from scripts.convert_hf_checkpoint import copy_weights_hf_llama
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    ours_config = Config.from_name(
+        "Mixtral-8x7B-Instruct-v0.1",
+        padded_vocab_size=10000,
+        n_layer=2,
+        n_embd=32,
+        n_head=8,
+        n_query_groups=2,
+        intermediate_size=86,
+        n_expert=4,
+    )
+    T = 5
+    theirs_config = MixtralConfig(
+        vocab_size=ours_config.padded_vocab_size,
+        hidden_size=ours_config.n_embd,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
+        intermediate_size=ours_config.intermediate_size,
+        max_position_embeddings=T,
+        rms_norm_eps=ours_config.norm_eps,
+        num_key_value_heads=ours_config.n_query_groups,
+        rope_theta=ours_config.rope_base,
+        num_local_experts=ours_config.n_expert,
+    )
+    assert ours_config.intermediate_size == theirs_config.intermediate_size
+
+    theirs_model = MixtralForCausalLM(theirs_config).to(device)
+    theirs_state_dict = theirs_model.state_dict()
+    state_dict = {}
+    copy_weights_hf_llama(ours_config, {}, state_dict, theirs_state_dict)
+    ours_model = GPT(ours_config).to(device)
+    ours_model.load_state_dict(state_dict)
+
+    # test end to end
+    x = torch.tensor([[9856, 23, 491, 1536, 304], [23, 345, 65, 123, 321]], dtype=torch.int32, device=device)
+    assert x.size(1) == T
+    ours_y = ours_model(x)
+    theirs_y = theirs_model(x)["logits"].to(dtype)  # HF converts logits to float
+    torch.testing.assert_close(ours_y, theirs_y)


### PR DESCRIPTION
Hi there 👋 

Fixes #849 

Due to a typo in `lit_gpt/adapter_v2.py` and `lit_gpt/lora.py`,  `LLaMAMoE` class inherited `LLaMAMLP`.
Thus, when trying to fine-tune Mixtral model with one of these method, you get:
```python
AttributeError: 'LLaMAMoE' object has no attribute 'fc_1'
```

This PR fixes it and adds tests to make sure that forward pass runs without issues for Mixtral model (or any other that uses mixture of experts).