### PR TITLE
Refactor `get_lr` in pretraining scripts

### DIFF
--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -139,7 +139,7 @@ def train(fabric: L.Fabric, state: dict, train_dataloader: DataLoader, val_datal
 
     for state["iter_num"] in range(state["iter_num"], max_iters):
         # determine and set the learning rate for this iteration
-        lr = get_lr(state["iter_num"]) if decay_lr else learning_rate
+        lr = get_lr(state["iter_num"], warmup_iters, max_iters) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
@@ -227,16 +227,16 @@ class Dataset(IterableDataset):
             yield x, y
 
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it: int) -> float:
+# learning rate decay scheduler (cosine with linear warmup)
+def get_lr(it: int, warmup_iters: int, max_iters: int) -> float:
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
         return learning_rate * it / warmup_iters
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
+    # 2) if it > max_iters, return min learning rate
+    if it > max_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_iters) / (max_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -91,7 +91,7 @@ class LightningGPTModule(L.LightningModule):
         if not decay_lr:
             return
         # determine and set the learning rate for this iteration
-        lr = get_lr(self.trainer.fit_loop.total_batch_idx)
+        lr = get_lr(self.trainer.fit_loop.total_batch_idx, warmup_iters, max_iters)
         for optimizer in self.trainer.strategy.optimizers:
             for param_group in optimizer.param_groups:
                 param_group["lr"] = lr
@@ -194,16 +194,16 @@ class Dataset(IterableDataset):
             yield x, y
 
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it: int) -> float:
+# learning rate decay scheduler (cosine with linear warmup)
+def get_lr(it: int, warmup_iters: int, max_iters: int) -> float:
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
         return learning_rate * it / warmup_iters
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
+    # 2) if it > max_iters, return min learning rate
+    if it > max_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_iters) / (max_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -166,7 +166,7 @@ def train(fabric: L.Fabric, state: dict, train_dataloader: DataLoader, val_datal
             break
 
         # determine and set the learning rate for this iteration
-        lr = get_lr(state["iter_num"]) if decay_lr else learning_rate
+        lr = get_lr(state["iter_num"], warmup_iters, max_iters) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
@@ -304,16 +304,16 @@ def create_dataloaders(
     return train_dataloader, val_dataloader
 
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it: int) -> float:
+# learning rate decay scheduler (cosine with linear warmup)
+def get_lr(it: int, warmup_iters: int, max_iters: int) -> float:
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
         return learning_rate * it / warmup_iters
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
+    # 2) if it > max_iters, return min learning rate
+    if it > max_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_iters) / (max_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -302,7 +302,7 @@ def create_dataloaders(batch_size: int, block_size: int) -> Tuple[DataLoader, Da
 
 
 # learning rate decay scheduler (cosine with linear warmup)
-def get_lr(it: int, warmup_iters: int, max_iters: int) -> int:
+def get_lr(it: int, warmup_iters: int, max_iters: int) -> float:
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
         return learning_rate * it / warmup_iters

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -165,7 +165,7 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
             break
 
         # determine and set the learning rate for this iteration
-        lr = get_lr(state["iter_num"], max_iters) if decay_lr else learning_rate
+        lr = get_lr(state["iter_num"], warmup_iters, max_iters) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
@@ -299,16 +299,16 @@ def create_dataloaders(batch_size: int, block_size: int) -> Tuple[DataLoader, Da
     return train_dataloader, val_dataloader
 
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it: int, lr_decay_iters: int) -> int:
+# learning rate decay scheduler (cosine with linear warmup)
+def get_lr(it: int, warmup_iters: int, max_iters: int) -> int:
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
         return learning_rate * it / warmup_iters
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
+    # 2) if it > max_iters, return min learning rate
+    if it > max_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_iters) / (max_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)


### PR DESCRIPTION
This is a minor cosmetic refactor for how hyperparameters are used in the `get_lr` function. Previously, the function did a mix of passing a global variable as input, and binding global variables at the same time. This seemed confusing and unnecessary to me. 