### PR TITLE
Add License at the top of individual files

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import re
 import sys
 import time

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import sys
 from pathlib import Path

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/generate/base.py
+++ b/generate/base.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/generate/full.py
+++ b/generate/full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/generate/sequentially.py
+++ b/generate/sequentially.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import itertools
 import logging
 import re

--- a/lit_gpt/__init__.py
+++ b/lit_gpt/__init__.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import re
 import logging
 

--- a/lit_gpt/adapter.py
+++ b/lit_gpt/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation of the paper:
 
 LLaMA-Adapter: Efficient Fine-tuning of Language Models with Zero-init Attention

--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation of the paper:
 
 LLaMA-Adapter V2: Parameter-Efficient Visual Instruction Model

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 from copy import deepcopy
 from dataclasses import dataclass, field

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # Derived from https://github.com/microsoft/LoRA
 #  ------------------------------------------------------------------------------------------
 #  Copyright (c) Microsoft Corporation. All rights reserved.

--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Full definition of a GPT NeoX Language Model, all of it in this single file.
 
 Based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT and

--- a/lit_gpt/packed_dataset.py
+++ b/lit_gpt/packed_dataset.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # Very loosely inspired by indexed_dataset in Fairseq, Megatron
 # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/data/indexed_dataset.py
 

--- a/lit_gpt/rmsnorm.py
+++ b/lit_gpt/rmsnorm.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 
 

--- a/lit_gpt/tokenizer.py
+++ b/lit_gpt/tokenizer.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 from pathlib import Path
 from typing import Optional, Union

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Utility functions for training and inference."""
 
 import math

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import math
 import sys
 import time

--- a/pretrain/openwebtext_trainer.py
+++ b/pretrain/openwebtext_trainer.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import math
 import sys
 import time

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import math
 import sys
 import time

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 This script is adapted from TinyLlama:
 https://github.com/jzhang38/TinyLlama/blob/main/pretrain/tinyllama.py

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This adapts GPTQ's quantization process: https://github.com/IST-DASLab/gptq/
 # E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 # portions copyright by the authors licensed under the Apache License 2.0

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import gc
 import json
 import sys

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import gc
 import sys
 from functools import partial

--- a/scripts/convert_pretrained_checkpoint.py
+++ b/scripts/convert_pretrained_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import shutil
 import sys

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 from pathlib import Path

--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """This script merges the LoRA weights with the base model"""
 
 import sys

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 
 import json

--- a/scripts/prepare_csv.py
+++ b/scripts/prepare_csv.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import logging
 import sys

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 
 import json

--- a/scripts/prepare_lima.py
+++ b/scripts/prepare_lima.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 
 import json

--- a/scripts/prepare_longform.py
+++ b/scripts/prepare_longform.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 
 import json

--- a/scripts/prepare_openwebtext.py
+++ b/scripts/prepare_openwebtext.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # saves the openwebtext dataset to a binary file for training. following was helpful:
 # https://github.com/HazyResearch/flash-attention/blob/main/training/src/datamodules/language_modeling_hf.py
 import os

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import glob
 import json
 import os

--- a/scripts/prepare_slimpajama.py
+++ b/scripts/prepare_slimpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import os
 import sys

--- a/scripts/prepare_starcoder.py
+++ b/scripts/prepare_starcoder.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 
 from setuptools import find_packages, setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 from pathlib import Path

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 from contextlib import redirect_stdout
 from dataclasses import asdict
 from io import StringIO

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 from contextlib import redirect_stdout
 from io import StringIO

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # this file is just to validate on the CI logs that these tests were run
 from conftest import RunIf
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import sys
 from pathlib import Path

--- a/tests/test_convert_hf_checkpoint.py
+++ b/tests/test_convert_hf_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 from unittest import mock
 
 import pytest

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import os
 from dataclasses import asdict

--- a/tests/test_convert_pretrained_checkpoint.py
+++ b/tests/test_convert_pretrained_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 
 import torch

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from contextlib import redirect_stdout
 from io import StringIO

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import itertools
 import json
 import subprocess

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import lightning as L
 import pytest
 import torch

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 from contextlib import redirect_stdout
 from io import StringIO

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import os
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 from functools import partial
 from pathlib import Path

--- a/tests/test_openwebtext_trainer.py
+++ b/tests/test_openwebtext_trainer.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import pytest
 
 

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from unittest.mock import MagicMock
 

--- a/tests/test_prepare_csv.py
+++ b/tests/test_prepare_csv.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import subprocess
 import sys

--- a/tests/test_prepare_redpajama.py
+++ b/tests/test_prepare_redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import os
 import subprocess

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 from pathlib import Path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from contextlib import redirect_stderr
 from io import StringIO

--- a/xla/finetune/adapter.py
+++ b/xla/finetune/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import time

--- a/xla/generate/adapter.py
+++ b/xla/generate/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/xla/generate/base.py
+++ b/xla/generate/base.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/xla/utils.py
+++ b/xla/utils.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import itertools
 from functools import partial
 from pathlib import Path


### PR DESCRIPTION
lit-gpt is being used in other projects, often vendored (individual files taken out and reused).

This is not a bad thing per se, but we need to make sure the license and authorship are clear when this happens.

This PR adds licenses at the top of every file, just like we do for PyTorch Lightning and Fabric.