### PR TITLE
Phi model update

### DIFF
--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -198,7 +198,7 @@ def copy_weights_phi(
 ) -> None:
     if any(layer_name.startswith(("layers.", "transformer.")) for layer_name in hf_weights):
         raise ValueError(
-            "You are using an outdated Phi1.5 checkpoint. Please reload it as described in 'tutorials/download_phi.md'"
+            "You are using an outdated Phi checkpoint. Please reload it as described in 'tutorials/download_phi.md'"
         )
 
     weight_map = {

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -247,9 +247,9 @@ def copy_weights_phi(
             if q is None or k is None or v is None:
                 # split across different .bin files
                 continue
-            q = load_param(q, f"layer {i} q", dtype)
-            k = load_param(k, f"layer {i} k", dtype)
-            v = load_param(v, f"layer {i} v", dtype)
+            q = load_param(q, f"layer {i} q {weight_type}", dtype)
+            k = load_param(k, f"layer {i} k {weight_type}", dtype)
+            v = load_param(v, f"layer {i} v {weight_type}", dtype)
             q_per_kv = config.n_head // config.n_query_groups
             qs = torch.split(q, config.head_size * q_per_kv)
             ks = torch.split(k, config.head_size)
@@ -306,8 +306,7 @@ def convert_hf_checkpoint(
     elif "phi" in model_name:
         # holder to reconstitute the split q, k, v
         qkv_weights = {}
-        qkv_biases = {}
-        copy_fn = partial(copy_weights_phi, config, qkv_weights, qkv_biases)
+        copy_fn = partial(copy_weights_phi, config, qkv_weights)
     else:
         copy_fn = copy_weights_gpt_neox
 

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -191,7 +191,6 @@ def copy_weights_hf_llama(
 def copy_weights_phi(
     config: Config,
     qkv_weights: Dict[int, List[Optional[NotYetLoadedTensor]]],
-    qkv_biases: Dict[int, List[Optional[NotYetLoadedTensor]]],
     state_dict: Dict[str, torch.Tensor],
     hf_weights: Dict[str, Union[torch.Tensor, NotYetLoadedTensor]],
     saver: Optional[incremental_save] = None,

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -81,21 +81,17 @@ def copy_weights_falcon(
     }
     # the original model definition is different for each size
     if "7b" in model_name:
-        weight_map.update(
-            {
-                "transformer.h.{}.input_layernorm.bias": "transformer.h.{}.norm_1.bias",
-                "transformer.h.{}.input_layernorm.weight": "transformer.h.{}.norm_1.weight",
-            }
-        )
+        weight_map.update({
+            "transformer.h.{}.input_layernorm.bias": "transformer.h.{}.norm_1.bias",
+            "transformer.h.{}.input_layernorm.weight": "transformer.h.{}.norm_1.weight",
+        })
     elif "40b" in model_name or "180B" in model_name:
-        weight_map.update(
-            {
-                "transformer.h.{}.ln_attn.bias": "transformer.h.{}.norm_1.bias",
-                "transformer.h.{}.ln_attn.weight": "transformer.h.{}.norm_1.weight",
-                "transformer.h.{}.ln_mlp.bias": "transformer.h.{}.norm_2.bias",
-                "transformer.h.{}.ln_mlp.weight": "transformer.h.{}.norm_2.weight",
-            }
-        )
+        weight_map.update({
+            "transformer.h.{}.ln_attn.bias": "transformer.h.{}.norm_1.bias",
+            "transformer.h.{}.ln_attn.weight": "transformer.h.{}.norm_1.weight",
+            "transformer.h.{}.ln_mlp.bias": "transformer.h.{}.norm_2.bias",
+            "transformer.h.{}.ln_mlp.weight": "transformer.h.{}.norm_2.weight",
+        })
     else:
         raise NotImplementedError
 
@@ -135,22 +131,18 @@ def copy_weights_hf_llama(
         "lm_head.weight": "lm_head.weight",
     }
     if config._mlp_class == "LLaMAMoE":
-        weight_map.update(
-            {
-                "model.layers.{}.block_sparse_moe.gate.weight": "transformer.h.{l}.mlp.gate.weight",
-                "model.layers.{}.block_sparse_moe.experts.{}.w1.weight": "transformer.h.{l}.mlp.experts.{e}.fc_1.weight",
-                "model.layers.{}.block_sparse_moe.experts.{}.w3.weight": "transformer.h.{l}.mlp.experts.{e}.fc_2.weight",
-                "model.layers.{}.block_sparse_moe.experts.{}.w2.weight": "transformer.h.{l}.mlp.experts.{e}.proj.weight",
-            }
-        )
+        weight_map.update({
+            "model.layers.{}.block_sparse_moe.gate.weight": "transformer.h.{l}.mlp.gate.weight",
+            "model.layers.{}.block_sparse_moe.experts.{}.w1.weight": "transformer.h.{l}.mlp.experts.{e}.fc_1.weight",
+            "model.layers.{}.block_sparse_moe.experts.{}.w3.weight": "transformer.h.{l}.mlp.experts.{e}.fc_2.weight",
+            "model.layers.{}.block_sparse_moe.experts.{}.w2.weight": "transformer.h.{l}.mlp.experts.{e}.proj.weight",
+        })
     elif config._mlp_class == "LLaMAMLP":
-        weight_map.update(
-            {
-                "model.layers.{}.mlp.gate_proj.weight": "transformer.h.{l}.mlp.fc_1.weight",
-                "model.layers.{}.mlp.up_proj.weight": "transformer.h.{l}.mlp.fc_2.weight",
-                "model.layers.{}.mlp.down_proj.weight": "transformer.h.{l}.mlp.proj.weight",
-            }
-        )
+        weight_map.update({
+            "model.layers.{}.mlp.gate_proj.weight": "transformer.h.{l}.mlp.fc_1.weight",
+            "model.layers.{}.mlp.up_proj.weight": "transformer.h.{l}.mlp.fc_2.weight",
+            "model.layers.{}.mlp.down_proj.weight": "transformer.h.{l}.mlp.proj.weight",
+        })
     else:
         raise NotImplementedError
 
@@ -220,8 +212,6 @@ def copy_weights_phi(
         "model.layers.{}.self_attn.k_proj.bias": None,
         "model.layers.{}.self_attn.v_proj.weight": None,
         "model.layers.{}.self_attn.v_proj.bias": None,
-        # "model.layers.{}.mixer.Wqkv.weight": "transformer.h.{}.attn.attn.weight",
-        # "model.layers.{}.mixer.Wqkv.bias": "transformer.h.{}.attn.attn.bias",
         "model.layers.{}.self_attn.dense.weight": "transformer.h.{}.attn.proj.weight",
         "model.layers.{}.self_attn.dense.bias": "transformer.h.{}.attn.proj.bias",
         "model.layers.{}.mlp.fc1.weight": "transformer.h.{}.mlp.fc.weight",

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -240,6 +240,8 @@ def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path
         copy_fn = partial(copy_weights_falcon, config.name)
     elif config._mlp_class in ("LLaMAMLP", "LLaMAMoE"):
         copy_fn = partial(copy_weights_llama, config)
+    elif "phi" in config.name:
+        copy_fn = partial(copy_weights_phi, config)
     else:
         copy_fn = copy_weights_gpt_neox
 

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -166,35 +166,55 @@ def copy_weights_phi(
     saver: Optional[incremental_save] = None,
 ) -> None:
     weight_map = {
-        "transformer.wte.weight": "transformer.embd.wte.weight",
-        "transformer.h.{}.norm_1.bias": "transformer.h.{}.ln.bias",
-        "transformer.h.{}.norm_1.weight": "transformer.h.{}.ln.weight",
-        "transformer.h.{}.attn.attn.bias": "transformer.h.{}.mixer.Wqkv.bias",
-        "transformer.h.{}.attn.attn.weight": "transformer.h.{}.mixer.Wqkv.weight",
-        "transformer.h.{}.attn.proj.bias": "transformer.h.{}.mixer.out_proj.bias",
-        "transformer.h.{}.attn.proj.weight": "transformer.h.{}.mixer.out_proj.weight",
-        "transformer.h.{}.mlp.fc.bias": "transformer.h.{}.mlp.fc1.bias",
-        "transformer.h.{}.mlp.fc.weight": "transformer.h.{}.mlp.fc1.weight",
-        "transformer.h.{}.mlp.proj.bias": "transformer.h.{}.mlp.fc2.bias",
-        "transformer.h.{}.mlp.proj.weight": "transformer.h.{}.mlp.fc2.weight",
-        "transformer.ln_f.weight": "lm_head.ln.weight",
-        "transformer.ln_f.bias": "lm_head.ln.bias",
-        "lm_head.weight": "lm_head.linear.weight",
-        "lm_head.bias": "lm_head.linear.bias",
+        "transformer.wte.weight": "model.embed_tokens.weight",
+        "transformer.h.{}.norm_1.weight": "model.layers.{}.input_layernorm.weight",
+        "transformer.h.{}.norm_1.bias": "model.layers.{}.input_layernorm.bias",
+        "transformer.h.{}.attn.proj.weight": "model.layers.{}.self_attn.dense.weight",
+        "transformer.h.{}.attn.proj.bias": "model.layers.{}.self_attn.dense.bias",
+        "transformer.h.{}.mlp.fc.weight": "model.layers.{}.mlp.fc1.weight",
+        "transformer.h.{}.mlp.fc.bias": "model.layers.{}.mlp.fc1.bias",
+        "transformer.h.{}.mlp.proj.weight": "model.layers.{}.mlp.fc2.weight",
+        "transformer.h.{}.mlp.proj.bias": "model.layers.{}.mlp.fc2.bias",
+        "transformer.ln_f.weight": "model.final_layernorm.weight",
+        "transformer.ln_f.bias": "model.final_layernorm.bias",
+        "lm_head.weight": "lm_head.weight",
+        "lm_head.bias": "lm_head.bias",
     }
 
     for name, param in lit_weights.items():
-        if name.startswith("transformer.h."):
-            from_name, number = layer_template(name, 2)
-            to_name = weight_map[from_name].format(number)
+        if name.endswith(".attn.attn.weight"):
+            from_name, l = layer_template(name, 2)
+            q = "model.layers.{}.self_attn.q_proj.weight".format(l)
+            k = "model.layers.{}.self_attn.k_proj.weight".format(l)
+            v = "model.layers.{}.self_attn.v_proj.weight".format(l)
+            qkv = load_param(param, name, None)
+            qp, kp, vp = qkv_split(qkv, config)
+            for to_name, param in zip((q, k, v), (qp, kp, vp)):
+                if saver is not None:
+                    param = saver.store_early(param)
+                state_dict[to_name] = param
+        elif name.endswith(".attn.attn.bias"):
+            from_name, l = layer_template(name, 2)
+            q = "model.layers.{}.self_attn.q_proj.bias".format(l)
+            k = "model.layers.{}.self_attn.k_proj.bias".format(l)
+            v = "model.layers.{}.self_attn.v_proj.bias".format(l)
+            qkv = load_param(param, name, None)
+            qp, kp, vp = qkv_split(qkv, config)
+            for to_name, param in zip((q, k, v), (qp, kp, vp)):
+                if saver is not None:
+                    param = saver.store_early(param)
+                state_dict[to_name] = param
         else:
-            to_name = weight_map[name]
-        param = load_param(param, name, None)
-        if "attn.attn." in name:
-            param = torch.cat(qkv_split(param, config))
-        if saver is not None:
-            param = saver.store_early(param)
-        state_dict[to_name] = param
+            if "transformer.h" in name:
+                from_name, l = layer_template(name, 2)
+                to_name = weight_map[from_name]
+                to_name = to_name.format(l)
+            else:
+                to_name = weight_map[name]
+            param = load_param(param, name, None)
+            if saver is not None:
+                param = saver.store_early(param)
+            state_dict[to_name] = param
 
 
 def qkv_split(

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -182,22 +182,12 @@ def copy_weights_phi(
     }
 
     for name, param in lit_weights.items():
-        if name.endswith(".attn.attn.weight"):
+        if name.endswith((".attn.attn.weight", ".attn.attn.bias")):
             from_name, l = layer_template(name, 2)
-            q = "model.layers.{}.self_attn.q_proj.weight".format(l)
-            k = "model.layers.{}.self_attn.k_proj.weight".format(l)
-            v = "model.layers.{}.self_attn.v_proj.weight".format(l)
-            qkv = load_param(param, name, None)
-            qp, kp, vp = qkv_split(qkv, config)
-            for to_name, param in zip((q, k, v), (qp, kp, vp)):
-                if saver is not None:
-                    param = saver.store_early(param)
-                state_dict[to_name] = param
-        elif name.endswith(".attn.attn.bias"):
-            from_name, l = layer_template(name, 2)
-            q = "model.layers.{}.self_attn.q_proj.bias".format(l)
-            k = "model.layers.{}.self_attn.k_proj.bias".format(l)
-            v = "model.layers.{}.self_attn.v_proj.bias".format(l)
+            weight_type = name.split(".")[-1]  # weight or bias
+            q = f"model.layers.{l}.self_attn.q_proj.{weight_type}"
+            k = f"model.layers.{l}.self_attn.k_proj.{weight_type}"
+            v = f"model.layers.{l}.self_attn.v_proj.{weight_type}"
             qkv = load_param(param, name, None)
             qp, kp, vp = qkv_split(qkv, config)
             for to_name, param in zip((q, k, v), (qp, kp, vp)):

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -52,7 +52,6 @@ def download_from_hub(
         raise ValueError("`--from_safetensors=True` won't have an effect with `--tokenizer_only=True`")
 
     # contains revisions that are known to work without issues
-    hf_model_revision_map = {"microsoft/phi-1_5": "24f9ea14df973a49a0d87c16d04df88d90067468"}
     directory = checkpoint_dir / repo_id
     snapshot_download(
         repo_id,
@@ -61,7 +60,6 @@ def download_from_hub(
         resume_download=True,
         allow_patterns=download_files,
         token=access_token,
-        revision=hf_model_revision_map.get(repo_id),
     )
 
     # convert safetensors to PyTorch binaries

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -258,14 +258,13 @@ def test_against_hf_phi():
     )
     T = 5
     theirs_config = PhiConfig(
-        n_positions=ours_config.block_size,
-        n_embd=ours_config.n_embd,
-        n_head=ours_config.n_head,
-        n_layer=ours_config.n_layer,
-        rotary_dim=ours_config.rope_n_elem,
-        architecture={"block_cls": "parallel", "mixer": {}, "mlp": {"mlp_cls": "mlp"}},
+        vocab_size=ours_config.padded_vocab_size,
+        max_position_embeddings=ours_config.block_size,
+        hidden_size=ours_config.n_embd,
+        intermediate_size=ours_config.intermediate_size,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
     )
-    theirs_config.vocab_size = ours_config.padded_vocab_size
 
     ours_model = GPT(ours_config)
     ours_state_dict = ours_model.state_dict()

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -241,8 +241,8 @@ def test_against_hf_phi():
     workdir.mkdir(parents=True, exist_ok=True)
     file_paths = [workdir / "original_phi_1_5.py", workdir / "configuration_phi.py"]
     urls = [
-        "https://huggingface.co/microsoft/phi-1_5/raw/24f9ea14df973a49a0d87c16d04df88d90067468/modeling_phi.py",
-        "https://huggingface.co/microsoft/phi-1_5/raw/24f9ea14df973a49a0d87c16d04df88d90067468/configuration_phi.py",
+        "https://huggingface.co/microsoft/phi-1_5/raw/main/modeling_phi.py",
+        "https://huggingface.co/microsoft/phi-1_5/raw/main/configuration_phi.py",
     ]
     for file_path, url in zip(file_paths, urls):
         if not file_path.is_file():

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -236,7 +236,7 @@ def test_against_original_open_llama_3b():
 
 
 @torch.inference_mode()
-def test_against_hf_phi():
+def test_against_hf_phi_1_5():
     workdir = wd / "tests" / "reference_models"
     workdir.mkdir(parents=True, exist_ok=True)
     file_paths = [workdir / "original_phi_1_5.py", workdir / "configuration_phi.py"]
@@ -255,6 +255,55 @@ def test_against_hf_phi():
 
     ours_config = Config.from_name(
         "phi-1_5", padded_vocab_size=10000, n_layer=2, n_head=4, n_embd=256, rotary_percentage=0.5
+    )
+    T = 5
+    theirs_config = PhiConfig(
+        vocab_size=ours_config.padded_vocab_size,
+        max_position_embeddings=ours_config.block_size,
+        hidden_size=ours_config.n_embd,
+        intermediate_size=ours_config.intermediate_size,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
+    )
+
+    ours_model = GPT(ours_config)
+    ours_state_dict = ours_model.state_dict()
+    theirs_state_dict = {}
+    copy_weights_phi(ours_config, theirs_state_dict, ours_state_dict)
+    theirs_model = PhiForCausalLM(theirs_config)
+    # strict=False because we don't save the rotary embeddings inv frequency
+    keys = theirs_model.load_state_dict(theirs_state_dict, strict=False)
+    assert not keys.unexpected_keys
+    assert all("inv_freq" in k for k in keys.missing_keys)
+
+    # test end to end
+    x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32)
+    assert x.size(1) == T
+    ours_y = ours_model(x)
+    theirs_y = theirs_model(x)["logits"]
+    torch.testing.assert_close(ours_y, theirs_y)
+
+
+@torch.inference_mode()
+def test_against_hf_phi_2():
+    workdir = wd / "tests" / "reference_models"
+    workdir.mkdir(parents=True, exist_ok=True)
+    file_paths = [workdir / "original_phi_2.py", workdir / "configuration_phi.py"]
+    urls = [
+        "https://huggingface.co/microsoft/phi-2/raw/main/modeling_phi.py",
+        "https://huggingface.co/microsoft/phi-2/raw/main/configuration_phi.py",
+    ]
+    for file_path, url in zip(file_paths, urls):
+        if not file_path.is_file():
+            urlretrieve(url=url, filename=file_path)
+
+    from lit_gpt import GPT, Config
+    from scripts.convert_lit_checkpoint import copy_weights_phi
+    from tests.reference_models.configuration_phi import PhiConfig
+    from tests.reference_models.original_phi_2 import PhiForCausalLM
+
+    ours_config = Config.from_name(
+        "phi-2", padded_vocab_size=10000, n_layer=2, n_head=4, n_embd=256, rotary_percentage=0.5
     )
     T = 5
     theirs_config = PhiConfig(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -277,8 +277,8 @@ def test_against_hf_phi_1_5(device, dtype):
     workdir.mkdir(parents=True, exist_ok=True)
     file_paths = [workdir / "original_phi_1_5.py", workdir / "configuration_phi.py"]
     urls = [
-        "https://huggingface.co/microsoft/phi-1_5/raw/24f9ea14df973a49a0d87c16d04df88d90067468/modeling_phi.py",
-        "https://huggingface.co/microsoft/phi-1_5/raw/24f9ea14df973a49a0d87c16d04df88d90067468/configuration_phi.py",
+        "https://huggingface.co/microsoft/phi-1_5/raw/main/modeling_phi.py",
+        "https://huggingface.co/microsoft/phi-1_5/raw/main/configuration_phi.py",
     ]
     for file_path, url in zip(file_paths, urls):
         if not file_path.is_file():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -302,6 +302,7 @@ def test_against_hf_phi_1_5(device, dtype):
         intermediate_size=ours_config.intermediate_size,
         num_attention_heads=ours_config.n_head,
         num_hidden_layers=ours_config.n_layer,
+        partial_rotary_factor=ours_config.rotary_percentage,
         torch_dtype=dtype,
     )
 
@@ -362,6 +363,7 @@ def test_against_hf_phi_2(device, dtype):
         intermediate_size=ours_config.intermediate_size,
         num_attention_heads=ours_config.n_head,
         num_hidden_layers=ours_config.n_layer,
+        partial_rotary_factor=ours_config.rotary_percentage,
         torch_dtype=dtype,
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -296,20 +296,19 @@ def test_against_hf_phi_1_5(device, dtype):
     )
     T = 5
     theirs_config = PhiConfig(
-        n_positions=ours_config.block_size,
-        n_embd=ours_config.n_embd,
-        n_head=ours_config.n_head,
-        n_layer=ours_config.n_layer,
-        rotary_dim=ours_config.rope_n_elem,
-        architecture={"block_cls": "parallel", "mixer": {}, "mlp": {"mlp_cls": "mlp"}},
+        vocab_size=ours_config.padded_vocab_size,
+        max_position_embeddings=ours_config.block_size,
+        hidden_size=ours_config.n_embd,
+        intermediate_size=ours_config.intermediate_size,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
         torch_dtype=dtype,
     )
-    theirs_config.vocab_size = ours_config.padded_vocab_size
 
     theirs_model = PhiForCausalLM(theirs_config).to(device)
     theirs_state_dict = theirs_model.state_dict()
     state_dict = {}
-    copy_weights_phi(ours_config, state_dict, theirs_state_dict)
+    copy_weights_phi(ours_config, {}, {}, state_dict, theirs_state_dict)
     ours_model = GPT(ours_config).to(device)
     ours_model.load_state_dict(state_dict)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -308,7 +308,7 @@ def test_against_hf_phi_1_5(device, dtype):
     theirs_model = PhiForCausalLM(theirs_config).to(device)
     theirs_state_dict = theirs_model.state_dict()
     state_dict = {}
-    copy_weights_phi(ours_config, {}, {}, state_dict, theirs_state_dict)
+    copy_weights_phi(ours_config, {}, state_dict, theirs_state_dict)
     ours_model = GPT(ours_config).to(device)
     ours_model.load_state_dict(state_dict)
 
@@ -368,7 +368,7 @@ def test_against_hf_phi_2(device, dtype):
     theirs_model = PhiForCausalLM(theirs_config).to(device)
     theirs_state_dict = theirs_model.state_dict()
     state_dict = {}
-    copy_weights_phi(ours_config, {}, {}, state_dict, theirs_state_dict)
+    copy_weights_phi(ours_config, {}, state_dict, theirs_state_dict)
     ours_model = GPT(ours_config).to(device)
     ours_model.load_state_dict(state_dict)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -356,20 +356,19 @@ def test_against_hf_phi_2(device, dtype):
     )
     T = 5
     theirs_config = PhiConfig(
-        n_positions=ours_config.block_size,
-        n_embd=ours_config.n_embd,
-        n_head=ours_config.n_head,
-        n_layer=ours_config.n_layer,
-        rotary_dim=ours_config.rope_n_elem,
-        architecture={"block_cls": "parallel", "mixer": {}, "mlp": {"mlp_cls": "mlp"}},
+        vocab_size=ours_config.padded_vocab_size,
+        max_position_embeddings=ours_config.block_size,
+        hidden_size=ours_config.n_embd,
+        intermediate_size=ours_config.intermediate_size,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
         torch_dtype=dtype,
     )
-    theirs_config.vocab_size = ours_config.padded_vocab_size
 
     theirs_model = PhiForCausalLM(theirs_config).to(device)
     theirs_state_dict = theirs_model.state_dict()
     state_dict = {}
-    copy_weights_phi(ours_config, state_dict, theirs_state_dict)
+    copy_weights_phi(ours_config, {}, {}, state_dict, theirs_state_dict)
     ours_model = GPT(ours_config).to(device)
     ours_model.load_state_dict(state_dict)
 


### PR DESCRIPTION
Hi there 👋 

As @awaelchli stated in #868, Phi1.5 model was changed. As it turned out, Phi2 was changed as well.

The main changes are:
- instead of `QKV` matrix now these models use separate `q`, `k` and `v` matrices
- `PhiConfig` now expects arguments with different names. What is dangerous about it, is that this config class also expects `**kwargs`, so old names (that don't match new args) just assigned to the keyword argument and thus no error is raised.