### PR TITLE
Add config for `Mistral-7B-Instruct-v0.2`

### DIFF
--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1191,6 +1191,22 @@ mistral = [
         _mlp_class="LLaMAMLP",
         intermediate_size=14336,
     ),
+    # https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/config.json
+    dict(
+        name="Mistral-7B-Instruct-{}v0.2",
+        hf_config=dict(org="mistralai", name="Mistral-7B-Instruct-{}v0.2"),
+        padded_vocab_size=32000,
+        block_size=4096,  # should be 32768 but sliding window attention is not implemented
+        n_layer=32,
+        n_query_groups=8,
+        rotary_percentage=1.0,
+        parallel_residual=False,
+        bias=False,
+        _norm_class="RMSNorm",
+        norm_eps=1e-05,
+        _mlp_class="LLaMAMLP",
+        intermediate_size=14336,
+    ),
     # https://huggingface.co/mistralai/Mixtral-8x7B-v0.1/blob/main/config.json
     dict(
         name="Mixtral-8x7B-{}v0.1",

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1191,22 +1191,6 @@ mistral = [
         _mlp_class="LLaMAMLP",
         intermediate_size=14336,
     ),
-    # https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/config.json
-    dict(
-        name="Mistral-7B-Instruct-{}v0.2",
-        hf_config=dict(org="mistralai", name="Mistral-7B-Instruct-{}v0.2"),
-        padded_vocab_size=32000,
-        block_size=4096,  # should be 32768 but sliding window attention is not implemented
-        n_layer=32,
-        n_query_groups=8,
-        rotary_percentage=1.0,
-        parallel_residual=False,
-        bias=False,
-        _norm_class="RMSNorm",
-        norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
-        intermediate_size=14336,
-    ),
     # https://huggingface.co/mistralai/Mixtral-8x7B-v0.1/blob/main/config.json
     dict(
         name="Mixtral-8x7B-{}v0.1",
@@ -1233,6 +1217,24 @@ for c in mistral:
         copy["name"] = c["name"].format(kind)
         copy["hf_config"]["name"] = c["hf_config"]["name"].format(kind)
         configs.append(copy)
+configs.append(
+    # https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/config.json
+    dict(
+        name="Mistral-7B-Instruct-v0.2",
+        hf_config=dict(org="mistralai", name="Mistral-7B-Instruct-{}v0.2"),
+        padded_vocab_size=32000,
+        block_size=32768,
+        n_layer=32,
+        n_query_groups=8,
+        rotary_percentage=1.0,
+        parallel_residual=False,
+        bias=False,
+        _norm_class="RMSNorm",
+        norm_eps=1e-05,
+        _mlp_class="LLaMAMLP",
+        intermediate_size=14336,
+    )
+)
 
 
 ############

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -1221,7 +1221,7 @@ configs.append(
     # https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/config.json
     dict(
         name="Mistral-7B-Instruct-v0.2",
-        hf_config=dict(org="mistralai", name="Mistral-7B-Instruct-{}v0.2"),
+        hf_config=dict(org="mistralai", name="Mistral-7B-Instruct-v0.2"),
         padded_vocab_size=32000,
         block_size=32768,
         n_layer=32,

--- a/tutorials/download_mistral.md
+++ b/tutorials/download_mistral.md
@@ -13,6 +13,22 @@
 
 Details about the data used to train the model or training procedure have not been made public.
 
+To see all the available checkpoints, run:
+
+```bash
+python scripts/download.py | grep -E 'Mistral|Mixtral'
+```
+
+which will print
+
+```text
+mistralai/Mistral-7B-v0.1
+mistralai/Mistral-7B-Instruct-v0.1
+mistralai/Mixtral-8x7B-v0.1
+mistralai/Mixtral-8x7B-Instruct-v0.1
+mistralai/Mistral-7B-Instruct-v0.2
+```
+
 In order to use the Mistral 7B model checkpoint, which requires about 14 GB of disk space, download the weights and convert the checkpoint to the lit-gpt format:
 
 ```bash

--- a/tutorials/download_mistral.md
+++ b/tutorials/download_mistral.md
@@ -18,9 +18,9 @@ In order to use the Mistral 7B model checkpoint, which requires about 14 GB of d
 ```bash
 pip install huggingface_hub
 
-python scripts/download.py --repo_id mistralai/Mistral-7B-Instruct-v0.1
+python scripts/download.py --repo_id mistralai/Mistral-7B-Instruct-v0.2
 
-python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/mistralai/Mistral-7B-Instruct-v0.1
+python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/mistralai/Mistral-7B-Instruct-v0.2
 ```
 
 You're done! To execute the model just run:
@@ -28,7 +28,7 @@ You're done! To execute the model just run:
 ```bash
 pip install sentencepiece
 
-python chat/base.py --checkpoint_dir checkpoints/mistralai/Mistral-7B-Instruct-v0.1
+python chat/base.py --checkpoint_dir checkpoints/mistralai/Mistral-7B-Instruct-v0.2
 ```
 
 ### Mixtral


### PR DESCRIPTION
I wanted to use mistral_instruct_v0.2, which is an instruction-fine tuned version of mistral_instruct_v0.1, but it was not supported by "python scripts/convert_hf_checkpoint.py". I compared each details and different points of mistral_instruct_v0.1 and v0.2, but there were no different points. So I added config for v0.2. 

Fixes https://github.com/Lightning-AI/lit-gpt/issues/865