### PR TITLE
Updates to full-finetune script

### DIFF
--- a/finetune/full.py
+++ b/finetune/full.py
@@ -202,7 +202,7 @@ def train(
 
             fabric.print(
                 f"iter {metrics['iter']} | step {metrics['step']}: loss {metrics['loss']:.4f}, iter time:"
-                f" {metrics['iter_time'] * 1000:.2f} ms{' (optimizer.step),' if not is_accumulating else ','}"
+                f" {metrics['iter_time'] * 1000:.2f} ms{' (optimizer.step)' if not is_accumulating else ''}"
             )
             fabric.log_dict(metrics, step=state["iter_num"])
 

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -40,7 +40,7 @@ devices = 1
 learning_rate = 3e-3
 batch_size = 64 / devices
 micro_batch_size = 1
-gradient_accumulation_iters = batch_size // micro_batch_size
+gradient_accumulation_iters = int(batch_size // micro_batch_size)
 assert gradient_accumulation_iters > 0
 max_seq_length = None  # assign value to truncate
 epoch_size = 50000  # train dataset size

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -25,6 +25,7 @@ from lit_gpt.utils import (
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
+    load_checkpoint,
     num_parameters,
 )
 from scripts.prepare_alpaca import generate_prompt
@@ -109,6 +110,8 @@ def main(fabric: L.Fabric, data_dir: Path, checkpoint_dir: Path, out_dir: Path, 
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)
+    else:
+        load_checkpoint(fabric, state["model"], checkpoint_path)
 
     fabric.seed_everything(1337 + fabric.global_rank)
 

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -156,7 +156,6 @@ def train(
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x
 
-    # TODO: max iters
     initial_iter = state["iter_num"]
 
     # resume data loader state by fast-forwarding through all seen batches
@@ -218,7 +217,7 @@ def train(
                 "iter_time": t1 - iter_t0,
                 "tokens": state["iter_num"] * micro_batch_size * model.config.block_size,
                 "total_tokens": state["iter_num"] * micro_batch_size * model.config.block_size * fabric.world_size,
-                # TODO: learning rate
+                # TODO: log learning rate
             }
 
             fabric.print(

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -57,10 +57,10 @@ decay_lr = True
 min_lr = 4e-5
 
 batch_size = global_batch_size // devices
-gradient_accumulation_steps = batch_size // micro_batch_size
-assert gradient_accumulation_steps > 0
-warmup_iters = warmup_steps * gradient_accumulation_steps
-log_iter_interval = log_step_interval * gradient_accumulation_steps
+gradient_accumulation_iters = batch_size // micro_batch_size
+assert gradient_accumulation_iters > 0
+warmup_iters = warmup_steps * gradient_accumulation_iters
+log_iter_interval = log_step_interval * gradient_accumulation_iters
 
 
 hparams = {k: v for k, v in locals().items() if isinstance(v, (int, float, str)) and not k.startswith("_")}
@@ -158,7 +158,7 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
             f" {initial_iter}, epoch {train_iterator.epoch}."
         )
 
-    running_loss = RunningMean(window=gradient_accumulation_steps, sync_on_compute=False).to(fabric.device)
+    running_loss = RunningMean(window=gradient_accumulation_iters, sync_on_compute=False).to(fabric.device)
     fabric.barrier()
     total_t0 = time.perf_counter()
 
@@ -177,11 +177,11 @@ def train(fabric, state, train_dataloader, val_dataloader, resume):
         input_ids = train_data[:, 0 : model.config.block_size].contiguous().long()
         targets = train_data[:, 1 : (model.config.block_size + 1)].contiguous().long()
 
-        is_accumulating = state["iter_num"] % gradient_accumulation_steps != 0
+        is_accumulating = state["iter_num"] % gradient_accumulation_iters != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
             loss = chunked_cross_entropy(logits, targets)
-            fabric.backward(loss / gradient_accumulation_steps)
+            fabric.backward(loss / gradient_accumulation_iters)
 
         running_loss.update(loss.detach())
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -16,8 +16,8 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import finetune.full as module
 
     module.gradient_accumulation_iters = 1
-    module.save_interval = 2
-    module.eval_interval = 2
+    module.save_step_interval = 2
+    module.eval_step_interval = 2
     module.eval_iters = 2
     module.eval_max_new_tokens = 1
     module.max_iters = 6
@@ -54,7 +54,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     logs = stdout.getvalue()
     assert logs.count("optimizer.step") == module.max_iters
-    assert logs.count("val loss") == module.max_iters // module.eval_interval
+    assert logs.count("val loss") == module.max_iters // module.eval_step_interval
     assert "of trainable parameters: 1,888" in logs
 
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -45,9 +45,9 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
         module.setup(data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path, precision="32-true")
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
-        "iter-000002-ckpt.pth",
-        "iter-000004-ckpt.pth",
-        "iter-000006-ckpt.pth",
+        "step-000002.pth",
+        "step-000004.pth",
+        "step-000006.pth",
         "lit_model_finetuned.pth",
     }
     assert (tmp_path / "version_0" / "metrics.csv").is_file()

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -74,7 +74,7 @@ def test_pretrain_tiny_llama(tmp_path, monkeypatch):
     module.global_batch_size = 1
     module.micro_batch_size = 1
     module.batch_size = 1
-    module.gradient_accumulation_steps = 1
+    module.gradient_accumulation_iters = 1
     module.model_name = "tmp"
     module.out_dir = tmp_path
 

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -51,7 +51,8 @@ You can test the finetuned model with your own instructions by running:
 ```bash
 python generate/full.py \
     --prompt "Recommend a movie to watch on the weekend." \
-    --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+    --checkpoint_dir checkpoints/tiiuae/falcon-7b \
+    --finetuned_path out/full/my-model-finetuned/lit_model_finetuned.pth
 ```
 
 Output:


### PR DESCRIPTION
The core logic for full finetuning is very similar to pretraining. The main differences are in loading the checkpoint, the data we train on, and the hyperparameters. 

In this PR, I'm porting over all the improvements made in tinyllama.py to this script. Most changes are for consistency. Notable additions are:
- Correct resuming logic for dataset
- Logging of metrics

Follow-up to #788