### PR TITLE
Update requirements.txt (add bitsandbytes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch>=2.1.0
+bitsandbytes==0.41.0
 lightning @ git+https://github.com/Lightning-AI/lightning@6dfa5cca9de5c28548eef5582a53c483b0eda66a
 jsonargparse[signatures]  # CLI


### PR DESCRIPTION
Hey,
I've created a pull request to address an issue encountered when running the **Falcon Inference notebook**. The error was related to a missing dependency, and to resolve this, I have added the following line to the requirements file:
```
bitsandbytes==0.41.0
```
