### PR TITLE
Update falcon-inference.ipynb

### DIFF
--- a/notebooks/falcon-inference.ipynb
+++ b/notebooks/falcon-inference.ipynb
@@ -48,7 +48,8 @@
    "outputs": [],
    "source": [
     "# install the dependencies\n",
-    "!pip install huggingface_hub tokenizers sentencepiece -r requirements.txt -q"
+    "!pip install bitsandbytes==0.41.0 huggingface_hub tokenizers sentencepiece -r requirements.txt -q"
+""
    ]
   },
   {

--- a/notebooks/falcon-inference.ipynb
+++ b/notebooks/falcon-inference.ipynb
@@ -48,8 +48,7 @@
    "outputs": [],
    "source": [
     "# install the dependencies\n",
-    "!pip install bitsandbytes==0.41.0 huggingface_hub tokenizers sentencepiece -r requirements.txt -q"
-""
+    "!pip install -r requirements-all.txt -q"
    ]
   },
   {


### PR DESCRIPTION
I've created a pull request to address an issue encountered when running the Falcon Inference notebook. The error was related to a missing dependency, and to resolve this, I have added the following line to the requirements file:
`bitsandbytes==0.41.0`