### PR TITLE
Args everywhere: input validation and some standardization

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -19,7 +19,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
-from lit_gpt.args import DataArgs, EvalArgs, IOArgs, OptimizationArgs, TrainArgs
+from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
     check_valid_checkpoint_dir,
@@ -47,7 +47,7 @@ def setup(
     global_batch_size: int = 64,
     micro_batch_size: int = 4,
     max_seq_length: Optional[int] = None,  # set value to truncate
-    lr_warmup_epochs: int = 2,
+    lr_warmup_steps: int = 100,
     epochs: int = 5,
     train_epoch_size: int = 50000,
 ) -> None:
@@ -85,35 +85,29 @@ def setup(
         main,
         devices,
         Config.from_name(name=checkpoint_dir.name),
-        IOArgs(data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
+        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
         TrainArgs(
             save_interval=save_interval,
             log_interval=log_interval,
             global_batch_size=global_batch_size,
             micro_batch_size=micro_batch_size,
-            lr_warmup_epochs=lr_warmup_epochs,
+            lr_warmup_steps=lr_warmup_steps,
             epochs=epochs,
             epoch_size=train_epoch_size,
+            learning_rate=learning_rate,
+            max_seq_length=max_seq_length,
         ),
         EvalArgs(interval=eval_interval, max_new_tokens=eval_max_new_tokens, max_iters=eval_iters),
-        OptimizationArgs(learning_rate=learning_rate),
-        DataArgs(max_seq_length=max_seq_length),
     )
 
 
 def main(
-    fabric: L.Fabric,
-    devices: int,
-    config: Config,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
-    optimization_args: OptimizationArgs,
-    data_args: DataArgs,
+    fabric: L.Fabric, devices: int, config: Config, io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs
 ) -> None:
+    validate_args(io_args, train_args, eval_args)
+
     steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
     lr_max_steps = train_args.epochs * steps_per_epoch
-    lr_warmup_steps = train_args.lr_warmup_epochs * steps_per_epoch
 
     check_valid_checkpoint_dir(io_args.checkpoint_dir)
 
@@ -122,8 +116,8 @@ def main(
     if fabric.global_rank == 0:
         os.makedirs(io_args.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.data_dir / "train.pt")
-    val_data = torch.load(io_args.data_dir / "test.pt")
+    train_data = torch.load(io_args.train_data_dir / "train.pt")
+    val_data = torch.load(io_args.val_data_dir / "test.pt")
 
     checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
@@ -145,12 +139,12 @@ def main(
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
         trainable_params,
-        lr=optimization_args.learning_rate,
-        weight_decay=optimization_args.weight_decay,
-        betas=(optimization_args.beta1, optimization_args.beta2),
+        lr=train_args.learning_rate,
+        weight_decay=train_args.weight_decay,
+        betas=(train_args.beta1, train_args.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
-    scheduler = get_lr_scheduler(optimizer, warmup_steps=lr_warmup_steps, max_steps=lr_max_steps)
+    scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
 
     # strict=False because missing keys due to Adapter weights not contained in state dict
     load_checkpoint(fabric, model, checkpoint_path, strict=False)
@@ -158,7 +152,7 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args, data_args)
+    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
@@ -179,18 +173,17 @@ def train(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    data_args: DataArgs,
 ) -> None:
     tokenizer = Tokenizer(io_args.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, data_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args, data_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
     )  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
@@ -205,7 +198,7 @@ def train(
             fabric,
             train_data,
             train_args.micro_batch_size,
-            data_args.max_seq_length,
+            train_args.max_seq_length,
             longest_seq_ix if iter_num == 1 else None,
         )
 
@@ -241,7 +234,7 @@ def train(
 
         if not is_accumulating and step_count % eval_args.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args, data_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
@@ -253,19 +246,13 @@ def train(
 # the adapter "kv cache" cannot be initialized under `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric,
-    model: GPT,
-    val_data: List[Dict],
-    tokenizer: Tokenizer,
-    eval_args: EvalArgs,
-    train_args: TrainArgs,
-    data_args: DataArgs,
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_args.max_iters)
     for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, data_args.max_seq_length)
+        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -350,6 +337,19 @@ def get_longest_seq_length(data: List[Dict]) -> Tuple[int, int]:
 def save_adapter_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_path: Path) -> None:
     fabric.print(f"Saving adapter weights to {str(file_path)!r}")
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
+
+
+def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
+    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+    for args, names in unsupported:
+        for name in names:
+            if getattr(args, name) is not None:
+                raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
+    required = [(io_args, ["checkpoint_dir"]), (train_args, ["epoch_size", "epochs"]), (eval_args, ["max_new_tokens"])]
+    for args, names in required:
+        for name in names:
+            if getattr(args, name) is None:
+                raise ValueError(f"{__file__} requires the {name!r} argument. This is set in {args}")
 
 
 if __name__ == "__main__":

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -18,7 +18,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.args import DataArgs, EvalArgs, IOArgs, OptimizationArgs, TrainArgs
+from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.model import GPT, Block, Config
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
@@ -58,7 +58,7 @@ def setup(
     global_batch_size: int = 64,
     micro_batch_size: int = 1,
     max_seq_length: Optional[int] = None,  # set value to truncate
-    lr_warmup_epochs: int = 2,
+    lr_warmup_steps: int = 100,
     epochs: int = 5,
     train_epoch_size: int = 50000,
     resume: Union[bool, Path] = False,
@@ -85,19 +85,19 @@ def setup(
         devices,
         resume,
         Config.from_name(name=checkpoint_dir.name),
-        IOArgs(data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
+        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
         TrainArgs(
             save_interval=save_interval,
             log_interval=log_interval,
             global_batch_size=global_batch_size,
             micro_batch_size=micro_batch_size,
-            lr_warmup_epochs=lr_warmup_epochs,
+            lr_warmup_steps=lr_warmup_steps,
             epochs=epochs,
             epoch_size=train_epoch_size,
+            learning_rate=learning_rate,
+            max_seq_length=max_seq_length,
         ),
         EvalArgs(interval=eval_interval, max_new_tokens=eval_max_new_tokens, max_iters=eval_iters),
-        OptimizationArgs(learning_rate=learning_rate),
-        DataArgs(max_seq_length=max_seq_length),
     )
 
 
@@ -109,12 +109,11 @@ def main(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    optimization_args: OptimizationArgs,
-    data_args: DataArgs,
 ) -> None:
+    validate_args(io_args, train_args, eval_args)
+
     steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
     lr_max_steps = train_args.epochs * steps_per_epoch
-    lr_warmup_steps = train_args.lr_warmup_epochs * steps_per_epoch
 
     check_valid_checkpoint_dir(io_args.checkpoint_dir)
 
@@ -123,8 +122,8 @@ def main(
     if fabric.global_rank == 0:
         os.makedirs(io_args.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.data_dir / "train.pt")
-    val_data = torch.load(io_args.data_dir / "test.pt")
+    train_data = torch.load(io_args.train_data_dir / "train.pt")
+    val_data = torch.load(io_args.val_data_dir / "test.pt")
 
     checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
@@ -136,12 +135,12 @@ def main(
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
         model.parameters(),
-        lr=optimization_args.learning_rate,
-        weight_decay=optimization_args.weight_decay,
-        betas=(optimization_args.beta1, optimization_args.beta2),
+        lr=train_args.learning_rate,
+        weight_decay=train_args.weight_decay,
+        betas=(train_args.beta1, train_args.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
-    scheduler = get_lr_scheduler(optimizer, warmup_steps=lr_warmup_steps, max_steps=lr_max_steps)
+    scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
     state = {"model": model, "optimizer": optimizer, "scheduler": scheduler, "iter_num": 0, "step_count": 0}
 
     if resume is True:
@@ -155,7 +154,7 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, state, train_data, val_data, devices, resume, io_args, train_args, eval_args, data_args)
+    train(fabric, state, train_data, val_data, devices, resume, io_args, train_args, eval_args)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
@@ -174,21 +173,20 @@ def train(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    data_args: DataArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
     tokenizer = Tokenizer(io_args.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, data_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args, data_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
     )  # sanity check
     initial_iter = state["iter_num"]
 
@@ -217,7 +215,7 @@ def train(
             fabric,
             train_data,
             train_args.micro_batch_size,
-            data_args.max_seq_length,
+            train_args.max_seq_length,
             longest_seq_ix if state["iter_num"] == 1 else None,
         )
 
@@ -258,7 +256,7 @@ def train(
 
         if not is_accumulating and state["step_count"] % eval_args.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args, data_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {state['iter_num']}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
@@ -273,19 +271,13 @@ def train(
 # FSDP has issues with `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric,
-    model: GPT,
-    val_data: List[Dict],
-    tokenizer: Tokenizer,
-    eval_args: EvalArgs,
-    train_args: TrainArgs,
-    data_args: DataArgs,
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_args.max_iters)
     for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, data_args.max_seq_length)
+        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -365,6 +357,19 @@ def get_longest_seq_length(data: List[Dict]) -> Tuple[int, int]:
     longest_seq_length = max(lengths)
     longest_seq_ix = lengths.index(longest_seq_length)
     return longest_seq_length, longest_seq_ix
+
+
+def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
+    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+    for args, names in unsupported:
+        for name in names:
+            if getattr(args, name) is not None:
+                raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
+    required = [(io_args, ["checkpoint_dir"]), (train_args, ["epoch_size", "epochs"]), (eval_args, ["max_new_tokens"])]
+    for args, names in required:
+        for name in names:
+            if getattr(args, name) is None:
+                raise ValueError(f"{__file__} requires the {name!r} argument. This is set in {args}")
 
 
 if __name__ == "__main__":

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -18,7 +18,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.args import DataArgs, EvalArgs, IOArgs, OptimizationArgs, TrainArgs
+from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trainable
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
@@ -107,7 +107,7 @@ def setup(
             to_mlp=lora_mlp,
             to_head=lora_head,
         ),
-        IOArgs(data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
+        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
         TrainArgs(
             save_interval=save_interval,
             log_interval=log_interval,
@@ -116,23 +116,18 @@ def setup(
             lr_warmup_steps=lr_warmup_steps,
             epochs=epochs,
             epoch_size=train_epoch_size,
+            learning_rate=learning_rate,
+            max_seq_length=max_seq_length,
         ),
         EvalArgs(interval=eval_interval, max_new_tokens=eval_max_new_tokens, max_iters=eval_iters),
-        OptimizationArgs(learning_rate=learning_rate),
-        DataArgs(max_seq_length=max_seq_length),
     )
 
 
 def main(
-    fabric: L.Fabric,
-    devices: int,
-    config: Config,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
-    optimization_args: OptimizationArgs,
-    data_args: DataArgs,
+    fabric: L.Fabric, devices: int, config: Config, io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs
 ) -> None:
+    validate_args(io_args, train_args, eval_args)
+
     steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
     lr_max_steps = train_args.epochs * steps_per_epoch
 
@@ -143,8 +138,8 @@ def main(
     if fabric.global_rank == 0:
         os.makedirs(io_args.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.data_dir / "train.pt")
-    val_data = torch.load(io_args.data_dir / "test.pt")
+    train_data = torch.load(io_args.train_data_dir / "train.pt")
+    val_data = torch.load(io_args.val_data_dir / "test.pt")
 
     checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
@@ -166,9 +161,9 @@ def main(
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
         trainable_params,
-        lr=optimization_args.learning_rate,
-        weight_decay=optimization_args.weight_decay,
-        betas=(optimization_args.beta1, optimization_args.beta2),
+        lr=train_args.learning_rate,
+        weight_decay=train_args.weight_decay,
+        betas=(train_args.beta1, train_args.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
@@ -179,7 +174,7 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args, data_args)
+    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
@@ -200,18 +195,17 @@ def train(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    data_args: DataArgs,
 ) -> None:
     tokenizer = Tokenizer(io_args.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, data_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args, data_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
     )  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
@@ -226,7 +220,7 @@ def train(
             fabric,
             train_data,
             train_args.micro_batch_size,
-            data_args.max_seq_length,
+            train_args.max_seq_length,
             longest_seq_ix if iter_num == 1 else None,
         )
 
@@ -262,7 +256,7 @@ def train(
 
         if not is_accumulating and step_count % eval_args.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args, data_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
@@ -274,19 +268,13 @@ def train(
 # FSDP has issues with `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric,
-    model: GPT,
-    val_data: List[Dict],
-    tokenizer: Tokenizer,
-    eval_args: EvalArgs,
-    train_args: TrainArgs,
-    data_args: DataArgs,
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
     losses = torch.zeros(eval_args.max_iters)
     for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, data_args.max_seq_length)
+        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -371,6 +359,19 @@ def get_longest_seq_length(data: List[Dict]) -> Tuple[int, int]:
 def save_lora_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_path: Path) -> None:
     fabric.print(f"Saving LoRA weights to {str(file_path)!r}")
     fabric.save(file_path, {"model": model}, filter={"model": lora_filter})
+
+
+def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
+    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+    for args, names in unsupported:
+        for name in names:
+            if getattr(args, name) is not None:
+                raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
+    required = [(io_args, ["checkpoint_dir"]), (train_args, ["epoch_size", "epochs"]), (eval_args, ["max_new_tokens"])]
+    for args, names in required:
+        for name in names:
+            if getattr(args, name) is None:
+                raise ValueError(f"{__file__} requires the {name!r} argument. This is set in {args}")
 
 
 if __name__ == "__main__":

--- a/lit_gpt/args.py
+++ b/lit_gpt/args.py
@@ -15,20 +15,25 @@ class TrainArgs:
     """Number of samples between optimizer steps across data-parallel ranks"""
     micro_batch_size: int = 4
     """Number of samples per data-parallel rank"""
-    lr_warmup_epochs: int = 2
-    """Number of epochs with learning rate warmup active"""
-    # TODO: some scripts use steps, other iters. Standardize?
     lr_warmup_steps: int = 100
-    """Number of optimizer steps with learning rate warmup active"""
-    lr_warmup_iters: int = 2000
     """Number of iterations with learning rate warmup active"""
-    # TODO: some scripts use epoch size, others epochs + epoch_size, others max_tokens. Standardize?
-    epochs: int = 5
+    epochs: Optional[int] = None
     """Number of epochs to run"""
-    epoch_size: int = 50000
+    epoch_size: Optional[int] = None
     """Size of the epoch"""
-    max_tokens: int = int(3e12)
+    # TODO: pretrain/tinyllama is the only script using `max_tokens` explicitly. replace it with epoch_size*epochs?
+    max_tokens: Optional[int] = None
     """Total number of tokens to train on"""
+    max_seq_length: Optional[int] = None
+    """Limits the length of samples. Off by default"""
+
+    # Optimization args
+    learning_rate: float = 1e-3
+    weight_decay: float = 0.02
+    beta1: float = 0.9
+    beta2: float = 0.95
+    max_norm: Optional[float] = None
+    min_lr: float = 6e-5
 
     def max_iters(self, devices: int) -> int:
         """Number of iterations"""
@@ -55,45 +60,22 @@ class EvalArgs:
 
     interval: int = 600
     """Number of optimizer steps between evaluation calls"""
-    max_new_tokens: int = 100
+    max_new_tokens: Optional[int] = None
     """Number of tokens to generate"""
     max_iters: int = 100
     """Number of iterations"""
 
 
 @dataclass
-class OptimizationArgs:
-    """Optimization related arguments"""
-
-    # TODO: evaluate merging these into TrainArgs
-    learning_rate: float = 1e-3
-    weight_decay: float = 0.02
-    beta1: float = 0.9
-    beta2: float = 0.95
-    max_norm: float = 1.0
-    min_lr: float = 6e-5
-
-
-@dataclass
-class DataArgs:
-    """Data related arguments"""
-
-    max_seq_length: Optional[int] = None
-    """Limits the length of samples. Off by default"""
-
-
-@dataclass
 class IOArgs:
     """Inputs and outputs related arguments"""
 
-    data_dir: Path = Path("data/alpaca")
-    """Where to read data from"""
-    # TODO: some scripts use the data_dir, others train_data_dir+val_data_dir. Standardize?
-    train_data_dir: Path = Path("data/alpaca")
+    # Optional because pretrain/tinyllama hardcodes the path
+    train_data_dir: Optional[Path] = Path("data/alpaca")
     """Where to read training data from"""
-    val_data_dir: Optional[Path] = Path("data/alpaca")
+    val_data_dir: Optional[Path] = None
     """Where to read validation data from"""
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b")
+    checkpoint_dir: Optional[Path] = None
     """Where to read weights and tokenizer data from"""
     out_dir: Path = Path("out/adapter/alpaca")
     """Where to save artifacts"""

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -19,7 +19,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Config
-from lit_gpt.args import EvalArgs, IOArgs, OptimizationArgs, TrainArgs
+from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.model import GPT, Block
 from lit_gpt.utils import chunked_cross_entropy, estimate_flops, get_default_supported_precision, num_parameters
 
@@ -39,7 +39,7 @@ def setup(
     weight_decay: float = 1e-1,
     beta1: float = 0.9,
     beta2: float = 0.95,
-    lr_warmup_iters: int = 2000,
+    lr_warmup_steps: int = 100,
     min_lr: float = 6e-5,
     global_batch_size: int = 125,
     micro_batch_size: int = 5,
@@ -69,18 +69,15 @@ def setup(
         devices,
         resume,
         Config.from_name(name=model_name),
-        IOArgs(data_dir=data_dir, out_dir=out_dir),
+        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, out_dir=out_dir),
         TrainArgs(
             save_interval=save_interval,
             log_interval=log_interval,
             global_batch_size=global_batch_size,
             micro_batch_size=micro_batch_size,
-            lr_warmup_iters=lr_warmup_iters,
+            lr_warmup_steps=lr_warmup_steps,
             epochs=epochs,
             epoch_size=train_epoch_size,
-        ),
-        EvalArgs(interval=eval_interval, max_iters=eval_iters),
-        OptimizationArgs(
             learning_rate=learning_rate,
             weight_decay=weight_decay,
             beta1=beta1,
@@ -88,6 +85,7 @@ def setup(
             max_norm=max_norm,
             min_lr=min_lr,
         ),
+        EvalArgs(interval=eval_interval, max_iters=eval_iters),
     )
 
 
@@ -99,8 +97,9 @@ def main(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    optimization_args: OptimizationArgs,
 ) -> None:
+    validate_args(io_args, train_args, eval_args)
+
     if fabric.global_rank == 0:
         io_args.out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -118,14 +117,14 @@ def main(
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
         model.parameters(),
-        lr=optimization_args.learning_rate,
-        weight_decay=optimization_args.weight_decay,
-        betas=(optimization_args.beta1, optimization_args.beta2),
+        lr=train_args.learning_rate,
+        weight_decay=train_args.weight_decay,
+        betas=(train_args.beta1, train_args.beta2),
         foreach=False,
     )
     optimizer = fabric.setup_optimizers(optimizer)
 
-    train_data, val_data = load_datasets(io_args.data_dir, max_seq_length=model.max_seq_length)
+    train_data, val_data = load_datasets(io_args, max_seq_length=model.max_seq_length)
     train_dataloader = DataLoader(train_data, batch_size=train_args.micro_batch_size, num_workers=2)
     val_dataloader = DataLoader(val_data, batch_size=train_args.micro_batch_size, num_workers=2)
     train_dataloader, val_dataloader = fabric.setup_dataloaders(train_dataloader, val_dataloader)
@@ -139,7 +138,7 @@ def main(
         fabric.load(resume, state)
 
     train_time = time.perf_counter()
-    train(fabric, devices, state, train_dataloader, val_dataloader, io_args, train_args, eval_args, optimization_args)
+    train(fabric, devices, state, train_dataloader, val_dataloader, io_args, train_args, eval_args)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
@@ -154,7 +153,6 @@ def train(
     io_args: IOArgs,
     train_args: TrainArgs,
     eval_args: EvalArgs,
-    optimization_args: OptimizationArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
@@ -180,14 +178,15 @@ def train(
 
     train_iter = iter(train_dataloader)
 
+    lr_warmup_iters = train_args.lr_warmup_steps * train_args.gradient_accumulation_iters(devices)
     for state["iter_num"] in range(state["iter_num"], train_args.max_iters(devices)):
         # determine and set the learning rate for this iteration
         lr = get_lr(
-            optimization_args.learning_rate,
+            train_args.learning_rate,
             state["iter_num"],
-            train_args.lr_warmup_iters,
+            lr_warmup_iters,
             train_args.max_iters(devices),
-            min_lr=optimization_args.min_lr,
+            min_lr=train_args.min_lr,
         )
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
@@ -204,7 +203,7 @@ def train(
             fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
 
         if not is_accumulating:
-            fabric.clip_gradients(model, optimizer, max_norm=optimization_args.max_norm)
+            fabric.clip_gradients(model, optimizer, max_norm=train_args.max_norm)
             optimizer.step()
             optimizer.zero_grad()
             state["step_count"] += 1
@@ -255,9 +254,9 @@ def validate(fabric: L.Fabric, model: torch.nn.Module, val_dataloader: DataLoade
     return out
 
 
-def load_datasets(data_dir: Path, max_seq_length: int) -> Tuple["Dataset", "Dataset"]:
-    train_data = Dataset(data_dir / "train.bin", max_seq_length)
-    val_data = Dataset(data_dir / "val.bin", max_seq_length)
+def load_datasets(io_args: IOArgs, max_seq_length: int) -> Tuple["Dataset", "Dataset"]:
+    train_data = Dataset(io_args.train_data_dir / "train.bin", max_seq_length)
+    val_data = Dataset(io_args.val_data_dir / "val.bin", max_seq_length)
     return train_data, val_data
 
 
@@ -289,6 +288,19 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)
+
+
+def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
+    unsupported = [(io_args, ["checkpoint_dir"]), (train_args, ["max_tokens"]), (eval_args, ["max_new_tokens"])]
+    for args, names in unsupported:
+        for name in names:
+            if getattr(args, name) is not None:
+                raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
+    required = [(io_args, ["train_data_dir", "val_data_dir"]), (train_args, ["epoch_size", "epochs", "max_norm"])]
+    for args, names in required:
+        for name in names:
+            if getattr(args, name) is None:
+                raise ValueError(f"{__file__} requires the {name!r} argument. This is set in {args}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Adds `validate_args` to the finetune and pretrain scripts
- Makes all scripts use `lr_warmup_steps` instead of `lr_warmup_epochs` or `lr_warmup_iters`
- Makes all scripts use `train_data_dir` and `val_data_dir` instead of `data_dir`
- Merges `OptimizationArgs` and `DataArgs` into `TrainArgs`