### PR TITLE
Replace deprecated use_auth_token

### DIFF
--- a/scripts/prepare_lima.py
+++ b/scripts/prepare_lima.py
@@ -54,7 +54,7 @@ def prepare(
 
     from datasets import load_dataset
 
-    dataset = load_dataset(data_repo_id, use_auth_token=access_token)
+    dataset = load_dataset(data_repo_id, token=access_token)
     train_data = format_dataset(dataset["train"], include_multiturn_conversations)
 
     # test set is present but doesn't have any solutions, so we cannot use it here


### PR DESCRIPTION
This updates the token authentication in the LIMA data preparation script:

> FutureWarning: 'use_auth_token' was deprecated in favor of 'token' in version 2.14.0 and will be removed in 3.0.0.
You can remove this warning by passing 'token=<use_auth_token>' instead.