### PR TITLE
Add missing newline in response template

### DIFF
--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -137,12 +137,12 @@ def generate_prompt(example: dict) -> str:
         return (
             "Below is an instruction that describes a task, paired with an input that provides further context. "
             "Write a response that appropriately completes the request.\n\n"
-            f"### Instruction:\n{example['instruction']}\n\n### Input:\n{example['input']}\n\n### Response:"
+            f"### Instruction:\n{example['instruction']}\n\n### Input:\n{example['input']}\n\n### Response:\n"
         )
     return (
         "Below is an instruction that describes a task. "
         "Write a response that appropriately completes the request.\n\n"
-        f"### Instruction:\n{example['instruction']}\n\n### Response:"
+        f"### Instruction:\n{example['instruction']}\n\n### Response:\n"
     )
 
 


### PR DESCRIPTION
There seems to be a spacing issue in the Alpaca response template. I.e., before the targets would look like as follows (see the missing newline before `### Response:`):

```
 is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.

### Instruction:
Given the topic, generate a story of length 100 words.

### Input:
The rise of artificial intelligence

### Response:The world awoke to a new reality as artificial intelligence infiltrated nearly every aspect of life. Machines seemed to be everywhere, from factories to homes and business offices. They ran the show, efficiently and effectively automating mundane chores and providing unprecedented insights. But what would happen when the machines became too intelligent, too powerful? Would machines become our masters, or could we find a way to work with them in harmony? Only time would tell what destiny awaited us in this age of AI.
```

But it should be

```
 is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.

### Instruction:
Given the topic, generate a story of length 100 words.

### Input:
The rise of artificial intelligence

### Response:
The world awoke to a new reality as artificial intelligence infiltrated nearly every aspect of life. Machines seemed to be everywhere, from factories to homes and business offices. They ran the show, efficiently and effectively automating mundane chores and providing unprecedented insights. But what would happen when the machines became too intelligent, too powerful? Would machines become our masters, or could we find a way to work with them in harmony? Only time would tell what destiny awaited us in this age of AI.
```