### PR TITLE
Update jsonargparse requirement

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-jsonargparse[signatures]  # CLI
+jsonargparse              # CLI
 bitsandbytes==0.41.0      # quantization
 scipy                     # required by bitsandbytes
 sentencepiece             # llama-based models


### PR DESCRIPTION
Every time I install the `requirements-all.txt` in a new environment, it complains that `jsonargparse` is not installed when running `scripts/downloads.py` and I have to manually pip install it. I think it needs the whole jsonargparse lib during import.