### PR TITLE
Create the directory before saving the results file in eval harness

### DIFF
--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -181,6 +181,7 @@ def run_eval_harness(
         print(results)
     else:
         print(f"Saving results to {str(save_filepath)!r}")
+        save_filepath.parent.mkdir(parents=True, exist_ok=True)
         data = json.dumps(results)
         with open(save_filepath, "w") as fw:
             fw.write(data)

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -71,14 +71,17 @@ def test_eval_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     run_eval_mock.return_value = {"foo": "test"}
     monkeypatch.setattr(module.EvalHarnessBase, "run_eval", run_eval_mock)
 
+    output_folder = tmp_path / "output"
+    assert not output_folder.exists()
+
     module.run_eval_harness(
-        checkpoint_dir=fake_checkpoint_dir, precision="32-true", save_filepath=tmp_path / "results.json"
+        checkpoint_dir=fake_checkpoint_dir, precision="32-true", save_filepath=(output_folder / "results.json"),
     )
 
     run_eval_mock.assert_called_once_with(
         ["arc_challenge", "piqa", "hellaswag", "hendrycksTest-*"], 0, None, 100000, True
     )
-    assert (tmp_path / "results.json").read_text() == '{"foo": "test"}'
+    assert (output_folder / "results.json").read_text() == '{"foo": "test"}'
 
 
 def test_cli():


### PR DESCRIPTION
Bug: You run the eval harness for 45 minutes just for it to fail saving the results because the directory does not exist. This PR fixes that.