### PR TITLE
Expose dataclasses from CLI

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -17,7 +17,7 @@ sys.path.append(str(wd))
 
 from generate.base import next_token
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
 @torch.inference_mode()
@@ -366,7 +366,6 @@ def prompt_config(checkpoint_dir: Path, tokenizer: Tokenizer) -> Tuple[str, Tupl
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -17,7 +17,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
 class EvalHarnessBase(BaseLM):
@@ -188,7 +188,6 @@ def run_eval_harness(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
-    CLI(run_eval_harness, as_positional=False)
+
+    CLI(run_eval_harness)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -22,6 +22,7 @@ from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapte
 from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
+    CLI,
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
@@ -32,24 +33,27 @@ from scripts.prepare_alpaca import generate_prompt
 
 
 def setup(
-    data_dir: Path = Path("data/alpaca"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    out_dir: Path = Path("out/adapter/alpaca"),
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
-    eval_interval: int = 600,
-    eval_max_new_tokens: int = 100,
-    save_interval: int = 1000,
-    eval_iters: int = 100,
-    log_interval: int = 1,
     devices: int = 1,
-    learning_rate: float = 1e-3,
-    global_batch_size: int = 64,
-    micro_batch_size: int = 4,
-    max_seq_length: Optional[int] = None,  # set value to truncate
-    lr_warmup_steps: int = 100,
-    epochs: int = 5,
-    train_epoch_size: int = 50000,
+    io_args: IOArgs = IOArgs(
+        train_data_dir=Path("data/alpaca"),
+        val_data_dir=Path("data/alpaca"),
+        checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+        out_dir=Path("out/adapter/alpaca"),
+    ),
+    train_args: TrainArgs = TrainArgs(
+        save_interval=1000,
+        log_interval=1,
+        global_batch_size=64,
+        micro_batch_size=4,
+        lr_warmup_steps=100,
+        epochs=5,
+        epoch_size=50000,
+        learning_rate=1e-3,
+        max_seq_length=None,
+    ),
+    eval_args: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -78,27 +82,9 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-
-    fabric.launch(
-        main,
-        devices,
-        Config.from_name(name=checkpoint_dir.name),
-        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
-        TrainArgs(
-            save_interval=save_interval,
-            log_interval=log_interval,
-            global_batch_size=global_batch_size,
-            micro_batch_size=micro_batch_size,
-            lr_warmup_steps=lr_warmup_steps,
-            epochs=epochs,
-            epoch_size=train_epoch_size,
-            learning_rate=learning_rate,
-            max_seq_length=max_seq_length,
-        ),
-        EvalArgs(interval=eval_interval, max_new_tokens=eval_max_new_tokens, max_iters=eval_iters),
-    )
+    fabric.launch(main, devices, Config.from_name(name=io_args.checkpoint_dir.name), io_args, train_args, eval_args)
 
 
 def main(
@@ -358,7 +344,5 @@ def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -
 
 if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
-
-    from jsonargparse import CLI
 
     CLI(setup)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -87,9 +87,7 @@ def setup(
     fabric.launch(main, devices, Config.from_name(name=io.checkpoint_dir.name), io, train, eval)
 
 
-def main(
-    fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs
-) -> None:
+def main(fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
     validate_args(io, train, eval)
 
     steps_per_epoch = train.epoch_size // devices // train.batch_size(devices)
@@ -124,10 +122,7 @@ def main(
     else:
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
-        trainable_params,
-        lr=train.learning_rate,
-        weight_decay=train.weight_decay,
-        betas=(train.beta1, train.beta2),
+        trainable_params, lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
     )
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
@@ -168,9 +163,7 @@ def fit(
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
-    validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
-    )  # sanity check
+    validate(fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train)  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
     step_count = 0
@@ -181,11 +174,7 @@ def fit(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(
-            fabric,
-            train_data,
-            train.micro_batch_size,
-            train.max_seq_length,
-            longest_seq_ix if iter_num == 1 else None,
+            fabric, train_data, train.micro_batch_size, train.max_seq_length, longest_seq_ix if iter_num == 1 else None
         )
 
         is_accumulating = iter_num % train.gradient_accumulation_iters(devices) != 0
@@ -207,10 +196,7 @@ def fit(
             loss_item = loss.item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             throughput.update(
-                time=t1 - total_t0,
-                batches=iter_num,
-                samples=iter_num * train.micro_batch_size,
-                lengths=total_lengths,
+                time=t1 - total_t0, batches=iter_num, samples=iter_num * train.micro_batch_size, lengths=total_lengths
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(
@@ -253,11 +239,7 @@ def validate(
         # do not set `max_seq_length=max_returned_token` because memory is not a concern here
         model.set_kv_cache(batch_size=1)
     output = generate(
-        model,
-        encoded,
-        max_returned_tokens=len(encoded) + eval.max_new_tokens,
-        temperature=0.8,
-        eos_id=tokenizer.eos_id,
+        model, encoded, max_returned_tokens=len(encoded) + eval.max_new_tokens, temperature=0.8, eos_id=tokenizer.eos_id
     )
     model.clear_kv_cache()
     output = tokenizer.decode(output)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -36,13 +36,13 @@ def setup(
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: int = 1,
-    io_args: IOArgs = IOArgs(
+    io: IOArgs = IOArgs(
         train_data_dir=Path("data/alpaca"),
         val_data_dir=Path("data/alpaca"),
         checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
         out_dir=Path("out/adapter/alpaca"),
     ),
-    train_args: TrainArgs = TrainArgs(
+    train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
         global_batch_size=64,
@@ -53,7 +53,7 @@ def setup(
         learning_rate=1e-3,
         max_seq_length=None,
     ),
-    eval_args: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
+    eval: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -82,30 +82,30 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
+    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, Config.from_name(name=io_args.checkpoint_dir.name), io_args, train_args, eval_args)
+    fabric.launch(main, devices, Config.from_name(name=io.checkpoint_dir.name), io, train, eval)
 
 
 def main(
-    fabric: L.Fabric, devices: int, config: Config, io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs
+    fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs
 ) -> None:
-    validate_args(io_args, train_args, eval_args)
+    validate_args(io, train, eval)
 
-    steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
-    lr_max_steps = train_args.epochs * steps_per_epoch
+    steps_per_epoch = train.epoch_size // devices // train.batch_size(devices)
+    lr_max_steps = train.epochs * steps_per_epoch
 
-    check_valid_checkpoint_dir(io_args.checkpoint_dir)
+    check_valid_checkpoint_dir(io.checkpoint_dir)
 
     fabric.seed_everything(1337)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io_args.out_dir, exist_ok=True)
+        os.makedirs(io.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.train_data_dir / "train.pt")
-    val_data = torch.load(io_args.val_data_dir / "test.pt")
+    train_data = torch.load(io.train_data_dir / "train.pt")
+    val_data = torch.load(io.val_data_dir / "test.pt")
 
-    checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -125,12 +125,12 @@ def main(
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
         trainable_params,
-        lr=train_args.learning_rate,
-        weight_decay=train_args.weight_decay,
-        betas=(train_args.beta1, train_args.beta2),
+        lr=train.learning_rate,
+        weight_decay=train.weight_decay,
+        betas=(train.beta1, train.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
-    scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
+    scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
 
     # strict=False because missing keys due to Adapter weights not contained in state dict
     load_checkpoint(fabric, model, checkpoint_path, strict=False)
@@ -138,17 +138,17 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args)
+    fit(fabric, model, optimizer, scheduler, train_data, val_data, devices, io, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    save_path = io_args.out_dir / "lit_model_adapter_finetuned.pth"
+    save_path = io.out_dir / "lit_model_adapter_finetuned.pth"
     save_adapter_checkpoint(fabric, model, save_path)
 
 
-def train(
+def fit(
     fabric: L.Fabric,
     model: GPT,
     optimizer: torch.optim.Optimizer,
@@ -156,20 +156,20 @@ def train(
     train_data: List[Dict],
     val_data: List[Dict],
     devices: int,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
-    tokenizer = Tokenizer(io_args.checkpoint_dir)
+    tokenizer = Tokenizer(io.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
     )  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
@@ -177,24 +177,24 @@ def train(
     total_lengths = 0
     total_t0 = time.perf_counter()
 
-    for iter_num in range(1, train_args.max_iters(devices) + 1):
+    for iter_num in range(1, train.max_iters(devices) + 1):
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(
             fabric,
             train_data,
-            train_args.micro_batch_size,
-            train_args.max_seq_length,
+            train.micro_batch_size,
+            train.max_seq_length,
             longest_seq_ix if iter_num == 1 else None,
         )
 
-        is_accumulating = iter_num % train_args.gradient_accumulation_iters(devices) != 0
+        is_accumulating = iter_num % train.gradient_accumulation_iters(devices) != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids, lm_head_chunk_size=128)
             # shift the targets such that output n predicts token n+1
             logits[-1] = logits[-1][..., :-1, :]
             loss = chunked_cross_entropy(logits, targets[..., 1:])
-            fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
 
         if not is_accumulating:
             optimizer.step()
@@ -203,13 +203,13 @@ def train(
             step_count += 1
 
         total_lengths += input_ids.numel()
-        if iter_num % train_args.log_interval == 0:
+        if iter_num % train.log_interval == 0:
             loss_item = loss.item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             throughput.update(
                 time=t1 - total_t0,
                 batches=iter_num,
-                samples=iter_num * train_args.micro_batch_size,
+                samples=iter_num * train.micro_batch_size,
                 lengths=total_lengths,
             )
             throughput.compute_and_log(step=iter_num)
@@ -218,27 +218,27 @@ def train(
                 f" {(t1 - iter_t0) * 1000:.2f} ms{' (optimizer.step)' if not is_accumulating else ''}"
             )
 
-        if not is_accumulating and step_count % eval_args.interval == 0:
+        if not is_accumulating and step_count % eval.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval, train)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
-        if not is_accumulating and step_count % train_args.save_interval == 0:
-            checkpoint_path = io_args.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
+        if not is_accumulating and step_count % train.save_interval == 0:
+            checkpoint_path = io.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_adapter_checkpoint(fabric, model, checkpoint_path)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval: EvalArgs, train: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
-    losses = torch.zeros(eval_args.max_iters)
-    for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
+    losses = torch.zeros(eval.max_iters)
+    for k in range(eval.max_iters):
+        input_ids, targets = get_batch(fabric, val_data, train.micro_batch_size, train.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -255,7 +255,7 @@ def validate(
     output = generate(
         model,
         encoded,
-        max_returned_tokens=len(encoded) + eval_args.max_new_tokens,
+        max_returned_tokens=len(encoded) + eval.max_new_tokens,
         temperature=0.8,
         eos_id=tokenizer.eos_id,
     )
@@ -325,16 +325,16 @@ def save_adapter_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_path:
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
-def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
-    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+    unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
         for name in names:
             if getattr(args, name) is not None:
                 raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io_args, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
-        (train_args, ["epoch_size", "epochs"]),
-        (eval_args, ["max_new_tokens"]),
+        (io, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
+        (train, ["epoch_size", "epochs"]),
+        (eval, ["max_new_tokens"]),
     ]
     for args, names in required:
         for name in names:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -22,6 +22,7 @@ from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_ada
 from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
+    CLI,
     check_valid_checkpoint_dir,
     chunked_cross_entropy,
     get_default_supported_precision,
@@ -32,24 +33,27 @@ from scripts.prepare_alpaca import generate_prompt
 
 
 def setup(
-    data_dir: Path = Path("data/alpaca"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-    out_dir: Path = Path("out/adapter_v2/alpaca"),
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
-    eval_interval: int = 600,
-    eval_max_new_tokens: int = 100,
-    save_interval: int = 1000,
-    eval_iters: int = 100,
-    log_interval: int = 1,
     devices: int = 1,
-    learning_rate: float = 1e-3,
-    global_batch_size: int = 128,
-    micro_batch_size: int = 2,  # set to 2 because this is fit into 12GB Vram
-    max_seq_length: Optional[int] = None,  # set value to truncate
-    lr_warmup_steps: int = 100,
-    epochs: int = 5,
-    train_epoch_size: int = 50000,
+    io_args: IOArgs = IOArgs(
+        train_data_dir=Path("data/alpaca"),
+        val_data_dir=Path("data/alpaca"),
+        checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+        out_dir=Path("out/adapter_v2/alpaca"),
+    ),
+    train_args: TrainArgs = TrainArgs(
+        save_interval=1000,
+        log_interval=1,
+        global_batch_size=128,
+        micro_batch_size=2,
+        lr_warmup_steps=100,
+        epochs=5,
+        epoch_size=50000,
+        learning_rate=1e-3,
+        max_seq_length=None,
+    ),
+    eval_args: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -78,27 +82,9 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-
-    fabric.launch(
-        main,
-        devices,
-        Config.from_name(name=checkpoint_dir.name),
-        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, checkpoint_dir=checkpoint_dir, out_dir=out_dir),
-        TrainArgs(
-            save_interval=save_interval,
-            log_interval=log_interval,
-            global_batch_size=global_batch_size,
-            micro_batch_size=micro_batch_size,
-            lr_warmup_steps=lr_warmup_steps,
-            epochs=epochs,
-            epoch_size=train_epoch_size,
-            learning_rate=learning_rate,
-            max_seq_length=max_seq_length,
-        ),
-        EvalArgs(interval=eval_interval, max_new_tokens=eval_max_new_tokens, max_iters=eval_iters),
-    )
+    fabric.launch(main, devices, Config.from_name(name=io_args.checkpoint_dir.name), io_args, train_args, eval_args)
 
 
 def main(
@@ -358,7 +344,5 @@ def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -
 
 if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
-
-    from jsonargparse import CLI
 
     CLI(setup)

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -36,13 +36,13 @@ def setup(
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: int = 1,
-    io_args: IOArgs = IOArgs(
+    io: IOArgs = IOArgs(
         train_data_dir=Path("data/alpaca"),
         val_data_dir=Path("data/alpaca"),
         checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
         out_dir=Path("out/adapter_v2/alpaca"),
     ),
-    train_args: TrainArgs = TrainArgs(
+    train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
         global_batch_size=128,
@@ -53,7 +53,7 @@ def setup(
         learning_rate=1e-3,
         max_seq_length=None,
     ),
-    eval_args: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
+    eval: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -82,30 +82,30 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
+    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, Config.from_name(name=io_args.checkpoint_dir.name), io_args, train_args, eval_args)
+    fabric.launch(main, devices, Config.from_name(name=io.checkpoint_dir.name), io, train, eval)
 
 
 def main(
-    fabric: L.Fabric, devices: int, config: Config, io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs
+    fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs
 ) -> None:
-    validate_args(io_args, train_args, eval_args)
+    validate_args(io, train, eval)
 
-    steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
-    lr_max_steps = train_args.epochs * steps_per_epoch
+    steps_per_epoch = train.epoch_size // devices // train.batch_size(devices)
+    lr_max_steps = train.epochs * steps_per_epoch
 
-    check_valid_checkpoint_dir(io_args.checkpoint_dir)
+    check_valid_checkpoint_dir(io.checkpoint_dir)
 
     fabric.seed_everything(1337)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io_args.out_dir, exist_ok=True)
+        os.makedirs(io.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.train_data_dir / "train.pt")
-    val_data = torch.load(io_args.val_data_dir / "test.pt")
+    train_data = torch.load(io.train_data_dir / "train.pt")
+    val_data = torch.load(io.val_data_dir / "test.pt")
 
-    checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -125,12 +125,12 @@ def main(
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
         trainable_params,
-        lr=train_args.learning_rate,
-        weight_decay=train_args.weight_decay,
-        betas=(train_args.beta1, train_args.beta2),
+        lr=train.learning_rate,
+        weight_decay=train.weight_decay,
+        betas=(train.beta1, train.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
-    scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
+    scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
 
     # strict=False because missing keys due to Adapter weights not contained in state dict
     load_checkpoint(fabric, model, checkpoint_path, strict=False)
@@ -138,17 +138,17 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, model, optimizer, scheduler, train_data, val_data, devices, io_args, train_args, eval_args)
+    fit(fabric, model, optimizer, scheduler, train_data, val_data, devices, io, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    save_path = io_args.out_dir / "lit_model_adapter_finetuned.pth"
+    save_path = io.out_dir / "lit_model_adapter_finetuned.pth"
     save_adapter_v2_checkpoint(fabric, model, save_path)
 
 
-def train(
+def fit(
     fabric: L.Fabric,
     model: GPT,
     optimizer: torch.optim.Optimizer,
@@ -156,20 +156,20 @@ def train(
     train_data: List[Dict],
     val_data: List[Dict],
     devices: int,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
-    tokenizer = Tokenizer(io_args.checkpoint_dir)
+    tokenizer = Tokenizer(io.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
     )  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
@@ -177,24 +177,24 @@ def train(
     total_lengths = 0
     total_t0 = time.perf_counter()
 
-    for iter_num in range(1, train_args.max_iters(devices) + 1):
+    for iter_num in range(1, train.max_iters(devices) + 1):
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(
             fabric,
             train_data,
-            train_args.micro_batch_size,
-            train_args.max_seq_length,
+            train.micro_batch_size,
+            train.max_seq_length,
             longest_seq_ix if iter_num == 1 else None,
         )
 
-        is_accumulating = iter_num % train_args.gradient_accumulation_iters(devices) != 0
+        is_accumulating = iter_num % train.gradient_accumulation_iters(devices) != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids, lm_head_chunk_size=128)
             # shift the targets such that output n predicts token n+1
             logits[-1] = logits[-1][..., :-1, :]
             loss = chunked_cross_entropy(logits, targets[..., 1:])
-            fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
 
         if not is_accumulating:
             optimizer.step()
@@ -203,13 +203,13 @@ def train(
             step_count += 1
 
         total_lengths += input_ids.numel()
-        if iter_num % train_args.log_interval == 0:
+        if iter_num % train.log_interval == 0:
             loss_item = loss.item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             throughput.update(
                 time=t1 - total_t0,
                 batches=iter_num,
-                samples=iter_num * train_args.micro_batch_size,
+                samples=iter_num * train.micro_batch_size,
                 lengths=total_lengths,
             )
             throughput.compute_and_log(step=iter_num)
@@ -218,27 +218,27 @@ def train(
                 f" {(t1 - iter_t0) * 1000:.2f} ms{' (optimizer.step)' if not is_accumulating else ''}"
             )
 
-        if not is_accumulating and step_count % eval_args.interval == 0:
+        if not is_accumulating and step_count % eval.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval, train)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
-        if not is_accumulating and step_count % train_args.save_interval == 0:
-            checkpoint_path = io_args.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
+        if not is_accumulating and step_count % train.save_interval == 0:
+            checkpoint_path = io.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_adapter_v2_checkpoint(fabric, model, checkpoint_path)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval: EvalArgs, train: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
-    losses = torch.zeros(eval_args.max_iters)
-    for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
+    losses = torch.zeros(eval.max_iters)
+    for k in range(eval.max_iters):
+        input_ids, targets = get_batch(fabric, val_data, train.micro_batch_size, train.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -255,7 +255,7 @@ def validate(
     output = generate(
         model,
         encoded,
-        max_returned_tokens=len(encoded) + eval_args.max_new_tokens,
+        max_returned_tokens=len(encoded) + eval.max_new_tokens,
         temperature=0.8,
         eos_id=tokenizer.eos_id,
     )
@@ -325,16 +325,16 @@ def save_adapter_v2_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_pa
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
-def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
-    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+    unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
         for name in names:
             if getattr(args, name) is not None:
                 raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io_args, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
-        (train_args, ["epoch_size", "epochs"]),
-        (eval_args, ["max_new_tokens"]),
+        (io, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
+        (train, ["epoch_size", "epochs"]),
+        (eval, ["max_new_tokens"]),
     ]
     for args, names in required:
         for name in names:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -87,9 +87,7 @@ def setup(
     fabric.launch(main, devices, Config.from_name(name=io.checkpoint_dir.name), io, train, eval)
 
 
-def main(
-    fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs
-) -> None:
+def main(fabric: L.Fabric, devices: int, config: Config, io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
     validate_args(io, train, eval)
 
     steps_per_epoch = train.epoch_size // devices // train.batch_size(devices)
@@ -124,10 +122,7 @@ def main(
     else:
         optimizer_cls = torch.optim.AdamW
     optimizer = optimizer_cls(
-        trainable_params,
-        lr=train.learning_rate,
-        weight_decay=train.weight_decay,
-        betas=(train.beta1, train.beta2),
+        trainable_params, lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
     )
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
@@ -168,9 +163,7 @@ def fit(
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
-    validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
-    )  # sanity check
+    validate(fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train)  # sanity check
 
     throughput = ThroughputMonitor(fabric, window_size=50)
     step_count = 0
@@ -181,11 +174,7 @@ def fit(
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(
-            fabric,
-            train_data,
-            train.micro_batch_size,
-            train.max_seq_length,
-            longest_seq_ix if iter_num == 1 else None,
+            fabric, train_data, train.micro_batch_size, train.max_seq_length, longest_seq_ix if iter_num == 1 else None
         )
 
         is_accumulating = iter_num % train.gradient_accumulation_iters(devices) != 0
@@ -207,10 +196,7 @@ def fit(
             loss_item = loss.item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             throughput.update(
-                time=t1 - total_t0,
-                batches=iter_num,
-                samples=iter_num * train.micro_batch_size,
-                lengths=total_lengths,
+                time=t1 - total_t0, batches=iter_num, samples=iter_num * train.micro_batch_size, lengths=total_lengths
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(
@@ -253,11 +239,7 @@ def validate(
         # do not set `max_seq_length=max_returned_token` because memory is not a concern here
         model.set_kv_cache(batch_size=1)
     output = generate(
-        model,
-        encoded,
-        max_returned_tokens=len(encoded) + eval.max_new_tokens,
-        temperature=0.8,
-        eos_id=tokenizer.eos_id,
+        model, encoded, max_returned_tokens=len(encoded) + eval.max_new_tokens, temperature=0.8, eos_id=tokenizer.eos_id
     )
     model.clear_kv_cache()
     output = tokenizer.decode(output)

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -36,13 +36,13 @@ def setup(
     precision: Optional[str] = None,
     devices: int = 1,
     resume: Union[bool, Path] = False,
-    io_args: IOArgs = IOArgs(
+    io: IOArgs = IOArgs(
         train_data_dir=Path("data/alpaca"),
         val_data_dir=Path("data/alpaca"),
         checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
         out_dir=Path("out/full/alpaca"),
     ),
-    train_args: TrainArgs = TrainArgs(
+    train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
         global_batch_size=64,
@@ -53,7 +53,7 @@ def setup(
         learning_rate=3e-3,
         max_seq_length=None,
     ),
-    eval_args: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
+    eval: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -69,10 +69,10 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
+    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
     fabric.launch(
-        main, devices, resume, Config.from_name(name=io_args.checkpoint_dir.name), io_args, train_args, eval_args
+        main, devices, resume, Config.from_name(name=io.checkpoint_dir.name), io, train, eval
     )
 
 
@@ -81,26 +81,26 @@ def main(
     devices: int,
     resume: Union[bool, Path],
     config: Config,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
-    validate_args(io_args, train_args, eval_args)
+    validate_args(io, train, eval)
 
-    steps_per_epoch = train_args.epoch_size // devices // train_args.batch_size(devices)
-    lr_max_steps = train_args.epochs * steps_per_epoch
+    steps_per_epoch = train.epoch_size // devices // train.batch_size(devices)
+    lr_max_steps = train.epochs * steps_per_epoch
 
-    check_valid_checkpoint_dir(io_args.checkpoint_dir)
+    check_valid_checkpoint_dir(io.checkpoint_dir)
 
     fabric.seed_everything(1337)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io_args.out_dir, exist_ok=True)
+        os.makedirs(io.out_dir, exist_ok=True)
 
-    train_data = torch.load(io_args.train_data_dir / "train.pt")
-    val_data = torch.load(io_args.val_data_dir / "test.pt")
+    train_data = torch.load(io.train_data_dir / "train.pt")
+    val_data = torch.load(io.val_data_dir / "test.pt")
 
-    checkpoint_path = io_args.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -110,16 +110,16 @@ def main(
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
         model.parameters(),
-        lr=train_args.learning_rate,
-        weight_decay=train_args.weight_decay,
-        betas=(train_args.beta1, train_args.beta2),
+        lr=train.learning_rate,
+        weight_decay=train.weight_decay,
+        betas=(train.beta1, train.beta2),
     )
     optimizer = fabric.setup_optimizers(optimizer)
-    scheduler = get_lr_scheduler(optimizer, warmup_steps=train_args.lr_warmup_steps, max_steps=lr_max_steps)
+    scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
     state = {"model": model, "optimizer": optimizer, "scheduler": scheduler, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = max(io_args.out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
+        resume = max(io.out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)
@@ -129,39 +129,39 @@ def main(
     fabric.seed_everything(1337 + fabric.global_rank)
 
     train_time = time.perf_counter()
-    train(fabric, state, train_data, val_data, devices, resume, io_args, train_args, eval_args)
+    fit(fabric, state, train_data, val_data, devices, resume, io, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    fabric.save(io_args.out_dir / "lit_model_finetuned.pth", {"model": state["model"]})
+    fabric.save(io.out_dir / "lit_model_finetuned.pth", {"model": state["model"]})
 
 
-def train(
+def fit(
     fabric: L.Fabric,
     state: Dict,
     train_data: List[Dict],
     val_data: List[Dict],
     devices: int,
     resume: Union[bool, Path],
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
-    tokenizer = Tokenizer(io_args.checkpoint_dir)
+    tokenizer = Tokenizer(io.checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_data)
-    model.max_seq_length = min(longest_seq_length, train_args.max_seq_length or float("inf"))
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
     validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval_args, max_iters=2), train_args
+        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
     )  # sanity check
     initial_iter = state["iter_num"]
 
@@ -178,28 +178,28 @@ def train(
             f" {initial_iter}."
         )
 
-    running_loss = RunningMean(window=train_args.gradient_accumulation_iters(devices), sync_on_compute=False).to(
+    running_loss = RunningMean(window=train.gradient_accumulation_iters(devices), sync_on_compute=False).to(
         fabric.device
     )
     fabric.barrier()
 
-    for state["iter_num"] in range(state["iter_num"] + 1, train_args.max_iters(devices) + 1):
+    for state["iter_num"] in range(state["iter_num"] + 1, train.max_iters(devices) + 1):
         iter_t0 = time.perf_counter()
 
         input_ids, targets = get_batch(
             fabric,
             train_data,
-            train_args.micro_batch_size,
-            train_args.max_seq_length,
+            train.micro_batch_size,
+            train.max_seq_length,
             longest_seq_ix if state["iter_num"] == 1 else None,
         )
 
-        is_accumulating = state["iter_num"] % train_args.gradient_accumulation_iters(devices) != 0
+        is_accumulating = state["iter_num"] % train.gradient_accumulation_iters(devices) != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
             # shift the targets such that output n predicts token n+1
             loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:])
-            fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
 
         running_loss.update(loss.detach())
 
@@ -209,7 +209,7 @@ def train(
             scheduler.step()
             state["step_count"] += 1
 
-        if state["iter_num"] % train_args.log_interval == 0:
+        if state["iter_num"] % train.log_interval == 0:
             loss = running_loss.compute().item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             metrics = {
@@ -217,9 +217,9 @@ def train(
                 "iter": state["iter_num"],
                 "step": state["step_count"],
                 "iter_time": t1 - iter_t0,
-                "tokens": state["iter_num"] * train_args.micro_batch_size * model.config.block_size,
+                "tokens": state["iter_num"] * train.micro_batch_size * model.config.block_size,
                 "total_tokens": (
-                    state["iter_num"] * train_args.micro_batch_size * model.config.block_size * fabric.world_size
+                    state["iter_num"] * train.micro_batch_size * model.config.block_size * fabric.world_size
                 ),
                 # TODO: log learning rate
             }
@@ -229,16 +229,16 @@ def train(
             )
             fabric.log_dict(metrics, step=state["iter_num"])
 
-        if not is_accumulating and state["step_count"] % eval_args.interval == 0:
+        if not is_accumulating and state["step_count"] % eval.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_data, tokenizer, eval_args, train_args)
+            val_loss = validate(fabric, model, val_data, tokenizer, eval, train)
             t1 = time.perf_counter() - t0
             fabric.print(f"iter {state['iter_num']}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
             fabric.log_dict(metrics, step=state["iter_num"])
             fabric.barrier()
-        if not is_accumulating and state["step_count"] % train_args.save_interval == 0:
-            checkpoint_path = io_args.out_dir / f"step-{state['step_count']:06d}.pth"
+        if not is_accumulating and state["step_count"] % train.save_interval == 0:
+            checkpoint_path = io.out_dir / f"step-{state['step_count']:06d}.pth"
             fabric.print(f"Saving checkpoint to {str(checkpoint_path)!r}")
             fabric.save(checkpoint_path, state)
 
@@ -246,13 +246,13 @@ def train(
 # FSDP has issues with `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval_args: EvalArgs, train_args: TrainArgs
+    fabric: L.Fabric, model: GPT, val_data: List[Dict], tokenizer: Tokenizer, eval: EvalArgs, train: TrainArgs
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
-    losses = torch.zeros(eval_args.max_iters)
-    for k in range(eval_args.max_iters):
-        input_ids, targets = get_batch(fabric, val_data, train_args.micro_batch_size, train_args.max_seq_length)
+    losses = torch.zeros(eval.max_iters)
+    for k in range(eval.max_iters):
+        input_ids, targets = get_batch(fabric, val_data, train.micro_batch_size, train.max_seq_length)
         logits = model(input_ids)
         losses[k] = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
     val_loss = losses.mean()
@@ -269,7 +269,7 @@ def validate(
     output = generate(
         model,
         encoded,
-        max_returned_tokens=len(encoded) + eval_args.max_new_tokens,
+        max_returned_tokens=len(encoded) + eval.max_new_tokens,
         temperature=0.8,
         eos_id=tokenizer.eos_id,
     )
@@ -334,16 +334,16 @@ def get_longest_seq_length(data: List[Dict]) -> Tuple[int, int]:
     return longest_seq_length, longest_seq_ix
 
 
-def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
-    unsupported = [(train_args, ["max_tokens", "max_norm"])]
+def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+    unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
         for name in names:
             if getattr(args, name) is not None:
                 raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io_args, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
-        (train_args, ["epoch_size", "epochs"]),
-        (eval_args, ["max_new_tokens"]),
+        (io, ["checkpoint_dir", "train_data_dir", "val_data_dir"]),
+        (train, ["epoch_size", "epochs"]),
+        (eval, ["max_new_tokens"]),
     ]
     for args, names in required:
         for name in names:

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -71,9 +71,7 @@ def setup(
 
     logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
-    fabric.launch(
-        main, devices, resume, Config.from_name(name=io.checkpoint_dir.name), io, train, eval
-    )
+    fabric.launch(main, devices, resume, Config.from_name(name=io.checkpoint_dir.name), io, train, eval)
 
 
 def main(
@@ -109,10 +107,7 @@ def main(
 
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
-        model.parameters(),
-        lr=train.learning_rate,
-        weight_decay=train.weight_decay,
-        betas=(train.beta1, train.beta2),
+        model.parameters(), lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
     )
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
@@ -160,9 +155,7 @@ def fit(
         f" {model.max_seq_length} and context length is {model.config.block_size}"
     )
 
-    validate(
-        fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train
-    )  # sanity check
+    validate(fabric, model, val_data, tokenizer, dataclasses.replace(eval, max_iters=2), train)  # sanity check
     initial_iter = state["iter_num"]
 
     # resume data loader state by fast-forwarding through all seen batches
@@ -267,11 +260,7 @@ def validate(
         # do not set `max_seq_length=max_returned_token` because memory is not a concern here
         model.set_kv_cache(batch_size=1)
     output = generate(
-        model,
-        encoded,
-        max_returned_tokens=len(encoded) + eval.max_new_tokens,
-        temperature=0.8,
-        eos_id=tokenizer.eos_id,
+        model, encoded, max_returned_tokens=len(encoded) + eval.max_new_tokens, temperature=0.8, eos_id=tokenizer.eos_id
     )
     model.clear_kv_cache()
     output = tokenizer.decode(output)

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.adapter import GPT, Config
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -114,7 +114,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.adapter_v2 import GPT, Config
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -114,7 +114,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/generate/base.py
+++ b/generate/base.py
@@ -16,7 +16,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
@@ -188,7 +188,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/generate/full.py
+++ b/generate/full.py
@@ -15,7 +15,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -110,7 +110,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 from generate.base import generate
 from lit_gpt import Tokenizer
 from lit_gpt.lora import GPT, Config, merge_lora_weights
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -135,7 +135,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
+
     CLI(main)

--- a/generate/sequentially.py
+++ b/generate/sequentially.py
@@ -24,7 +24,7 @@ sys.path.append(str(wd))
 import generate.base as generate_base
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import Block, build_mask_cache
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision
 
 
 @torch.inference_mode()
@@ -224,8 +224,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
 
     logging.getLogger("lightning.fabric.plugins.precision.bitsandbytes").setLevel(logging.DEBUG)

--- a/generate/tp.py
+++ b/generate/tp.py
@@ -22,7 +22,7 @@ sys.path.append(str(wd))
 import generate.base as generate_base
 from lit_gpt import GPT, Config, Tokenizer
 from lit_gpt.model import CausalSelfAttention, GptNeoxMLP, LLaMAMLP, LLaMAMoE
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision
 
 
 def tensor_parallel_linear(fabric: L.Fabric, linear: torch.nn.Linear, style: str) -> None:
@@ -216,8 +216,6 @@ def main(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     torch.set_float32_matmul_precision("high")
 
     bnb_logger = logging.getLogger("lightning.fabric.plugins.precision.bitsandbytes")

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -368,3 +368,12 @@ class CycleIterator:
 
     def __iter__(self) -> Self:
         return self
+
+
+def CLI(*args: Any, **kwargs: Any) -> Any:
+    from jsonargparse import CLI, set_docstring_parse_options
+
+    set_docstring_parse_options(attribute_docstrings=True)
+
+    kwargs.setdefault("as_positional", False)
+    return CLI(*args, **kwargs)

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -29,9 +29,7 @@ def setup(
     precision: Optional[str] = None,
     resume: Union[bool, Path] = False,
     devices: int = 1,
-    io: IOArgs = IOArgs(
-        train_data_dir=Path("data/openwebtext"), val_data_dir=None, out_dir=Path("out/openwebtext")
-    ),
+    io: IOArgs = IOArgs(train_data_dir=Path("data/openwebtext"), val_data_dir=None, out_dir=Path("out/openwebtext")),
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -162,11 +160,7 @@ def fit(
     for state["iter_num"] in range(state["iter_num"], train.max_iters(devices)):
         # determine and set the learning rate for this iteration
         lr = get_lr(
-            train.learning_rate,
-            state["iter_num"],
-            lr_warmup_iters,
-            train.max_iters(devices),
-            min_lr=train.min_lr,
+            train.learning_rate, state["iter_num"], lr_warmup_iters, train.max_iters(devices), min_lr=train.min_lr
         )
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr

--- a/pretrain/openwebtext.py
+++ b/pretrain/openwebtext.py
@@ -21,31 +21,33 @@ sys.path.append(str(wd))
 from lit_gpt import Config
 from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 from lit_gpt.model import GPT, Block
-from lit_gpt.utils import chunked_cross_entropy, estimate_flops, get_default_supported_precision, num_parameters
+from lit_gpt.utils import CLI, chunked_cross_entropy, estimate_flops, get_default_supported_precision, num_parameters
 
 
 def setup(
     model_name: str = "pythia-70m",
-    data_dir: Path = Path("data/openwebtext"),
-    out_dir: Path = Path("out/openwebtext"),
     precision: Optional[str] = None,
     resume: Union[bool, Path] = False,
-    eval_interval: int = 1000,
-    save_interval: int = 1000,
-    eval_iters: int = 100,
-    log_interval: int = 1,
     devices: int = 1,
-    learning_rate: float = 6e-4,
-    weight_decay: float = 1e-1,
-    beta1: float = 0.9,
-    beta2: float = 0.95,
-    lr_warmup_steps: int = 100,
-    min_lr: float = 6e-5,
-    global_batch_size: int = 125,
-    micro_batch_size: int = 5,
-    max_norm: float = 1.0,
-    epochs: int = 1,
-    train_epoch_size: int = 600000,
+    io_args: IOArgs = IOArgs(
+        train_data_dir=Path("data/openwebtext"), val_data_dir=None, out_dir=Path("out/openwebtext")
+    ),
+    train_args: TrainArgs = TrainArgs(
+        save_interval=1000,
+        log_interval=1,
+        global_batch_size=125,
+        micro_batch_size=5,
+        lr_warmup_steps=100,
+        epochs=1,
+        epoch_size=600000,
+        learning_rate=6e-4,
+        weight_decay=1e-1,
+        beta1=0.9,
+        beta2=0.95,
+        max_norm=1.0,
+        min_lr=6e-5,
+    ),
+    eval_args: EvalArgs = EvalArgs(interval=1000, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -61,32 +63,10 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=log_interval)
+    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
 
-    fabric.launch(
-        main,
-        devices,
-        resume,
-        Config.from_name(name=model_name),
-        IOArgs(train_data_dir=data_dir, val_data_dir=data_dir, out_dir=out_dir),
-        TrainArgs(
-            save_interval=save_interval,
-            log_interval=log_interval,
-            global_batch_size=global_batch_size,
-            micro_batch_size=micro_batch_size,
-            lr_warmup_steps=lr_warmup_steps,
-            epochs=epochs,
-            epoch_size=train_epoch_size,
-            learning_rate=learning_rate,
-            weight_decay=weight_decay,
-            beta1=beta1,
-            beta2=beta2,
-            max_norm=max_norm,
-            min_lr=min_lr,
-        ),
-        EvalArgs(interval=eval_interval, max_iters=eval_iters),
-    )
+    fabric.launch(main, devices, resume, Config.from_name(name=model_name), io_args, train_args, eval_args)
 
 
 def main(
@@ -305,7 +285,5 @@ def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -
 
 if __name__ == "__main__":
     torch.set_float32_matmul_precision("high")
-
-    from jsonargparse import CLI
 
     CLI(setup)

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -41,9 +41,7 @@ def setup(
     precision: Optional[str] = None,
     resume: Union[bool, Path] = False,
     devices: int = 4,
-    io: IOArgs = IOArgs(
-        train_data_dir=Path("data/redpajama_sample"), val_data_dir=None, out_dir=Path("out/redpajama")
-    ),
+    io: IOArgs = IOArgs(train_data_dir=Path("data/redpajama_sample"), val_data_dir=None, out_dir=Path("out/redpajama")),
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -184,11 +182,7 @@ def fit(
 
         # determine and set the learning rate for this iteration
         lr = get_lr(
-            train.learning_rate,
-            state["iter_num"],
-            lr_warmup_iters,
-            train.max_iters(devices),
-            min_lr=train.min_lr,
+            train.learning_rate, state["iter_num"], lr_warmup_iters, train.max_iters(devices), min_lr=train.min_lr
         )
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -41,10 +41,10 @@ def setup(
     precision: Optional[str] = None,
     resume: Union[bool, Path] = False,
     devices: int = 4,
-    io_args: IOArgs = IOArgs(
+    io: IOArgs = IOArgs(
         train_data_dir=Path("data/redpajama_sample"), val_data_dir=None, out_dir=Path("out/redpajama")
     ),
-    train_args: TrainArgs = TrainArgs(
+    train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
         global_batch_size=125,
@@ -59,7 +59,7 @@ def setup(
         max_norm=1.0,
         min_lr=6e-5,
     ),
-    eval_args: EvalArgs = EvalArgs(interval=1000, max_iters=100),
+    eval: EvalArgs = EvalArgs(interval=1000, max_iters=100),
 ) -> None:
     print(locals())
     precision = precision or get_default_supported_precision(training=True)
@@ -75,10 +75,10 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io_args.out_dir.parent, io_args.out_dir.name, flush_logs_every_n_steps=train_args.log_interval)
+    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
 
-    fabric.launch(main, devices, resume, Config.from_name(name=model_name), io_args, train_args, eval_args)
+    fabric.launch(main, devices, resume, Config.from_name(name=model_name), io, train, eval)
 
 
 def main(
@@ -86,21 +86,21 @@ def main(
     devices: int,
     resume: Union[bool, Path],
     config: Config,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
-    validate_args(io_args, train_args, eval_args)
+    validate_args(io, train, eval)
 
     if fabric.global_rank == 0:
-        io_args.out_dir.mkdir(parents=True, exist_ok=True)
+        io.out_dir.mkdir(parents=True, exist_ok=True)
 
     train_dataloader, val_dataloader = create_dataloaders(
-        batch_size=train_args.micro_batch_size,
+        batch_size=train.micro_batch_size,
         block_size=config.block_size,
         fabric=fabric,
-        train_data_dir=io_args.train_data_dir,
-        val_data_dir=io_args.val_data_dir,
+        train_data_dir=io.train_data_dir,
+        val_data_dir=io.val_data_dir,
         seed=(1337 + fabric.global_rank),
     )
     if val_dataloader is None:
@@ -122,9 +122,9 @@ def main(
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
         model.parameters(),
-        lr=train_args.learning_rate,
-        weight_decay=train_args.weight_decay,
-        betas=(train_args.beta1, train_args.beta2),
+        lr=train.learning_rate,
+        weight_decay=train.weight_decay,
+        betas=(train.beta1, train.beta2),
         foreach=False,
     )
     optimizer = fabric.setup_optimizers(optimizer)
@@ -132,27 +132,27 @@ def main(
     state = {"model": model, "optimizer": optimizer, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = max(io_args.out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))
+        resume = max(io.out_dir.glob("*.pth"), key=lambda p: int(p.name.split("-")[1]))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)
 
     train_time = time.perf_counter()
-    train(fabric, devices, state, train_dataloader, val_dataloader, io_args, train_args, eval_args)
+    fit(fabric, devices, state, train_dataloader, val_dataloader, io, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
 
-def train(
+def fit(
     fabric: L.Fabric,
     devices: int,
     state: dict,
     train_dataloader: DataLoader,
     val_dataloader: Optional[DataLoader],
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
@@ -165,9 +165,9 @@ def train(
         # "estimated" is not as precise as "measured". Estimated is optimistic but widely used in the wild.
         # When comparing MFU or FLOP numbers with other projects that use estimated FLOPs,
         # consider passing `flops_per_batch=estimated_flops` instead
-        estimated_flops = estimate_flops(meta_model, training=True) * train_args.micro_batch_size
+        estimated_flops = estimate_flops(meta_model, training=True) * train.micro_batch_size
         fabric.print(f"Estimated TFLOPs: {estimated_flops * fabric.world_size / 1e12:.2f}")
-        x = torch.randint(0, 1, (train_args.micro_batch_size, model.max_seq_length))
+        x = torch.randint(0, 1, (train.micro_batch_size, model.max_seq_length))
         forward_fn = lambda: meta_model(x)
         loss_fn = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
         measured_flops = measure_flops(meta_model, forward_fn, loss_fn)
@@ -177,18 +177,18 @@ def train(
     throughput = ThroughputMonitor(fabric, window_size=50)
     total_t0 = time.perf_counter()
 
-    lr_warmup_iters = train_args.lr_warmup_steps * train_args.gradient_accumulation_iters(devices)
+    lr_warmup_iters = train.lr_warmup_steps * train.gradient_accumulation_iters(devices)
     for state["iter_num"], train_data in enumerate(train_dataloader, state["iter_num"]):
-        if state["iter_num"] >= train_args.max_iters(devices):
+        if state["iter_num"] >= train.max_iters(devices):
             break
 
         # determine and set the learning rate for this iteration
         lr = get_lr(
-            train_args.learning_rate,
+            train.learning_rate,
             state["iter_num"],
             lr_warmup_iters,
-            train_args.max_iters(devices),
-            min_lr=train_args.min_lr,
+            train.max_iters(devices),
+            min_lr=train.min_lr,
         )
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
@@ -199,27 +199,27 @@ def train(
         input_ids = train_data[:, 0 : model.max_seq_length].contiguous()
         targets = train_data[:, 1 : model.max_seq_length + 1].contiguous()
 
-        is_accumulating = iter_num % train_args.gradient_accumulation_iters(devices) != 0
+        is_accumulating = iter_num % train.gradient_accumulation_iters(devices) != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
             loss = chunked_cross_entropy(logits, targets, chunk_size=0)
-            fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
 
         if not is_accumulating:
-            fabric.clip_gradients(model, optimizer, max_norm=train_args.max_norm)
+            fabric.clip_gradients(model, optimizer, max_norm=train.max_norm)
             optimizer.step()
             optimizer.zero_grad()
             state["step_count"] += 1
 
-        if iter_num % train_args.log_interval == 0:
+        if iter_num % train.log_interval == 0:
             loss_item = loss.item()  # expensive device-to-host synchronization
             t1 = time.perf_counter()
             throughput.update(
                 time=t1 - total_t0,
                 batches=iter_num,
-                samples=iter_num * train_args.micro_batch_size,
-                lengths=iter_num * train_args.micro_batch_size * model.max_seq_length,
-                flops=measured_flops * train_args.log_interval,
+                samples=iter_num * train.micro_batch_size,
+                lengths=iter_num * train.micro_batch_size * model.max_seq_length,
+                flops=measured_flops * train.log_interval,
             )
             throughput.compute_and_log(step=iter_num)
             fabric.print(
@@ -227,14 +227,14 @@ def train(
                 f" {(t1 - iter_t0) * 1000:.2f}ms{' (optimizer.step)' if not is_accumulating else ''}"
             )
 
-        if val_dataloader is not None and not is_accumulating and state["step_count"] % eval_args.interval == 0:
+        if val_dataloader is not None and not is_accumulating and state["step_count"] % eval.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_dataloader, max_iters=eval_args.max_iters)
+            val_loss = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
             t1 = time.perf_counter() - t0
             fabric.print(f"step {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f}ms")
             fabric.barrier()
-        if not is_accumulating and state["step_count"] % train_args.save_interval == 0:
-            checkpoint_path = io_args.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
+        if not is_accumulating and state["step_count"] % train.save_interval == 0:
+            checkpoint_path = io.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             fabric.print(f"Saving checkpoint to {str(checkpoint_path)!r}")
             fabric.save(checkpoint_path, state)
 
@@ -342,13 +342,13 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
     return min_lr + coeff * (learning_rate - min_lr)
 
 
-def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
-    unsupported = [(io_args, ["checkpoint_dir"]), (train_args, ["max_tokens"]), (eval_args, ["max_new_tokens"])]
+def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+    unsupported = [(io, ["checkpoint_dir"]), (train, ["max_tokens"]), (eval, ["max_new_tokens"])]
     for args, names in unsupported:
         for name in names:
             if getattr(args, name) is not None:
                 raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
-    required = [(io_args, ["train_data_dir"]), (train_args, ["epoch_size", "epochs", "max_norm"])]
+    required = [(io, ["train_data_dir"]), (train, ["epoch_size", "epochs", "max_norm"])]
     for args, names in required:
         for name in names:
             if getattr(args, name) is None:

--- a/pretrain/tinyllama.py
+++ b/pretrain/tinyllama.py
@@ -39,10 +39,10 @@ def setup(
     logger_name: Literal["wandb", "tensorboard", "csv"] = "tensorboard",
     resume: Union[bool, Path] = False,
     devices: int = torch.cuda.device_count() or 1,
-    io_args: IOArgs = IOArgs(
+    io: IOArgs = IOArgs(
         out_dir=Path(os.getenv("LIGHTNING_ARTIFACTS_DIR", "out")) / "lit-tiny-llama-1.1b", train_data_dir=None
     ),
-    train_args: TrainArgs = TrainArgs(
+    train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
         global_batch_size=512,
@@ -56,10 +56,10 @@ def setup(
         min_lr=4e-5,
         lr_warmup_steps=2000,
     ),
-    eval_args: EvalArgs = EvalArgs(interval=1000, max_iters=100),
+    eval: EvalArgs = EvalArgs(interval=1000, max_iters=100),
 ):
     hparams = locals()
-    logger = choose_logger(io_args.out_dir, logger_name, name=name, resume=resume)
+    logger = choose_logger(io.out_dir, logger_name, name=name, resume=resume)
 
     strategy = FSDPStrategy(auto_wrap_policy={Block}, state_dict_type="full", sharding_strategy="HYBRID_SHARD")
     fabric = L.Fabric(devices=devices, strategy=strategy, precision="bf16-mixed", loggers=[logger])
@@ -69,7 +69,7 @@ def setup(
     if logger_name in ("tensorboard", "wandb"):
         fabric.logger.log_hyperparams(hparams)
 
-    fabric.launch(main, devices, resume, Config.from_name(name=model_name), io_args, train_args, eval_args)
+    fabric.launch(main, devices, resume, Config.from_name(name=model_name), io, train, eval)
 
 
 def main(
@@ -77,17 +77,17 @@ def main(
     devices: int,
     resume: Union[bool, Path],
     config: Config,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
-    validate_args(io_args, train_args, eval_args)
+    validate_args(io, train, eval)
 
     if fabric.global_rank == 0:
-        io_args.out_dir.mkdir(parents=True, exist_ok=True)
+        io.out_dir.mkdir(parents=True, exist_ok=True)
 
     train_dataloader, val_dataloader = create_dataloaders(
-        batch_size=train_args.micro_batch_size, block_size=config.block_size
+        batch_size=train.micro_batch_size, block_size=config.block_size
     )
     train_dataloader, val_dataloader = fabric.setup_dataloaders(train_dataloader, val_dataloader)
 
@@ -106,9 +106,9 @@ def main(
     model = fabric.setup(model)
     optimizer = torch.optim.AdamW(
         model.parameters(),
-        lr=train_args.learning_rate,
-        weight_decay=train_args.weight_decay,
-        betas=(train_args.beta1, train_args.beta2),
+        lr=train.learning_rate,
+        weight_decay=train.weight_decay,
+        betas=(train.beta1, train.beta2),
         fused=True,
     )
     optimizer = fabric.setup_optimizers(optimizer)
@@ -122,27 +122,27 @@ def main(
     }
 
     if resume is True:
-        resume = max(io_args.out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
+        resume = max(io.out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)
 
     train_time = time.perf_counter()
-    train(fabric, devices, state, train_dataloader, val_dataloader, io_args, train_args, eval_args)
+    fit(fabric, devices, state, train_dataloader, val_dataloader, io, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
 
-def train(
+def fit(
     fabric,
     devices: int,
     state: dict,
     train_dataloader: DataLoader,
     val_dataloader: DataLoader,
-    io_args: IOArgs,
-    train_args: TrainArgs,
-    eval_args: EvalArgs,
+    io: IOArgs,
+    train: TrainArgs,
+    eval: EvalArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
@@ -152,33 +152,33 @@ def train(
 
     with torch.device("meta"):
         meta_model = GPT(model.config)
-        x = torch.randint(0, 1, (train_args.micro_batch_size, meta_model.config.block_size))
+        x = torch.randint(0, 1, (train.micro_batch_size, meta_model.config.block_size))
         model_fwd = lambda: meta_model(x)
         model_loss = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
         measured_flops = measure_flops(meta_model, model_fwd, model_loss)
         fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
         del meta_model, x
 
-    max_tokens_per_device = train_args.max_tokens // fabric.world_size
-    tokens_per_iter = train_args.micro_batch_size * model.config.block_size
+    max_tokens_per_device = train.max_tokens // fabric.world_size
+    tokens_per_iter = train.micro_batch_size * model.config.block_size
     max_iters = max_tokens_per_device // tokens_per_iter
-    log_iter_interval = train_args.log_interval * train_args.gradient_accumulation_iters(devices)
+    log_iter_interval = train.log_interval * train.gradient_accumulation_iters(devices)
     initial_iter = state["iter_num"]
     train_iterator = CycleIterator(train_dataloader)
 
-    running_loss = RunningMean(window=train_args.gradient_accumulation_iters(devices), sync_on_compute=False).to(
+    running_loss = RunningMean(window=train.gradient_accumulation_iters(devices), sync_on_compute=False).to(
         fabric.device
     )
     fabric.barrier()
     total_t0 = time.perf_counter()
 
-    warmup_iters = train_args.lr_warmup_steps * train_args.gradient_accumulation_iters(devices)
+    warmup_iters = train.lr_warmup_steps * train.gradient_accumulation_iters(devices)
     for train_data in train_iterator:
         if state["iter_num"] >= max_iters:
             break
 
         # determine and set the learning rate for this iteration
-        lr = get_lr(train_args.learning_rate, state["iter_num"], warmup_iters, max_iters, train_args.min_lr)
+        lr = get_lr(train.learning_rate, state["iter_num"], warmup_iters, max_iters, train.min_lr)
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
@@ -188,16 +188,16 @@ def train(
         input_ids = train_data[:, 0 : model.config.block_size].contiguous().long()
         targets = train_data[:, 1 : (model.config.block_size + 1)].contiguous().long()
 
-        is_accumulating = state["iter_num"] % train_args.gradient_accumulation_iters(devices) != 0
+        is_accumulating = state["iter_num"] % train.gradient_accumulation_iters(devices) != 0
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
             loss = chunked_cross_entropy(logits, targets)
-            fabric.backward(loss / train_args.gradient_accumulation_iters(devices))
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
 
         running_loss.update(loss.detach())
 
         if not is_accumulating:
-            fabric.clip_gradients(model, optimizer, max_norm=train_args.max_norm)
+            fabric.clip_gradients(model, optimizer, max_norm=train.max_norm)
             optimizer.step()
             optimizer.zero_grad()
             state["step_count"] += 1
@@ -209,8 +209,8 @@ def train(
                 time=(t1 - total_t0),
                 flops=(measured_flops * log_iter_interval),
                 batches=state["iter_num"],
-                samples=(state["iter_num"] * train_args.micro_batch_size),
-                lengths=(state["iter_num"] * train_args.micro_batch_size * model.config.block_size),
+                samples=(state["iter_num"] * train.micro_batch_size),
+                lengths=(state["iter_num"] * train.micro_batch_size * model.config.block_size),
             )
             metrics = {
                 "loss": loss,
@@ -221,9 +221,9 @@ def train(
                 "remaining_time": (
                     (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"])
                 ),
-                "tokens": state["iter_num"] * train_args.micro_batch_size * model.config.block_size,
+                "tokens": state["iter_num"] * train.micro_batch_size * model.config.block_size,
                 "total_tokens": (
-                    state["iter_num"] * train_args.micro_batch_size * model.config.block_size * fabric.world_size
+                    state["iter_num"] * train.micro_batch_size * model.config.block_size * fabric.world_size
                 ),
                 "learning_rate": lr,
             }
@@ -238,9 +238,9 @@ def train(
             metrics.update(throughput_metrics)
             fabric.log_dict(metrics, step=state["iter_num"])
 
-        if val_dataloader is not None and not is_accumulating and state["step_count"] % eval_args.interval == 0:
+        if val_dataloader is not None and not is_accumulating and state["step_count"] % eval.interval == 0:
             t0 = time.perf_counter()
-            val_loss = validate(fabric, model, val_dataloader, max_iters=eval_args.max_iters)
+            val_loss = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
             val_loss = val_loss.item()
             td = time.perf_counter() - t0
 
@@ -249,8 +249,8 @@ def train(
             fabric.log_dict(metrics, step=state["iter_num"])
             fabric.barrier()
 
-        if not is_accumulating and state["step_count"] % train_args.save_interval == 0:
-            checkpoint_path = io_args.out_dir / f"step-{state['step_count']:08d}.pth"
+        if not is_accumulating and state["step_count"] % train.save_interval == 0:
+            checkpoint_path = io.out_dir / f"step-{state['step_count']:08d}.pth"
             fabric.print(f"Saving checkpoint to {str(checkpoint_path)!r}")
             fabric.save(checkpoint_path, state)
 
@@ -354,17 +354,17 @@ def choose_logger(out_dir: Path, logger_name: str, name: str, resume: Union[bool
     raise ValueError(f"`logger={logger_name}` is not a valid option.")
 
 
-def validate_args(io_args: IOArgs, train_args: TrainArgs, eval_args: EvalArgs) -> None:
+def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
     unsupported = [
-        (io_args, ["train_data_dir", "val_data_dir", "checkpoint_dir"]),
-        (train_args, ["epoch_size", "epochs"]),
-        (eval_args, ["max_new_tokens"]),
+        (io, ["train_data_dir", "val_data_dir", "checkpoint_dir"]),
+        (train, ["epoch_size", "epochs"]),
+        (eval, ["max_new_tokens"]),
     ]
     for args, names in unsupported:
         for name in names:
             if getattr(args, name) is not None:
                 raise ValueError(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
-    required = [(train_args, ["max_tokens", "max_norm"])]
+    required = [(train, ["max_tokens", "max_norm"])]
     for args, names in required:
         for name in names:
             if getattr(args, name) is None:

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -14,7 +14,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Config
-from lit_gpt.utils import incremental_save, lazy_load
+from lit_gpt.utils import CLI, incremental_save, lazy_load
 from scripts.convert_hf_checkpoint import layer_template, load_param
 
 
@@ -265,6 +265,4 @@ def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
-    CLI(convert_lit_checkpoint, as_positional=False)
+    CLI(convert_lit_checkpoint)

--- a/scripts/convert_pretrained_checkpoint.py
+++ b/scripts/convert_pretrained_checkpoint.py
@@ -13,7 +13,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Config
-from lit_gpt.utils import incremental_save
+from lit_gpt.utils import CLI, incremental_save
 
 
 @torch.inference_mode()
@@ -75,6 +75,4 @@ def convert_checkpoint(checkpoint_file: Path, tokenizer_dir: Path, config_name: 
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
-    CLI(convert_checkpoint, as_positional=False)
+    CLI(convert_checkpoint)

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -12,6 +12,8 @@ from lightning_utilities.core.imports import RequirementCache
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
+from lit_gpt.utils import CLI
+
 _SAFETENSORS_AVAILABLE = RequirementCache("safetensors")
 _HF_TRANSFER_AVAILABLE = RequirementCache("hf_transfer")
 
@@ -92,6 +94,4 @@ def download_from_hub(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(download_from_hub)

--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -14,7 +14,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.lora import GPT, Config, lora_filter, merge_lora_weights
-from lit_gpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 
 
 def merge_lora(
@@ -80,6 +80,4 @@ def merge_lora(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(merge_lora)

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -17,6 +17,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
 
 
 def prepare(
@@ -147,6 +148,4 @@ def generate_prompt(example: dict) -> str:
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_csv.py
+++ b/scripts/prepare_csv.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
 
 
 def prepare(
@@ -135,6 +136,4 @@ def generate_prompt(example: dict) -> str:
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
-    CLI(prepare, as_positional=False)
+    CLI(prepare)

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -11,13 +11,13 @@ import torch
 from torch.utils.data import random_split
 from tqdm import tqdm
 
-from scripts.prepare_alpaca import download_if_missing
-
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
+from scripts.prepare_alpaca import download_if_missing
 
 
 def prepare(
@@ -141,6 +141,4 @@ def generate_prompt(example: dict) -> str:
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_flan.py
+++ b/scripts/prepare_flan.py
@@ -9,13 +9,13 @@ from typing import Optional
 import torch
 from tqdm import tqdm
 
-from scripts.prepare_alpaca import download_if_missing
-
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
+from scripts.prepare_alpaca import download_if_missing
 
 
 def load_jsonl(filename):
@@ -229,6 +229,4 @@ def generate_prompt(example):
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_lima.py
+++ b/scripts/prepare_lima.py
@@ -17,6 +17,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
 
 
 def prepare(
@@ -164,6 +165,4 @@ def generate_prompt(example: dict) -> str:
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_longform.py
+++ b/scripts/prepare_longform.py
@@ -10,13 +10,13 @@ from typing import Optional
 import torch
 from tqdm import tqdm
 
-from scripts.prepare_alpaca import download_if_missing
-
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt.tokenizer import Tokenizer
+from lit_gpt.utils import CLI
+from scripts.prepare_alpaca import download_if_missing
 
 
 def prepare(
@@ -133,6 +133,4 @@ def generate_prompt(example: dict) -> str:
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_openwebtext.py
+++ b/scripts/prepare_openwebtext.py
@@ -15,6 +15,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Tokenizer
+from lit_gpt.utils import CLI
 
 
 def prepare(
@@ -77,6 +78,4 @@ def prepare(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -15,6 +15,7 @@ sys.path.append(str(wd))
 
 import lit_gpt.packed_dataset as packed_dataset
 from lit_gpt import Config, Tokenizer
+from lit_gpt.utils import CLI
 
 filenames_sample = [
     "arxiv_sample.jsonl",
@@ -162,6 +163,4 @@ def prepare(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_slimpajama.py
+++ b/scripts/prepare_slimpajama.py
@@ -14,6 +14,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Tokenizer
+from lit_gpt.utils import CLI
 
 
 class SlimPajamaDataRecipe(DataChunkRecipe):
@@ -59,6 +60,4 @@ def prepare(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/scripts/prepare_starcoder.py
+++ b/scripts/prepare_starcoder.py
@@ -14,6 +14,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_gpt import Tokenizer
+from lit_gpt.utils import CLI
 
 
 class StarcoderDataRecipe(DataChunkRecipe):
@@ -70,6 +71,4 @@ def prepare(
 
 
 if __name__ == "__main__":
-    from jsonargparse import CLI
-
     CLI(prepare)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -48,6 +48,7 @@ def test_adapter_filter(tmp_path):
 
 def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import finetune.adapter as module
+    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 
     data = [
         {"input_ids": torch.tensor([0, 1, 2]), "labels": torch.tensor([1, 2, 3])},
@@ -71,18 +72,12 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
             precision="32-true",
-            global_batch_size=1,
-            save_interval=2,
-            eval_interval=2,
-            eval_iters=2,
-            eval_max_new_tokens=1,
-            epochs=1,
-            train_epoch_size=6,
-            micro_batch_size=1,
+            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -74,12 +74,12 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
             precision="32-true",
-            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
-            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
+            train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
@@ -167,7 +167,7 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
         module.setup(
             precision="16-true",
             quantize="bnb.nf4-dq",
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
         )

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -6,9 +6,11 @@ from unittest.mock import Mock
 
 import pytest
 import torch
-from conftest import RunIf
 from lightning import Fabric
+from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 from lightning.fabric.wrappers import _FabricOptimizer
+
+from conftest import RunIf
 
 
 def test_config_identical():
@@ -136,7 +138,7 @@ def test_adapter_compile():
 # platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
 @pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
-    from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
+    from lit_gpt.args import IOArgs
 
     if not _BITSANDBYTES_AVAILABLE:
         pytest.skip("BNB not available")
@@ -163,11 +165,11 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
             precision="16-true",
             quantize="bnb.nf4-dq",
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
         )
 
     args, kwargs = train_mock.call_args

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -6,11 +6,10 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from conftest import RunIf
 from lightning import Fabric
 from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 from lightning.fabric.wrappers import _FabricOptimizer
-
-from conftest import RunIf
 
 
 def test_config_identical():

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -97,12 +97,12 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
             precision="32-true",
-            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
-            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
+            train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
@@ -256,7 +256,7 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
         module.setup(
             precision="16-true",
             quantize="bnb.nf4-dq",
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
         )

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 from conftest import RunIf
 from lightning import Fabric
+from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 from lightning.fabric.wrappers import _FabricOptimizer
 
 # support running without installing as a package
@@ -72,6 +73,7 @@ def test_adapter_v2_filter(tmp_path):
 
 def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import finetune.adapter_v2 as module
+    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 
     data = [
         {"input_ids": torch.tensor([0, 1, 2]), "labels": torch.tensor([1, 2, 3])},
@@ -95,18 +97,12 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
             precision="32-true",
-            global_batch_size=1,
-            save_interval=2,
-            eval_interval=2,
-            eval_iters=2,
-            eval_max_new_tokens=1,
-            epochs=1,
-            train_epoch_size=6,
-            micro_batch_size=1,
+            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
@@ -231,7 +227,7 @@ def test_against_hf_mixtral():
 # platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
 @pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
-    from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
+    from lit_gpt.args import IOArgs
 
     if not _BITSANDBYTES_AVAILABLE:
         pytest.skip("BNB not available")
@@ -258,11 +254,11 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
             precision="16-true",
             quantize="bnb.nf4-dq",
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
         )
 
     args, kwargs = train_mock.call_args

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -12,6 +12,7 @@ import torch
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import finetune.full as module
+    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 
     data = [
         {"input_ids": torch.tensor([0, 1, 2]), "labels": torch.tensor([1, 2, 3])},
@@ -34,18 +35,12 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
             precision="32-true",
-            global_batch_size=1,
-            save_interval=2,
-            eval_interval=2,
-            eval_iters=2,
-            eval_max_new_tokens=1,
-            epochs=1,
-            train_epoch_size=6,
-            micro_batch_size=1,
+            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -35,12 +35,12 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
             precision="32-true",
-            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
-            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
+            train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -180,6 +180,7 @@ def test_lora_filter(tmp_path):
 
 def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import finetune.lora as module
+    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
 
     data = [
         {"input_ids": torch.tensor([0, 1, 2]), "labels": torch.tensor([1, 2, 3])},
@@ -202,18 +203,12 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
             precision="32-true",
-            global_batch_size=1,
-            save_interval=2,
-            eval_interval=2,
-            eval_iters=2,
-            eval_max_new_tokens=1,
-            epochs=1,
-            train_epoch_size=6,
-            micro_batch_size=1,
+            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
@@ -629,9 +624,9 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            data_dir=tmp_path,
-            checkpoint_dir=fake_checkpoint_dir,
-            out_dir=tmp_path,
+            io_args=IOArgs(
+                train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
+            ),
             precision="16-true",
             quantize="bnb.nf4-dq",
         )

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -9,9 +9,11 @@ from unittest.mock import Mock
 
 import pytest
 import torch
-from conftest import RunIf
 from lightning import Fabric
+from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 from lightning.fabric.wrappers import _FabricOptimizer
+
+from conftest import RunIf
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -586,7 +588,7 @@ def test_against_hf_mixtral():
 # platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
 @pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
-    from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
+    from lit_gpt.args import IOArgs
 
     if not _BITSANDBYTES_AVAILABLE:
         pytest.skip("BNB not available")

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -9,11 +9,10 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from conftest import RunIf
 from lightning import Fabric
 from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 from lightning.fabric.wrappers import _FabricOptimizer
-
-from conftest import RunIf
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -205,12 +205,12 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
             precision="32-true",
-            train_args=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
-            eval_args=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
+            train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, epoch_size=6, micro_batch_size=1),
+            eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
         )
 
     assert {p.name for p in tmp_path.glob("*.pth")} == {
@@ -427,7 +427,7 @@ def test_lora_merge_with_bitsandbytes():
     optimizer = PagedAdamW(model.parameters(), lr=1.0)
     model, optimizer = fabric.setup(model, optimizer)
 
-    model.train()
+    model.fit()
 
     attn_proj = model.transformer.h[0].attn.proj
     initial_weight = attn_proj.linear.weight.clone()
@@ -626,7 +626,7 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            io_args=IOArgs(
+            io=IOArgs(
                 train_data_dir=tmp_path, val_data_dir=tmp_path, checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path
             ),
             precision="16-true",

--- a/tests/test_pretrain_tinyllama.py
+++ b/tests/test_pretrain_tinyllama.py
@@ -32,7 +32,7 @@ def test_pretrain_tiny_llama(tmp_path, monkeypatch):
             devices=2,
             model_name="tmp",
             io=IOArgs(out_dir=tmp_path, train_data_dir=None),
-            train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1),
+            train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1, max_norm=1.0),
             eval=EvalArgs(interval=1, max_iters=1),
         )
 

--- a/tests/test_pretrain_tinyllama.py
+++ b/tests/test_pretrain_tinyllama.py
@@ -1,8 +1,10 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import os
+import sys
 from contextlib import redirect_stdout
 from io import StringIO
+from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
@@ -11,12 +13,15 @@ from conftest import RunIf
 from torch.utils.data import DataLoader
 
 
+
 @RunIf(min_cuda_gpus=2, standalone=True)
 # Set CUDA_VISIBLE_DEVICES for FSDP hybrid-shard, if fewer GPUs are used than are available
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
 def test_pretrain_tiny_llama(tmp_path, monkeypatch):
     import pretrain.tinyllama as module
     from lit_gpt.config import name_to_config
+    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+
 
     model_config = dict(block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
@@ -28,15 +33,11 @@ def test_pretrain_tiny_llama(tmp_path, monkeypatch):
     stdout = StringIO()
     with redirect_stdout(stdout):
         module.setup(
-            save_interval=1,
-            eval_interval=1,
-            eval_iters=2,
-            max_tokens=16,
             devices=2,
-            global_batch_size=2,
-            micro_batch_size=1,
             model_name="tmp",
-            out_dir=tmp_path,
+            io_args=IOArgs(out_dir=tmp_path),
+            train_args=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1),
+            eval_args=EvalArgs(interval=1, max_iters=1),
         )
 
     if torch.distributed.get_rank() == 0:

--- a/tests/test_pretrain_tinyllama.py
+++ b/tests/test_pretrain_tinyllama.py
@@ -1,10 +1,8 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import os
-import sys
 from contextlib import redirect_stdout
 from io import StringIO
-from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
@@ -13,15 +11,13 @@ from conftest import RunIf
 from torch.utils.data import DataLoader
 
 
-
 @RunIf(min_cuda_gpus=2, standalone=True)
 # Set CUDA_VISIBLE_DEVICES for FSDP hybrid-shard, if fewer GPUs are used than are available
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
 def test_pretrain_tiny_llama(tmp_path, monkeypatch):
     import pretrain.tinyllama as module
-    from lit_gpt.config import name_to_config
     from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
-
+    from lit_gpt.config import name_to_config
 
     model_config = dict(block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     monkeypatch.setitem(name_to_config, "tmp", model_config)
@@ -35,9 +31,9 @@ def test_pretrain_tiny_llama(tmp_path, monkeypatch):
         module.setup(
             devices=2,
             model_name="tmp",
-            io_args=IOArgs(out_dir=tmp_path),
-            train_args=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1),
-            eval_args=EvalArgs(interval=1, max_iters=1),
+            io=IOArgs(out_dir=tmp_path, train_data_dir=None),
+            train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1),
+            eval=EvalArgs(interval=1, max_iters=1),
         )
 
     if torch.distributed.get_rank() == 0:

--- a/tutorials/download_tinyllama.md
+++ b/tutorials/download_tinyllama.md
@@ -55,7 +55,7 @@ pip install sentencepiece
 # base version
 python chat/base.py --checkpoint_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 
-or
+# or
 
 # chat version
 python chat/base.py --checkpoint_dir checkpoints/TinyLlama/TinyLlama-1.1B-Chat-v1.0

--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -27,13 +27,13 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-python finetune/adapter.py --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+python finetune/adapter.py --io.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 or for Adapter V2
 
 ```bash
-python finetune/adapter_v2.py --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+python finetune/adapter_v2.py --io.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 The finetuning requires at least one GPU with ~12 GB memory.
@@ -44,26 +44,26 @@ To fit Adapter V2 to 12GB memory set `--micro_batch_size 2`.
 For example, the following settings will let you finetune the model in under 1 hour:
 
 ```bash
---devices 4 --train_args.micro_batch_size 4
+--devices 4 --train.micro_batch_size 4
 ```
 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-python finetune/adapter.py --io_args.out_dir out/adapter/my-model-finetuned
+python finetune/adapter.py --io.out_dir out/adapter/my-model-finetuned
 ```
 
 or for Adapter V2
 
 ```bash
-python finetune/adapter_v2.py --io_args.out_dir out/adapter_v2/my-model-finetuned
+python finetune/adapter_v2.py --io.out_dir out/adapter_v2/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-python finetune/adapter.py --io_args.out_dir out/adapter/my-model-finetuned --precision 32-true
+python finetune/adapter.py --io.out_dir out/adapter/my-model-finetuned --precision 32-true
 ```
 
 Note that `mps` as the accelerator will be picked up automatically by Fabric when running on a modern Mac.
@@ -146,7 +146,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
     ```bash
     python finetune/adapter.py \
-        --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
-        --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
-        --io_args.out_dir data/mydata-finetuned
+        --io.train_data_dir data/mydata --io.val_data_dir data/mydata/ \
+        --io.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
+        --io.out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -27,13 +27,13 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-python finetune/adapter.py --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+python finetune/adapter.py --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 or for Adapter V2
 
 ```bash
-python finetune/adapter_v2.py --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+python finetune/adapter_v2.py --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 The finetuning requires at least one GPU with ~12 GB memory.
@@ -44,26 +44,26 @@ To fit Adapter V2 to 12GB memory set `--micro_batch_size 2`.
 For example, the following settings will let you finetune the model in under 1 hour:
 
 ```bash
---devices 4 --micro_batch_size 4
+--devices 4 --train_args.micro_batch_size 4
 ```
 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-python finetune/adapter.py --out_dir out/adapter/my-model-finetuned
+python finetune/adapter.py --io_args.out_dir out/adapter/my-model-finetuned
 ```
 
 or for Adapter V2
 
 ```bash
-python finetune/adapter_v2.py --out_dir out/adapter_v2/my-model-finetuned
+python finetune/adapter_v2.py --io_args.out_dir out/adapter_v2/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-python finetune/adapter.py --out_dir out/adapter/my-model-finetuned --precision 32-true
+python finetune/adapter.py --io_args.out_dir out/adapter/my-model-finetuned --precision 32-true
 ```
 
 Note that `mps` as the accelerator will be picked up automatically by Fabric when running on a modern Mac.
@@ -146,7 +146,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
     ```bash
     python finetune/adapter.py \
-        --data_dir data/mydata/ \
-        --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
-        --out_dir data/mydata-finetuned
+        --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
+        --io_args.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
+        --io_args.out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -11,7 +11,7 @@ The steps here only need to be done once:
 3. Download the data and generate the Alpaca instruction tuning dataset:
 
 ```bash
-python scripts/prepare_alpaca.py --checkpoint_dir checkpoints/tiiuae/falcon-7b
+python scripts/prepare_alpaca.py --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 or [prepare your own dataset](#tune-on-your-dataset).
@@ -21,7 +21,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-python finetune/full.py --checkpoint_dir checkpoints/tiiuae/falcon-7b
+python finetune/full.py --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 Finetuning the falcon-7b model requires at least 8 GPUs with ~40 GB memory each.
@@ -32,14 +32,14 @@ Depending on the available GPU memory, you can also tune the `micro_batch_size` 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-python finetune/full.py --out_dir out/full/my-model-finetuned
+python finetune/full.py --io_args.out_dir out/full/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-python finetune/full.py --out_dir out/full/my-model-finetuned --precision 32-true
+python finetune/full.py --io_args.out_dir out/full/my-model-finetuned --precision 32-true
 ```
 
 Note that `mps` as the accelerator will be picked up automatically by Fabric when running on a modern Mac.
@@ -99,7 +99,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
     ```bash
     python finetune/full.py \
-        --data_dir data/mydata/ \
-        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
-        --out_dir data/mydata-finetuned
+        --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
+        --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b \
+        --io_args.out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -11,7 +11,7 @@ The steps here only need to be done once:
 3. Download the data and generate the Alpaca instruction tuning dataset:
 
 ```bash
-python scripts/prepare_alpaca.py --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b
+python scripts/prepare_alpaca.py --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 or [prepare your own dataset](#tune-on-your-dataset).
@@ -21,7 +21,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-python finetune/full.py --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b
+python finetune/full.py --io.checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 Finetuning the falcon-7b model requires at least 8 GPUs with ~40 GB memory each.
@@ -32,14 +32,14 @@ Depending on the available GPU memory, you can also tune the `micro_batch_size` 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-python finetune/full.py --io_args.out_dir out/full/my-model-finetuned
+python finetune/full.py --io.out_dir out/full/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-python finetune/full.py --io_args.out_dir out/full/my-model-finetuned --precision 32-true
+python finetune/full.py --io.out_dir out/full/my-model-finetuned --precision 32-true
 ```
 
 Note that `mps` as the accelerator will be picked up automatically by Fabric when running on a modern Mac.
@@ -99,7 +99,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
     ```bash
     python finetune/full.py \
-        --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
-        --io_args.checkpoint_dir checkpoints/tiiuae/falcon-7b \
-        --io_args.out_dir data/mydata-finetuned
+        --io.train_data_dir data/mydata --io.val_data_dir data/mydata/ \
+        --io.checkpoint_dir checkpoints/tiiuae/falcon-7b \
+        --io.out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -136,7 +136,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
    ```bash
    python finetune/lora.py  \
-     --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
+     --io.train_data_dir data/mydata --io.val_data_dir data/mydata/ \
      --out_dir out/myexperiment
    ```
 
@@ -153,9 +153,9 @@ Let's assume we finetuned a model using LoRA as follows:
 
 ```bash
 python finetune/lora.py \
-  --io_args.checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
-  --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
-  --io_args.out_dir "out/lora_weights/stablelm-base-alpha-3b/"
+  --io.checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
+  --io.train_data_dir data/mydata --io.val_data_dir data/mydata/ \
+  --io.out_dir "out/lora_weights/stablelm-base-alpha-3b/"
 ```
 
 Then, we can merge the LoRA weights with the checkpoint model using the `merge_lora.py` script as shown below:

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -136,7 +136,7 @@ With only a few modifications, you can prepare and train on your own instruction
 
    ```bash
    python finetune/lora.py  \
-     --data_dir data/mydata/ \
+     --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
      --out_dir out/myexperiment
    ```
 
@@ -153,9 +153,9 @@ Let's assume we finetuned a model using LoRA as follows:
 
 ```bash
 python finetune/lora.py \
-  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
-  --data_dir "data/alpaca" \
-  --out_dir "out/lora_weights/stablelm-base-alpha-3b/"
+  --io_args.checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
+  --io_args.train_data_dir data/mydata --io_args.val_data_dir data/mydata/ \
+  --io_args.out_dir "out/lora_weights/stablelm-base-alpha-3b/"
 ```
 
 Then, we can merge the LoRA weights with the checkpoint model using the `merge_lora.py` script as shown below:

--- a/tutorials/oom.md
+++ b/tutorials/oom.md
@@ -14,7 +14,7 @@ Here's a few things you can try:
 
 ### Reduce the micro batch size
 
-Adjust the `--train_args.micro_batch_size` argument in the fine-tuning and pretraining scripts. This variable determines the number of samples loaded per iteration.
+Adjust the `--train.micro_batch_size` argument in the fine-tuning and pretraining scripts. This variable determines the number of samples loaded per iteration.
 
 A smaller value will simply load fewer samples simultaneously. The minimum value is 1.
 
@@ -25,7 +25,7 @@ Experiment with different micro batch sizes to find a balance between memory con
 The context length (`block_size` in the code) plays a significant role in running models with attention.
 
 * The pretraining scripts are configured to use the full context length of the model to train.
-* The finetuning scripts are configured to use the longest sample length of the training data to avoid allocating unnecessary memory (`--train_args.max_seq_length` argument).
+* The finetuning scripts are configured to use the longest sample length of the training data to avoid allocating unnecessary memory (`--train.max_seq_length` argument).
   If that's longer than the model's context length, an error is raised. If you try to run a batch that is longer than this, an error is raised.
 
 However, your hardware may not support such large context lengths. Here's what you can do:

--- a/tutorials/oom.md
+++ b/tutorials/oom.md
@@ -14,7 +14,7 @@ Here's a few things you can try:
 
 ### Reduce the micro batch size
 
-Adjust the `--micro_batch_size` argument in the fine-tuning and pretraining scripts. This variable determines the number of samples loaded per iteration.
+Adjust the `--train_args.micro_batch_size` argument in the fine-tuning and pretraining scripts. This variable determines the number of samples loaded per iteration.
 
 A smaller value will simply load fewer samples simultaneously. The minimum value is 1.
 
@@ -25,7 +25,7 @@ Experiment with different micro batch sizes to find a balance between memory con
 The context length (`block_size` in the code) plays a significant role in running models with attention.
 
 * The pretraining scripts are configured to use the full context length of the model to train.
-* The finetuning scripts are configured to use the longest sample length of the training data to avoid allocating unnecessary memory (`--max_seq_length` argument).
+* The finetuning scripts are configured to use the longest sample length of the training data to avoid allocating unnecessary memory (`--train_args.max_seq_length` argument).
   If that's longer than the model's context length, an error is raised. If you try to run a batch that is longer than this, an error is raised.
 
 However, your hardware may not support such large context lengths. Here's what you can do:

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -218,15 +218,15 @@ After preparing the dataset, you can finetune the model using the [`finetune/*.p
 
 ```bash
 python finetune/lora.py
- --io_args.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
- --io_args.train_data_dir "data/alpaca_libre" --io_args.val_data_dir "data/alpaca_libre" \
- --io_args.out_dir "out/lora/alpaca"
+ --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+ --io.train_data_dir "data/alpaca_libre" --io.val_data_dir "data/alpaca_libre" \
+ --io.out_dir "out/lora/alpaca"
 ```
 
 Please read the [tutorials/finetune_*.md](.) documents for more information about finetuning models.
 
 > [!IMPORTANT]
-> Make sure that the `prepare_*.py` and `finetune/*.py` scripts use the same model checkpoint specified via `--io_args.checkpoint_dir`.
+> Make sure that the `prepare_*.py` and `finetune/*.py` scripts use the same model checkpoint specified via `checkpoint_dir`.
 
 > [!IMPORTANT]
 > By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -218,15 +218,15 @@ After preparing the dataset, you can finetune the model using the [`finetune/*.p
 
 ```bash
 python finetune/lora.py
- --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
- --data_dir "data/alpaca_libre" \
- --out_dir "out/lora/alpaca"
+ --io_args.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+ --io_args.train_data_dir "data/alpaca_libre" --io_args.val_data_dir "data/alpaca_libre" \
+ --io_args.out_dir "out/lora/alpaca"
 ```
 
 Please read the [tutorials/finetune_*.md](.) documents for more information about finetuning models.
 
 > [!IMPORTANT]
-> Make sure that the `prepare_*.py` and `finetune/*.py` scripts use the same model checkpoint specified via `--checkpoint_dir`.
+> Make sure that the `prepare_*.py` and `finetune/*.py` scripts use the same model checkpoint specified via `--io_args.checkpoint_dir`.
 
 > [!IMPORTANT]
 > By default, the maximum sequence length is obtained from the model configuration file. In case you run into out-of-memory errors, especially in the cases of LIMA and Dolly,
@@ -300,12 +300,12 @@ To use the settings described above, you can add the respective command line arg
 
 ```bash
 python scripts/prepare_csv.py --csv_path test_data.csv \
---destination_path data/csv \
---checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
---test_split_fraction 0.1 \
---seed 42 \
---mask_inputs false \
---ignore_index -1
+  --destination_path data/csv \
+  --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b \
+  --test_split_fraction 0.1 \
+  --seed 42 \
+  --mask_inputs false \
+  --ignore_index -1
 ```
 
 Replace `test_data.csv` with your CSV path and the other additional parameters accordingly. Executing the command above will save `train.pt` and `test.pt` on your disk at the `destination_path`. Now you can use the prepared data to [finetune your model](finetune_lora.md#running-the-finetuning).

--- a/tutorials/pretrain_openwebtext.md
+++ b/tutorials/pretrain_openwebtext.md
@@ -61,7 +61,7 @@ to launch the script across machines:
 
 The exposes several hyperparameters you can tweak through the command line.
 
-For instance, `--train_args.micro_batch_size` should be adjusted so the process will use the available
+For instance, `--train.micro_batch_size` should be adjusted so the process will use the available
 GPU memory. For more tips to avoid out-of-memory issues, please also see the more detailed
 [Dealing with out-of-memory (OOM) errors](oom.md) guide.
 

--- a/tutorials/pretrain_openwebtext.md
+++ b/tutorials/pretrain_openwebtext.md
@@ -27,8 +27,7 @@ The script will take about 15 min to run.
 Running the pretraining script with its default settings requires at least 4 GPUs with 40GB+ each. (However, alternatively, you can train a smaller Pythia-70m on 1 GPU, more information about that further below).
 
 ```bash
-python pretrain/openwebtext.py \
-  --devices 4
+python pretrain/openwebtext.py --devices 4
 ```
 
 The script will save checkpoints periodically to the folder `out/`.
@@ -62,7 +61,7 @@ to launch the script across machines:
 
 The exposes several hyperparameters you can tweak through the command line.
 
-For instance, `micro_batch_size` should be adjusted so the process will use the available
+For instance, `--train_args.micro_batch_size` should be adjusted so the process will use the available
 GPU memory. For more tips to avoid out-of-memory issues, please also see the more detailed
 [Dealing with out-of-memory (OOM) errors](oom.md) guide.
 
@@ -83,6 +82,5 @@ python scripts/prepare_openwebtext.py \
   --checkpoint_dir checkpoints/EleutherAI/pythia-70m/ \
   --destination_path data/lit-openwebtext
 
-python pretrain/openwebtext.py \
-  --devices 4
+python pretrain/openwebtext.py --devices 4
 ```

--- a/tutorials/pretrain_redpajama.md
+++ b/tutorials/pretrain_redpajama.md
@@ -91,7 +91,7 @@ Running the pretraining script with its default settings requires at least 4 GPU
 ```bash
 python pretrain/redpajama.py \
   --devices 4 \
-  --train_data_dir data/lit-redpajama
+  --io_args.train_data_dir data/lit-redpajama
 ```
 
 For running on the sample dataset:
@@ -99,7 +99,7 @@ For running on the sample dataset:
 ```bash
 python pretrain/redpajama.py \
   --devices 4 \
-  --train_data_dir data/lit-redpajama-sample
+  --io_args.train_data_dir data/lit-redpajama-sample
 ```
 
 The script will save checkpoints periodically to the folder `out/`.

--- a/tutorials/pretrain_redpajama.md
+++ b/tutorials/pretrain_redpajama.md
@@ -91,7 +91,7 @@ Running the pretraining script with its default settings requires at least 4 GPU
 ```bash
 python pretrain/redpajama.py \
   --devices 4 \
-  --io_args.train_data_dir data/lit-redpajama
+  --io.train_data_dir data/lit-redpajama
 ```
 
 For running on the sample dataset:
@@ -99,7 +99,7 @@ For running on the sample dataset:
 ```bash
 python pretrain/redpajama.py \
   --devices 4 \
-  --io_args.train_data_dir data/lit-redpajama-sample
+  --io.train_data_dir data/lit-redpajama-sample
 ```
 
 The script will save checkpoints periodically to the folder `out/`.

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -132,7 +132,7 @@ to launch the script across machines:
 
 The exposes several hyperparameters you can tweak through the command line.
 
-For instance, `--train_args.micro_batch_size` should be adjusted so the process will use the available
+For instance, `--train.micro_batch_size` should be adjusted so the process will use the available
 GPU memory. For more tips to avoid out-of-memory issues, please also see the more detailed
 [Dealing with out-of-memory (OOM) errors](oom.md) guide.
 

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -132,7 +132,7 @@ to launch the script across machines:
 
 The exposes several hyperparameters you can tweak through the command line.
 
-For instance, `micro_batch_size` should be adjusted so the process will use the available
+For instance, `--train_args.micro_batch_size` should be adjusted so the process will use the available
 GPU memory. For more tips to avoid out-of-memory issues, please also see the more detailed
 [Dealing with out-of-memory (OOM) errors](oom.md) guide.
 


### PR DESCRIPTION
Example CLI output

```shell
python pretrain/tinyllama.py --help
```

```text
usage: tinyllama.py [-h] [--config CONFIG] [--print_config[=flags]] [--model_name MODEL_NAME] [--name NAME] [--logger_name {wandb,tensorboard,csv}] [--resume RESUME] [--devices DEVICES] [--io CONFIG]
                    [--io.train_data_dir TRAIN_DATA_DIR] [--io.val_data_dir VAL_DATA_DIR] [--io.checkpoint_dir CHECKPOINT_DIR] [--io.out_dir OUT_DIR] [--train CONFIG] [--train.save_interval SAVE_INTERVAL]
                    [--train.log_interval LOG_INTERVAL] [--train.global_batch_size GLOBAL_BATCH_SIZE] [--train.micro_batch_size MICRO_BATCH_SIZE] [--train.lr_warmup_steps LR_WARMUP_STEPS] [--train.epochs EPOCHS]
                    [--train.epoch_size EPOCH_SIZE] [--train.max_tokens MAX_TOKENS] [--train.max_seq_length MAX_SEQ_LENGTH] [--train.learning_rate LEARNING_RATE] [--train.weight_decay WEIGHT_DECAY] [--train.beta1 BETA1]
                    [--train.beta2 BETA2] [--train.max_norm MAX_NORM] [--train.min_lr MIN_LR] [--eval CONFIG] [--eval.interval INTERVAL] [--eval.max_new_tokens MAX_NEW_TOKENS] [--eval.max_iters MAX_ITERS]

<function setup at 0x7f3bdbfe9090>

options:
  -h, --help            Show this help message and exit.
  --config CONFIG       Path to a configuration file.
  --print_config[=flags]
                        Print the configuration after applying all other arguments and exit. The optional flags customizes the output and are one or more keywords separated by comma. The supported flags are: comments, skip_default,
                        skip_null.
  --model_name MODEL_NAME
                        (type: str, default: tiny-llama-1.1b)
  --name NAME           (type: str, default: lit-tiny-llama-1.1b)
  --logger_name {wandb,tensorboard,csv}
                        (type: Literal['wandb', 'tensorboard', 'csv'], default: tensorboard)
  --resume RESUME       (type: Union[bool, Path], default: False)
  --devices DEVICES     (type: int, default: 1)

Inputs and outputs related arguments:
  --io CONFIG           Path to a configuration file.
  --io.train_data_dir TRAIN_DATA_DIR
                        Where to read training data from (type: Optional[Path], default: null)
  --io.val_data_dir VAL_DATA_DIR
                        Where to read validation data from (type: Optional[Path], default: null)
  --io.checkpoint_dir CHECKPOINT_DIR
                        Where to read weights and tokenizer data from (type: Optional[Path], default: null)
  --io.out_dir OUT_DIR  Where to save artifacts (type: <class 'Path'>, default: out/lit-tiny-llama-1.1b)

Training related arguments:
  --train CONFIG        Path to a configuration file.
  --train.save_interval SAVE_INTERVAL
                        Number of optimizer steps between checkpoints (type: int, default: 1000)
  --train.log_interval LOG_INTERVAL
                        Number of iterations between logging calls (type: int, default: 1)
  --train.global_batch_size GLOBAL_BATCH_SIZE
                        Number of samples between optimizer steps across data-parallel ranks (type: int, default: 512)
  --train.micro_batch_size MICRO_BATCH_SIZE
                        Number of samples per data-parallel rank (type: int, default: 4)
  --train.lr_warmup_steps LR_WARMUP_STEPS
                        Number of iterations with learning rate warmup active (type: int, default: 2000)
  --train.epochs EPOCHS
                        Number of epochs to run (type: Optional[int], default: null)
  --train.epoch_size EPOCH_SIZE
                        Size of the epoch (type: Optional[int], default: null)
  --train.max_tokens MAX_TOKENS
                        Total number of tokens to train on (type: Optional[int], default: 3000000000000)
  --train.max_seq_length MAX_SEQ_LENGTH
                        Limits the length of samples. Off by default (type: Optional[int], default: null)
  --train.learning_rate LEARNING_RATE
                        (type: float, default: 0.1)
  --train.weight_decay WEIGHT_DECAY
                        (type: float, default: 0.0004)
  --train.beta1 BETA1   (type: float, default: 0.9)
  --train.beta2 BETA2   (type: float, default: 0.95)
  --train.max_norm MAX_NORM
                        (type: Optional[float], default: 1.0)
  --train.min_lr MIN_LR
                        (type: float, default: 4e-05)

Evaluation related arguments:
  --eval CONFIG         Path to a configuration file.
  --eval.interval INTERVAL
                        Number of optimizer steps between evaluation calls (type: int, default: 1000)
  --eval.max_new_tokens MAX_NEW_TOKENS
                        Number of tokens to generate (type: Optional[int], default: null)
  --eval.max_iters MAX_ITERS
                        Number of iterations (type: int, default: 100)
```

```shell
python pretrain/tinyllama.py --print_config=comments
```

```yaml
# <function setup at 0x7fa9091e9090>

#   (type: str, default: tiny-llama-1.1b)
model_name: tiny-llama-1.1b

#   (type: str, default: lit-tiny-llama-1.1b)
name: lit-tiny-llama-1.1b

#   (type: Literal['wandb', 'tensorboard', 'csv'], default: tensorboard)
logger_name: tensorboard

#   (type: Union[bool, Path], default: False)
resume: false

#   (type: int, default: 1)
devices: 1

# Inputs and outputs related arguments
io:

  # Where to read training data from (type: Optional[Path], default: null)
  train_data_dir:

  # Where to read validation data from (type: Optional[Path], default: null)
  val_data_dir:

  # Where to read weights and tokenizer data from (type: Optional[Path], default: null)
  checkpoint_dir:

  # Where to save artifacts (type: <class 'Path'>, default: out/lit-tiny-llama-1.1b)
  out_dir: out/lit-tiny-llama-1.1b

# Training related arguments
train:

  # Number of optimizer steps between checkpoints (type: int, default: 1000)
  save_interval: 1000

  # Number of iterations between logging calls (type: int, default: 1)
  log_interval: 1

  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 512)
  global_batch_size: 512

  # Number of samples per data-parallel rank (type: int, default: 4)
  micro_batch_size: 4

  # Number of iterations with learning rate warmup active (type: int, default: 2000)
  lr_warmup_steps: 2000

  # Number of epochs to run (type: Optional[int], default: null)
  epochs:

  # Size of the epoch (type: Optional[int], default: null)
  epoch_size:

  # Total number of tokens to train on (type: Optional[int], default: 3000000000000)
  max_tokens: 3000000000000

  # Limits the length of samples. Off by default (type: Optional[int], default: null)
  max_seq_length:

  #   (type: float, default: 0.1)
  learning_rate: 0.1

  #   (type: float, default: 0.0004)
  weight_decay: 0.0004

  #   (type: float, default: 0.9)
  beta1: 0.9

  #   (type: float, default: 0.95)
  beta2: 0.95

  #   (type: Optional[float], default: 1.0)
  max_norm: 1.0

  #   (type: float, default: 4e-05)
  min_lr: 4.0e-05

# Evaluation related arguments
eval:

  # Number of optimizer steps between evaluation calls (type: int, default: 1000)
  interval: 1000

  # Number of tokens to generate (type: Optional[int], default: null)
  max_new_tokens:

  # Number of iterations (type: int, default: 100)
  max_iters: 100
```

`# <function setup at 0x7f773cfe9090>` is because we don't define docstring for `setup()` in each script.