### PR TITLE
Remove bitsandbytes xfails

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -138,8 +138,6 @@ def test_adapter_compile():
 
 
 @RunIf(min_cuda_gpus=1)
-# platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
-@pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -228,8 +228,6 @@ def test_against_hf_mixtral():
 
 
 @RunIf(min_cuda_gpus=1)
-# platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
-@pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -397,8 +397,6 @@ def test_lora_qkv_linear_weights_merged_status(rank, enable_lora, expected_merge
 
 
 @RunIf(min_cuda_gpus=1)
-# platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
-@pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_lora_merge_with_bitsandbytes():
     from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 
@@ -588,8 +586,6 @@ def test_against_hf_mixtral():
 
 
 @RunIf(min_cuda_gpus=1)
-# platform dependent cuda issue: libbitsandbytes_cpu.so: undefined symbol: cquantize_blockwise_fp16_nf4
-@pytest.mark.xfail(raises=AttributeError, strict=False)
 def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir):
     from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision
 


### PR DESCRIPTION
These xfails were added because `bitsandbytes` can be installed on devices that don't support these kernels (aka my laptop), but I'm afraid this might silently introduce issues into our CI