### PR TITLE
Refactor Data - Args Improvements

### DIFF
--- a/config_hub/pretrain/debug.yaml
+++ b/config_hub/pretrain/debug.yaml
@@ -30,9 +30,7 @@ resume: false
 devices: auto
 seed: 42
 data: OpenWebText
-io:
-  checkpoint_dir: null
-  out_dir: out/debug
+out_dir: out/pretrain/debug
 train:
   save_interval: 1000
   log_interval: 1

--- a/config_hub/pretrain/tinyllama.yaml
+++ b/config_hub/pretrain/tinyllama.yaml
@@ -28,9 +28,7 @@ resume: false
 devices: auto
 seed: 42
 data: TinyLlama
-io:
-  checkpoint_dir: null
-  out_dir: out/lit-tiny-llama-1.1b
+out_dir: out/pretrain/tiny-llama
 train:
   save_interval: 1000
   log_interval: 1

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -20,7 +20,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
-from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import Alpaca, LitDataModule, apply_prompt_template
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
@@ -41,10 +41,8 @@ def setup(
     devices: Union[int, str] = 1,
     seed: int = 1337,
     data: Optional[LitDataModule] = None,
-    io: IOArgs = IOArgs(
-        checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-        out_dir=Path("out/adapter"),
-    ),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    out_dir: Path = Path("out/finetune/adapter"),
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -88,17 +86,17 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, seed, Config.from_name(name=io.checkpoint_dir.name), data, io, train, eval)
+    fabric.launch(main, devices, seed, Config.from_name(name=checkpoint_dir.name), data, checkpoint_dir, out_dir, train, eval)
 
 
-def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDataModule, io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
-    validate_args(io, train, eval)
+def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDataModule, checkpoint_dir: Path, out_dir: Path, train: TrainArgs, eval: EvalArgs) -> None:
+    validate_args(train, eval)
 
-    check_valid_checkpoint_dir(io.checkpoint_dir)
+    check_valid_checkpoint_dir(checkpoint_dir)
 
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     train_dataloader, val_dataloader = get_dataloaders(fabric, data, tokenizer, train)
     steps_per_epoch = len(train_dataloader) // train.gradient_accumulation_iters(devices)
     lr_max_steps = min(train.epochs * steps_per_epoch, (train.max_steps or float("inf")))
@@ -106,9 +104,9 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io.out_dir, exist_ok=True)
+        os.makedirs(out_dir, exist_ok=True)
 
-    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -136,13 +134,13 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     load_checkpoint(fabric, model, checkpoint_path, strict=False)
 
     train_time = time.perf_counter()
-    fit(fabric, model, optimizer, scheduler, train_dataloader, val_dataloader, devices, io, train, eval)
+    fit(fabric, model, optimizer, scheduler, train_dataloader, val_dataloader, devices, checkpoint_dir, out_dir, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    save_path = io.out_dir / "lit_model_adapter_finetuned.pth"
+    save_path = out_dir / "lit_model_adapter_finetuned.pth"
     save_adapter_checkpoint(fabric, model, save_path)
 
 
@@ -154,11 +152,12 @@ def fit(
     train_dataloader: DataLoader,
     val_dataloader: DataLoader,
     devices: int,
-    io: IOArgs,
+    checkpoint_dir: Path,
+    out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
 ) -> None:
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
@@ -217,7 +216,7 @@ def fit(
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
         if not is_accumulating and step_count % train.save_interval == 0:
-            checkpoint_path = io.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
+            checkpoint_path = out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_adapter_checkpoint(fabric, model, checkpoint_path)
 
 
@@ -288,7 +287,7 @@ def save_adapter_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_path:
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
-def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+def validate_args(train: TrainArgs, eval: EvalArgs) -> None:
     issues = []
     unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
@@ -296,7 +295,6 @@ def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
             if getattr(args, name) is not None:
                 issues.append(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io, ["checkpoint_dir"]),
         (train, ["epochs"]),
         (eval, ["max_new_tokens"]),
     ]

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -20,7 +20,7 @@ sys.path.append(str(wd))
 
 from generate.base import generate
 from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_adapter_v2_as_trainable
-from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import Alpaca, LitDataModule, apply_prompt_template
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
@@ -41,10 +41,8 @@ def setup(
     devices: Union[int, str] = 1,
     seed: int = 1337,
     data: Optional[LitDataModule] = None,
-    io: IOArgs = IOArgs(
-        checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-        out_dir=Path("out/adapter_v2"),
-    ),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    out_dir: Path = Path("out/adapter_v2"),
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -88,17 +86,17 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, seed, Config.from_name(name=io.checkpoint_dir.name), data, io, train, eval)
+    fabric.launch(main, devices, seed, Config.from_name(name=checkpoint_dir.name), data, checkpoint_dir, out_dir, train, eval)
 
 
-def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDataModule, io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
-    validate_args(io, train, eval)
+def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDataModule, checkpoint_dir: Path, out_dir: Path, train: TrainArgs, eval: EvalArgs) -> None:
+    validate_args(train, eval)
 
-    check_valid_checkpoint_dir(io.checkpoint_dir)
+    check_valid_checkpoint_dir(checkpoint_dir)
 
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     train_dataloader, val_dataloader = get_dataloaders(fabric, data, tokenizer, train)
     steps_per_epoch = len(train_dataloader) // train.gradient_accumulation_iters(devices)
     lr_max_steps = min(train.epochs * steps_per_epoch, (train.max_steps or float("inf")))
@@ -106,9 +104,9 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io.out_dir, exist_ok=True)
+        os.makedirs(out_dir, exist_ok=True)
 
-    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -136,13 +134,13 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     load_checkpoint(fabric, model, checkpoint_path, strict=False)
 
     train_time = time.perf_counter()
-    fit(fabric, model, optimizer, scheduler, train_dataloader, val_dataloader, devices, io, train, eval)
+    fit(fabric, model, optimizer, scheduler, train_dataloader, val_dataloader, devices, checkpoint_dir, out_dir, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    save_path = io.out_dir / "lit_model_adapter_finetuned.pth"
+    save_path = out_dir / "lit_model_adapter_finetuned.pth"
     save_adapter_v2_checkpoint(fabric, model, save_path)
 
 
@@ -154,11 +152,12 @@ def fit(
     train_dataloader: DataLoader,
     val_dataloader: DataLoader,
     devices: int,
-    io: IOArgs,
+    checkpoint_dir: Path,
+    out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
 ) -> None:
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
@@ -217,7 +216,7 @@ def fit(
             fabric.print(f"iter {iter_num}: val loss {val_loss.item():.4f}, val time: {t1 * 1000:.2f} ms")
             fabric.barrier()
         if not is_accumulating and step_count % train.save_interval == 0:
-            checkpoint_path = io.out_dir / f"iter-{iter_num:06d}-ckpt.pth"
+            checkpoint_path = out_dir / f"iter-{iter_num:06d}-ckpt.pth"
             save_adapter_v2_checkpoint(fabric, model, checkpoint_path)
 
 
@@ -288,7 +287,7 @@ def save_adapter_v2_checkpoint(fabric: L.Fabric, model: torch.nn.Module, file_pa
     fabric.save(file_path, {"model": model}, filter={"model": adapter_filter})
 
 
-def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+def validate_args(train: TrainArgs, eval: EvalArgs) -> None:
     issues = []
     unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
@@ -296,7 +295,6 @@ def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
             if getattr(args, name) is not None:
                 issues.append(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io, ["checkpoint_dir"]),
         (train, ["epochs"]),
         (eval, ["max_new_tokens"]),
     ]

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -20,7 +20,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.model import GPT, Block, Config
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.data import Alpaca, LitDataModule, apply_prompt_template
@@ -42,10 +42,8 @@ def setup(
     resume: Union[bool, Path] = False,
     seed: int = 1337,
     data: Optional[LitDataModule] = None,
-    io: IOArgs = IOArgs(
-        checkpoint_dir=Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
-        out_dir=Path("out/full"),
-    ),
+    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    out_dir: Path = Path("out/finetune/full"),
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -76,9 +74,9 @@ def setup(
     else:
         strategy = "auto"
 
-    logger = CSVLogger(io.out_dir.parent, io.out_dir.name, flush_logs_every_n_steps=train.log_interval)
+    logger = CSVLogger(out_dir.parent, out_dir.name, flush_logs_every_n_steps=train.log_interval)
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
-    fabric.launch(main, devices, resume, seed, Config.from_name(name=io.checkpoint_dir.name), data, io, train, eval)
+    fabric.launch(main, devices, resume, seed, Config.from_name(name=checkpoint_dir.name), data, checkpoint_dir, out_dir, train, eval)
 
 
 def main(
@@ -88,14 +86,15 @@ def main(
     seed: int,
     config: Config,
     data: LitDataModule,
-    io: IOArgs,
+    checkpoint_dir: Path,
+    out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
 ) -> None:
-    validate_args(io, train, eval)
-    check_valid_checkpoint_dir(io.checkpoint_dir)
+    validate_args(train, eval)
+    check_valid_checkpoint_dir(checkpoint_dir)
 
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     train_dataloader, val_dataloader = get_dataloaders(fabric, data, tokenizer, train)
     steps_per_epoch = len(train_dataloader) // train.gradient_accumulation_iters(devices)
     lr_max_steps = min(train.epochs * steps_per_epoch, (train.max_steps or float("inf")))
@@ -103,9 +102,9 @@ def main(
     fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
 
     if fabric.global_rank == 0:
-        os.makedirs(io.out_dir, exist_ok=True)
+        os.makedirs(out_dir, exist_ok=True)
 
-    checkpoint_path = io.checkpoint_dir / "lit_model.pth"
+    checkpoint_path = checkpoint_dir / "lit_model.pth"
     fabric.print(f"Loading model {str(checkpoint_path)!r} with {config.__dict__}")
     with fabric.init_module(empty_init=(devices > 1)):
         model = GPT(config)
@@ -121,7 +120,7 @@ def main(
     state = {"model": model, "optimizer": optimizer, "scheduler": scheduler, "iter_num": 0, "step_count": 0}
 
     if resume is True:
-        resume = max(io.out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
+        resume = max(out_dir.glob("*.pth"), key=(lambda p: int(p.name.split("-")[1])))
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)
@@ -135,7 +134,7 @@ def main(
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Save the final checkpoint at the end of training
-    fabric.save(io.out_dir / "lit_model_finetuned.pth", {"model": state["model"]})
+    fabric.save(out_dir / "lit_model_finetuned.pth", {"model": state["model"]})
 
 
 def fit(
@@ -145,14 +144,15 @@ def fit(
     val_dataloader: DataLoader,
     devices: int,
     resume: Union[bool, Path],
-    io: IOArgs,
+    checkpoint_dir: Path,
+    out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
-    tokenizer = Tokenizer(io.checkpoint_dir)
+    tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
@@ -233,7 +233,7 @@ def fit(
             fabric.log_dict(metrics, step=state["iter_num"])
             fabric.barrier()
         if not is_accumulating and state["step_count"] % train.save_interval == 0:
-            checkpoint_path = io.out_dir / f"step-{state['step_count']:06d}.pth"
+            checkpoint_path = out_dir / f"step-{state['step_count']:06d}.pth"
             fabric.print(f"Saving checkpoint to {str(checkpoint_path)!r}")
             fabric.save(checkpoint_path, state)
 
@@ -300,7 +300,7 @@ def get_longest_seq_length(data: List[Dict]) -> Tuple[int, int]:
     return longest_seq_length, longest_seq_ix
 
 
-def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
+def validate_args(train: TrainArgs, eval: EvalArgs) -> None:
     issues = []
     unsupported = [(train, ["max_tokens", "max_norm"])]
     for args, names in unsupported:
@@ -308,7 +308,6 @@ def validate_args(io: IOArgs, train: TrainArgs, eval: EvalArgs) -> None:
             if getattr(args, name) is not None:
                 issues.append(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
     required = [
-        (io, ["checkpoint_dir"]),
         (train, ["epochs"]),
         (eval, ["max_new_tokens"]),
     ]

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -128,7 +128,7 @@ def main(
         load_checkpoint(fabric, state["model"], checkpoint_path)
 
     train_time = time.perf_counter()
-    fit(fabric, state, train_dataloader, val_dataloader, devices, resume, io, train, eval)
+    fit(fabric, state, train_dataloader, val_dataloader, devices, resume, checkpoint_dir, out_dir, train, eval)
     fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
     if fabric.device.type == "cuda":
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -19,7 +19,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt.args import EvalArgs, TrainArgs, LoraArgs
+from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import LitDataModule, Alpaca, apply_prompt_template
 from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trainable
 from lit_gpt.tokenizer import Tokenizer
@@ -40,17 +40,15 @@ def setup(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: Union[int, str] = 1,
     seed: int = 1337,
-    lora: LoraArgs = LoraArgs(
-        r=8,
-        alpha=16,
-        dropout=0.05,
-        to_query=True,
-        to_key=False,
-        to_value=True,
-        to_projection=False,
-        to_mlp=False,
-        to_head=False,
-    ),
+    lora_r: int = 8,
+    lora_alpha: int = 16,
+    lora_dropout: float = 0.05,
+    lora_query: bool = True,
+    lora_key: bool = False,
+    lora_value: bool = True,
+    lora_projection: bool = False,
+    lora_mlp: bool = False,
+    lora_head: bool = False,
     data: Optional[LitDataModule] = None,
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/lora"),
@@ -104,7 +102,18 @@ def setup(
         main,
         devices,
         seed,
-        Config.from_name(name=checkpoint_dir.name, **dataclasses.asdict(lora)),
+        Config.from_name(
+            name=checkpoint_dir.name,
+            r=lora_r,
+            alpha=lora_alpha,
+            dropout=lora_dropout,
+            to_query=lora_query,
+            to_key=lora_key,
+            to_value=lora_value,
+            to_projection=lora_projection,
+            to_mlp=lora_mlp,
+            to_head=lora_head,
+        ),
         data,
         checkpoint_dir,
         out_dir,

--- a/lit_gpt/args.py
+++ b/lit_gpt/args.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional
 
 
@@ -61,10 +60,27 @@ class EvalArgs:
 
 
 @dataclass
-class IOArgs:
-    """Inputs and outputs related arguments"""
+class LoraArgs:
+    """LoRA arguments"""
+    r: int = 8
+    """LoRA rank"""
+    alpha: int = 16
+    """LoRA alpha"""
+    dropout: float = 0.05
+    """Droptout probability applied to the LoRA update"""
+    to_query: bool = True
+    """Whether to apply LoRA to the attention query matrix"""
+    to_key: bool = False
+    """Whether to apply LoRA to the attention key matrix"""
+    to_value: bool = True
+    """Whether to apply LoRA to the attention value matrix"""
+    to_projection: bool = False
+    """Whether to apply LoRA to the projection layer"""
+    to_mlp: bool = False
+    """Whether to apply LoRA to the MLPs"""
+    to_head: bool = False
+    """Whether to apply LoRA to classification head"""
 
-    checkpoint_dir: Optional[Path] = None
-    """Where to read weights and tokenizer data from"""
-    out_dir: Path = Path("out")
-    """Where to save artifacts"""
+    def __post_init__(self) -> None:
+        if not any((self.to_query, self.to_key, self.to_value, self.to_projection, self.to_mlp, self.to_head)):
+            print("Warning: all LoRA layers are disabled!")

--- a/lit_gpt/args.py
+++ b/lit_gpt/args.py
@@ -57,30 +57,3 @@ class EvalArgs:
     """Number of tokens to generate"""
     max_iters: int = 100
     """Number of iterations"""
-
-
-@dataclass
-class LoraArgs:
-    """LoRA arguments"""
-    r: int = 8
-    """LoRA rank"""
-    alpha: int = 16
-    """LoRA alpha"""
-    dropout: float = 0.05
-    """Droptout probability applied to the LoRA update"""
-    to_query: bool = True
-    """Whether to apply LoRA to the attention query matrix"""
-    to_key: bool = False
-    """Whether to apply LoRA to the attention key matrix"""
-    to_value: bool = True
-    """Whether to apply LoRA to the attention value matrix"""
-    to_projection: bool = False
-    """Whether to apply LoRA to the projection layer"""
-    to_mlp: bool = False
-    """Whether to apply LoRA to the MLPs"""
-    to_head: bool = False
-    """Whether to apply LoRA to classification head"""
-
-    def __post_init__(self) -> None:
-        if not any((self.to_query, self.to_key, self.to_value, self.to_projection, self.to_mlp, self.to_head)):
-            print("Warning: all LoRA layers are disabled!")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -170,7 +170,8 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca
             ),
             precision="16-true",
             quantize="bnb.nf4-dq",
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
         )
 
     args, kwargs = train_mock.call_args

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -53,7 +53,7 @@ def test_adapter_filter(tmp_path):
 def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     import finetune.adapter as module
     from lit_gpt.data import Alpaca
-    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+    from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.config import name_to_config
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8, adapter_start_layer=0)
@@ -75,7 +75,8 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
                 test_split_fraction=0.5,
                 num_workers=0
             ),
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
             eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -136,7 +136,6 @@ def test_adapter_compile():
 
 @RunIf(min_cuda_gpus=1)
 def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_path):
-    from lit_gpt.args import IOArgs
     from lit_gpt.config import name_to_config
     from lit_gpt.data import Alpaca
     import finetune.adapter as module

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -75,7 +75,7 @@ def test_adapter_v2_filter(tmp_path):
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     import finetune.adapter_v2 as module
-    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+    from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.data import Alpaca
     from lit_gpt.config import name_to_config
 
@@ -98,7 +98,8 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
                 test_split_fraction=0.5,
                 num_workers=0
             ),
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
             eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
@@ -224,7 +225,6 @@ def test_against_hf_mixtral():
 
 @RunIf(min_cuda_gpus=1)
 def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_path):
-    from lit_gpt.args import IOArgs
     from lit_gpt.config import name_to_config
     from lit_gpt.data import Alpaca
     import finetune.adapter_v2 as module
@@ -259,7 +259,8 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alp
             ),
             precision="16-true",
             quantize="bnb.nf4-dq",
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
         )
 
     args, kwargs = train_mock.call_args

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -12,7 +12,7 @@ import torch
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     import finetune.full as module
-    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+    from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.data import Alpaca
     from lit_gpt.config import name_to_config
 
@@ -34,7 +34,8 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
                 test_split_fraction=0.5,
                 num_workers=0
             ),
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
             eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -183,7 +183,7 @@ def test_lora_filter(tmp_path):
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     import finetune.lora as module
-    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+    from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.data import Alpaca
     from lit_gpt.config import name_to_config
 
@@ -205,7 +205,8 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
                 test_split_fraction=0.5,
                 num_workers=0
             ),
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
             eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
@@ -582,7 +583,6 @@ def test_against_hf_mixtral():
 
 @RunIf(min_cuda_gpus=1)
 def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_path):
-    from lit_gpt.args import IOArgs
     from lit_gpt.config import name_to_config
     from lit_gpt.data import Alpaca
     import finetune.lora as module
@@ -626,7 +626,8 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
                 test_split_fraction=0.5,
                 num_workers=0,
             ),
-            io=IOArgs(checkpoint_dir=fake_checkpoint_dir, out_dir=tmp_path),
+            checkpoint_dir=fake_checkpoint_dir,
+            out_dir=tmp_path,
             precision="16-true",
             quantize="bnb.nf4-dq",
         )

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -16,7 +16,7 @@ from torch.utils.data import DataLoader
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
 def test_pretrain_tiny_llama(tmp_path, monkeypatch):
     import pretrain.pretrain as module
-    from lit_gpt.args import EvalArgs, IOArgs, TrainArgs
+    from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.config import Config
 
     model_config = Config(block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
@@ -30,7 +30,7 @@ def test_pretrain_tiny_llama(tmp_path, monkeypatch):
         module.setup(
             devices=2,
             model=model_config,
-            io=IOArgs(out_dir=tmp_path),
+            out_dir=tmp_path,
             train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1, max_norm=1.0),
             eval=EvalArgs(interval=1, max_iters=1),
         )

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -93,8 +93,8 @@ python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/$repo_id
 export finetuned_dir=out/lit-finetuned-model
 
 python finetune/lora.py \
-   --io.checkpoint_dir checkpoints/$repo_id \
-   --io.out_dir $finetuned_dir \
+   --checkpoint_dir checkpoints/$repo_id \
+   --out_dir $finetuned_dir \
    --train.epochs 1 \
    --data Alpaca
 ```

--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -24,7 +24,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ```bash
 python finetune/adapter.py \
   --data Alpaca \
-  --io.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+  --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 or for Adapter V2
@@ -32,7 +32,7 @@ or for Adapter V2
 ```bash
 python finetune/adapter_v2.py \
   --data Alpaca \
-  --io.checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+  --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 The finetuning requires at least one GPU with ~12 GB memory.
@@ -51,7 +51,7 @@ This script will save checkpoints periodically to the `out_dir` directory. If yo
 ```bash
 python finetune/adapter.py \
   --data Alpaca \
-  --io.out_dir out/adapter/my-model-finetuned
+  --out_dir out/adapter/my-model-finetuned
 ```
 
 or for Adapter V2
@@ -59,7 +59,7 @@ or for Adapter V2
 ```bash
 python finetune/adapter_v2.py \
   --data Alpaca \
-  --io.out_dir out/adapter_v2/my-model-finetuned
+  --out_dir out/adapter_v2/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
@@ -68,7 +68,7 @@ For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 ```bash
 python finetune/adapter.py \
   --data Alpaca \
-  --io.out_dir out/adapter/my-model-finetuned \
+  --out_dir out/adapter/my-model-finetuned \
   --precision 32-true
 ```
 
@@ -141,6 +141,6 @@ You can easily train on your own instruction dataset saved in JSON format.
     python finetune/adapter.py \
         --data JSON \
         --data.json_path data/mydata.json \
-        --io.checkpoint_dir checkpoints/tiiuae/falcon-7b \
-        --io.out_dir data/mydata-finetuned
+        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
+        --out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -18,7 +18,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ```bash
 python finetune/full.py \
   --data Alpaca \
-  --io.checkpoint_dir checkpoints/tiiuae/falcon-7b
+  --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 Finetuning the falcon-7b model requires at least 8 GPUs with ~40 GB memory each.
@@ -31,7 +31,7 @@ This script will save checkpoints periodically to the `out_dir` directory. If yo
 ```bash
 python finetune/full.py \
   --data Alpaca \
-  --io.out_dir out/full/my-model-finetuned
+  --out_dir out/full/my-model-finetuned
 ```
 
 If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` argument.
@@ -40,7 +40,7 @@ For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 ```bash
 python finetune/full.py \
   --data Alpaca \
-  --io.out_dir out/full/my-model-finetuned \
+  --out_dir out/full/my-model-finetuned \
   --precision 32-true
 ```
 
@@ -90,6 +90,6 @@ You can easily train on your own instruction dataset saved in JSON format.
     python finetune/full.py \
         --data JSON \
         --data.json_path data/mydata.json \
-        --io.checkpoint_dir checkpoints/tiiuae/falcon-7b \
-        --io.out_dir data/mydata-finetuned
+        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
+        --out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -117,8 +117,8 @@ You can easily train on your own instruction dataset saved in JSON format.
     python finetune/lora.py \
         --data JSON \
         --data.json_path data/mydata.json \
-        --io.checkpoint_dir checkpoints/tiiuae/falcon-7b \
-        --io.out_dir data/mydata-finetuned
+        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
+        --out_dir data/mydata-finetuned
     ```
 
 
@@ -135,9 +135,9 @@ Let's assume we finetuned a model using LoRA as follows:
 
 ```bash
 python finetune/lora.py \
-  --io.checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
-  --io.train_data_dir data/mydata --io.val_data_dir data/mydata/ \
-  --io.out_dir "out/lora_weights/stablelm-base-alpha-3b/"
+  --checkpoint_dir "checkpoints/stabilityai/stablelm-base-alpha-3b/" \
+  --train_data_dir data/mydata --val_data_dir data/mydata/ \
+  --out_dir "out/lora_weights/stablelm-base-alpha-3b/"
 ```
 
 Then, we can merge the LoRA weights with the checkpoint model using the `merge_lora.py` script as shown below:

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -45,7 +45,7 @@ The original [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html) dataset 
 ```bash
 python finetune/lora.py \
   --data Alpaca \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 #### Truncating datasets
@@ -59,7 +59,7 @@ In this case, a cut-off of 256 may be a reasonable choice:
 ```bash
 python finetune/lora.py \
   --data Alpaca \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -78,7 +78,7 @@ python finetune/lora.py \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
   --data.file_name "alpaca_libre_data_cleaned_archive.json" \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 The Alpaca Libre dataset distribution is shown below.
@@ -92,7 +92,7 @@ python finetune/lora.py \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
   --data.file_name "alpaca_libre_data_cleaned_archive.json" \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -107,7 +107,7 @@ The usage is similar to the Alpaca dataset described above. Using Falcon 7b as a
 ```bash
 python finetune/lora.py \
   --data Dolly \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
 ```
 
 The Dolly dataset distribution is shown below.
@@ -119,7 +119,7 @@ You may want to consider truncating the dataset (see the *Truncating datasets* d
 ```bash
 python finetune/lora.py \
   --data Dolly \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -160,7 +160,7 @@ You may want to consider truncating the dataset (see the *Truncating datasets* d
 ```bash
 python finetune/lora.py \
   --data LongForm \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 1500
 ```
 
@@ -177,7 +177,7 @@ export HF_TOKEN="insert_your_huggingface_token_here"
 
 python finetune/lora.py \
   --data LIMA \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 LIMA contains a handful of multiturn conversations. By default, only the first instruction-response pairs from
@@ -193,7 +193,7 @@ You may want to consider truncating the dataset (see the *Truncating datasets* d
 ```bash
 python finetune/lora.py \
   --data LIMA \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 512
 ```
 
@@ -209,7 +209,7 @@ By default, all subsets (1,386,050 samples) and validations sets (367,190 subset
 ```bash
 python finetune/lora.py \
   --data FLAN \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 However, you can also select individual subsets via comma-separated strings as follows:
@@ -219,7 +219,7 @@ However, you can also select individual subsets via comma-separated strings as f
 python finetune/lora.py \
   --data FLAN \
   --data.subsets "aeslc_10templates,ag_news_subset_10templates,anli_r1_10templates" \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 You can find a list of all 66 supported subsets [here](https://huggingface.co/datasets/Muennighoff/flan).
@@ -273,7 +273,7 @@ Then simply run any of the finetuning scripts with this input:
 python finetune/lora.py \
   --data JSON \
   --data.json_path path/to/your/data.json \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 You can also customize how the dataset is read by using these additional parameters
@@ -296,7 +296,7 @@ python finetune/lora.py \
   --data.seed 42 \
   --data.mask_inputs False \
   --data.ignore_index -1 \
-  --io.checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 
 &nbsp;


### PR DESCRIPTION
A couple of improvements to args in scripts:

Removed IOArgs. Was originally used to group data args, but they have moved out. Checkpoint dir is not used by all scripts, and out dir requires to be defined dynamically for some scripts.


Alternatively, `out_dir` could also be defined under TrainArgs.