### PR TITLE
Avoid underscores for config args

### DIFF
--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -28,7 +28,7 @@ from lit_gpt.utils import map_old_state_dict_weights
 class Config(BaseConfig):
     @property
     def mlp_class(self) -> Type:
-        return getattr(lit_gpt.adapter_v2, self._mlp_class)
+        return getattr(lit_gpt.adapter_v2, self.mlp_class_str)
 
 
 def adapter_filter(key: str, value: Any) -> bool:

--- a/lit_gpt/adapter_v2.py
+++ b/lit_gpt/adapter_v2.py
@@ -28,7 +28,7 @@ from lit_gpt.utils import map_old_state_dict_weights
 class Config(BaseConfig):
     @property
     def mlp_class(self) -> Type:
-        return getattr(lit_gpt.adapter_v2, self.mlp_class_str)
+        return getattr(lit_gpt.adapter_v2, self.mlp_class_name)
 
 
 def adapter_filter(key: str, value: Any) -> bool:

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -52,9 +52,9 @@ class Config:
     # credit https://arxiv.org/pdf/2305.13245.pdf
     n_query_groups: Optional[int] = None
     shared_attention_norm: bool = False
-    norm_class_str: Literal["LayerNorm", "RMSNorm"] = "LayerNorm"
+    norm_class_name: Literal["LayerNorm", "RMSNorm"] = "LayerNorm"
     norm_eps: float = 1e-5
-    mlp_class_str: Literal["GptNeoxMLP", "LLaMAMLP", "GemmaMLP", "LLaMAMoE"] = "GptNeoxMLP"
+    mlp_class_name: Literal["GptNeoxMLP", "LLaMAMLP", "GemmaMLP", "LLaMAMoE"] = "GptNeoxMLP"
     gelu_approximate: str = "none"
     intermediate_size: Optional[int] = None
     rope_condense_ratio: int = 1
@@ -85,7 +85,7 @@ class Config:
 
         # compute the intermediate size for MLP if not set
         if self.intermediate_size is None:
-            if self.mlp_class_str == "LLaMAMLP":
+            if self.mlp_class_name == "LLaMAMLP":
                 raise ValueError("The config needs to set the `intermediate_size`")
             self.intermediate_size = 4 * self.n_embd
 
@@ -124,19 +124,19 @@ class Config:
 
     @property
     def mlp_class(self) -> Type:
-        # `self.mlp_class_str` cannot be the type to keep the config json serializable
-        return getattr(lit_gpt.model, self.mlp_class_str)
+        # `self.mlp_class_name` cannot be the type to keep the config json serializable
+        return getattr(lit_gpt.model, self.mlp_class_name)
 
     @property
     def norm_class(self) -> Type:
-        # `self.norm_class_str` cannot be the type to keep the config json serializable
-        if self.norm_class_str == "RMSNorm":
+        # `self.norm_class_name` cannot be the type to keep the config json serializable
+        if self.norm_class_name == "RMSNorm":
             from functools import partial
 
             from lit_gpt.rmsnorm import RMSNorm
 
             return partial(RMSNorm, add_unit_offset="Gemma" in self.name)
-        return getattr(torch.nn, self.norm_class_str)
+        return getattr(torch.nn, self.norm_class_name)
 
 
 ########################
@@ -173,7 +173,7 @@ configs = [
         n_embd=2560,
         parallel_residual=False,
         bias=False,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=6912,
     ),
 ]
@@ -448,9 +448,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=8640,
     ),
     # https://huggingface.co/openlm-research/open_llama_7b/blob/main/config.json
@@ -464,9 +464,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/openlm-research/open_llama_13b/blob/main/config.json
@@ -482,9 +482,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
 ]
@@ -506,9 +506,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/lmsys/vicuna-13b-v1.3/blob/main/config.json
@@ -524,9 +524,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/lmsys/vicuna-33b-v1.3/blob/main/config.json
@@ -542,9 +542,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=17920,
     ),
     # https://huggingface.co/lmsys/vicuna-7b-v1.5/blob/main/config.json
@@ -557,8 +557,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/lmsys/vicuna-7b-v1.5-16k/blob/main/config.json
@@ -572,8 +572,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=4,
     ),
@@ -589,8 +589,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/lmsys/vicuna-13b-v1.5-16k/blob/main/config.json
@@ -606,8 +606,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
         rope_condense_ratio=4,
     ),
@@ -630,9 +630,9 @@ long_chat = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=8,
     ),
@@ -649,9 +649,9 @@ long_chat = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
         rope_condense_ratio=8,
     ),
@@ -672,9 +672,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/NousResearch/Nous-Hermes-13B/blob/main/config.json
@@ -690,9 +690,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-6,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/NousResearch/Nous-Hermes-Llama2-13b
@@ -707,9 +707,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
 ]
@@ -730,8 +730,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/meta-llama/Llama-2-13b-hf/blob/main/config.json
@@ -746,8 +746,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/meta-llama/Llama-2-70b-hf/blob/main/config.json
@@ -763,8 +763,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
     ),
 ]
@@ -794,8 +794,8 @@ gemma = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="GemmaMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="GemmaMLP",
         intermediate_size=16384,
     ),
     # https://huggingface.co/google/gemma-7b/blob/main/config.json
@@ -812,8 +812,8 @@ gemma = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="GemmaMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="GemmaMLP",
         intermediate_size=24576,
     ),
 ]
@@ -842,8 +842,8 @@ freewilly_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
     )
 ]
@@ -865,9 +865,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -884,9 +884,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -904,9 +904,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -924,9 +924,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -941,9 +941,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -960,9 +960,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -980,9 +980,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -1000,9 +1000,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -1017,9 +1017,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -1036,9 +1036,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -1056,9 +1056,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -1076,9 +1076,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -1102,9 +1102,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-06,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=17920,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-7B/blob/main/config.json
@@ -1116,9 +1116,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-13B/blob/main/config.json
@@ -1132,9 +1132,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-70B/blob/main/config.json
@@ -1148,8 +1148,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
     ),
     # https://huggingface.co/garage-bAInd/Camel-Platypus2-13B/blob/main/config.json
@@ -1163,8 +1163,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Camel-Platypus2-70B/blob/main/config.json
@@ -1179,8 +1179,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
     ),
     # https://huggingface.co/garage-bAInd/Stable-Platypus2-13B/blob/main/config.json
@@ -1194,8 +1194,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-70B-instruct/blob/main/config.json
@@ -1210,8 +1210,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=28672,
     ),
 ]
@@ -1265,8 +1265,8 @@ together_llama2_32k = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=8,
     )
@@ -1325,9 +1325,9 @@ mistral = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=14336,
     ),
     # https://huggingface.co/mistralai/Mixtral-8x7B-v0.1/blob/main/config.json
@@ -1341,9 +1341,9 @@ mistral = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMoE",
+        mlp_class_name="LLaMAMoE",
         intermediate_size=14336,
         rope_base=1000000,
         n_expert=8,
@@ -1368,9 +1368,9 @@ configs.append(
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
+        norm_class_name="RMSNorm",
         norm_eps=1e-05,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=14336,
     )
 )
@@ -1392,9 +1392,9 @@ tiny_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",  # original TinyLlama uses FusedRMSNorm
+        norm_class_name="RMSNorm",  # original TinyLlama uses FusedRMSNorm
         norm_eps=1e-5,
-        mlp_class_str="LLaMAMLP",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=5632,
         n_query_groups=4,
     )
@@ -1420,8 +1420,8 @@ llama_2_function_calling = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_str="RMSNorm",
-        mlp_class_str="LLaMAMLP",
+        norm_class_name="RMSNorm",
+        mlp_class_name="LLaMAMLP",
         intermediate_size=11008,
         norm_eps=1e-6,
         block_size=4096,

--- a/lit_gpt/config.py
+++ b/lit_gpt/config.py
@@ -52,9 +52,9 @@ class Config:
     # credit https://arxiv.org/pdf/2305.13245.pdf
     n_query_groups: Optional[int] = None
     shared_attention_norm: bool = False
-    _norm_class: Literal["LayerNorm", "RMSNorm"] = "LayerNorm"
+    norm_class_str: Literal["LayerNorm", "RMSNorm"] = "LayerNorm"
     norm_eps: float = 1e-5
-    _mlp_class: Literal["GptNeoxMLP", "LLaMAMLP", "GemmaMLP", "LLaMAMoE"] = "GptNeoxMLP"
+    mlp_class_str: Literal["GptNeoxMLP", "LLaMAMLP", "GemmaMLP", "LLaMAMoE"] = "GptNeoxMLP"
     gelu_approximate: str = "none"
     intermediate_size: Optional[int] = None
     rope_condense_ratio: int = 1
@@ -85,7 +85,7 @@ class Config:
 
         # compute the intermediate size for MLP if not set
         if self.intermediate_size is None:
-            if self._mlp_class == "LLaMAMLP":
+            if self.mlp_class_str == "LLaMAMLP":
                 raise ValueError("The config needs to set the `intermediate_size`")
             self.intermediate_size = 4 * self.n_embd
 
@@ -103,8 +103,6 @@ class Config:
             conf_dict = name_to_config[name]
 
         conf_dict = conf_dict.copy()
-        if "condense_ratio" in kwargs:  # legacy name
-            kwargs["rope_condense_ratio"] = kwargs.pop("condense_ratio")
         conf_dict.update(kwargs)
         return cls(**conf_dict)
 
@@ -112,14 +110,6 @@ class Config:
     def from_json(cls, path: Union[str, Path], **kwargs: Any) -> Self:
         with open(path, encoding="utf-8") as fp:
             json_kwargs = json.load(fp)
-        if "condense_ratio" in json_kwargs:  # legacy name
-            json_kwargs["rope_condense_ratio"] = json_kwargs.pop("condense_ratio")
-        if "condense_ratio" in kwargs:  # legacy name
-            kwargs["rope_condense_ratio"] = kwargs.pop("condense_ratio")
-        if "org" in json_kwargs:  # legacy name
-            json_kwargs["hf_config"] = {"name": json_kwargs["name"], "org": json_kwargs.pop("org")}
-        if "org" in kwargs:  # legacy name
-            kwargs["hf_config"] = {"name": kwargs.get("name", json_kwargs["name"]), "org": kwargs.pop("org")}
         json_kwargs.update(kwargs)
         return cls(**json_kwargs)
 
@@ -134,19 +124,19 @@ class Config:
 
     @property
     def mlp_class(self) -> Type:
-        # `self._mlp_class` cannot be the type to keep the config json serializable
-        return getattr(lit_gpt.model, self._mlp_class)
+        # `self.mlp_class_str` cannot be the type to keep the config json serializable
+        return getattr(lit_gpt.model, self.mlp_class_str)
 
     @property
     def norm_class(self) -> Type:
-        # `self._norm_class` cannot be the type to keep the config json serializable
-        if self._norm_class == "RMSNorm":
+        # `self.norm_class_str` cannot be the type to keep the config json serializable
+        if self.norm_class_str == "RMSNorm":
             from functools import partial
 
             from lit_gpt.rmsnorm import RMSNorm
 
             return partial(RMSNorm, add_unit_offset="Gemma" in self.name)
-        return getattr(torch.nn, self._norm_class)
+        return getattr(torch.nn, self.norm_class_str)
 
 
 ########################
@@ -183,7 +173,7 @@ configs = [
         n_embd=2560,
         parallel_residual=False,
         bias=False,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=6912,
     ),
 ]
@@ -458,9 +448,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=8640,
     ),
     # https://huggingface.co/openlm-research/open_llama_7b/blob/main/config.json
@@ -474,9 +464,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/openlm-research/open_llama_13b/blob/main/config.json
@@ -492,9 +482,9 @@ open_LLaMA = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
 ]
@@ -516,9 +506,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/lmsys/vicuna-13b-v1.3/blob/main/config.json
@@ -534,9 +524,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/lmsys/vicuna-33b-v1.3/blob/main/config.json
@@ -552,9 +542,9 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=17920,
     ),
     # https://huggingface.co/lmsys/vicuna-7b-v1.5/blob/main/config.json
@@ -567,8 +557,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/lmsys/vicuna-7b-v1.5-16k/blob/main/config.json
@@ -582,8 +572,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=4,
     ),
@@ -599,8 +589,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/lmsys/vicuna-13b-v1.5-16k/blob/main/config.json
@@ -616,8 +606,8 @@ vicuna = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
         rope_condense_ratio=4,
     ),
@@ -640,9 +630,9 @@ long_chat = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=8,
     ),
@@ -659,9 +649,9 @@ long_chat = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
         rope_condense_ratio=8,
     ),
@@ -682,9 +672,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/NousResearch/Nous-Hermes-13B/blob/main/config.json
@@ -700,9 +690,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-6,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/NousResearch/Nous-Hermes-Llama2-13b
@@ -717,9 +707,9 @@ nous_research = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
 ]
@@ -740,8 +730,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/meta-llama/Llama-2-13b-hf/blob/main/config.json
@@ -756,8 +746,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/meta-llama/Llama-2-70b-hf/blob/main/config.json
@@ -773,8 +763,8 @@ llama_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
     ),
 ]
@@ -804,8 +794,8 @@ gemma = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="GemmaMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="GemmaMLP",
         intermediate_size=16384,
     ),
     # https://huggingface.co/google/gemma-7b/blob/main/config.json
@@ -822,8 +812,8 @@ gemma = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="GemmaMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="GemmaMLP",
         intermediate_size=24576,
     ),
 ]
@@ -852,8 +842,8 @@ freewilly_2 = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
     )
 ]
@@ -875,9 +865,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -894,9 +884,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -914,9 +904,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -934,9 +924,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -951,9 +941,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -970,9 +960,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -990,9 +980,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -1010,9 +1000,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -1027,9 +1017,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_base=1000000,
     ),
@@ -1046,9 +1036,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
         rope_base=1000000,
     ),
@@ -1066,9 +1056,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=22016,
         rope_base=1000000,
     ),
@@ -1086,9 +1076,9 @@ code_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
         rope_base=1000000,
     ),
@@ -1112,9 +1102,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-06,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=17920,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-7B/blob/main/config.json
@@ -1126,9 +1116,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-13B/blob/main/config.json
@@ -1142,9 +1132,9 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-70B/blob/main/config.json
@@ -1158,8 +1148,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
     ),
     # https://huggingface.co/garage-bAInd/Camel-Platypus2-13B/blob/main/config.json
@@ -1173,8 +1163,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Camel-Platypus2-70B/blob/main/config.json
@@ -1189,8 +1179,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
     ),
     # https://huggingface.co/garage-bAInd/Stable-Platypus2-13B/blob/main/config.json
@@ -1204,8 +1194,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=13824,
     ),
     # https://huggingface.co/garage-bAInd/Platypus2-70B-instruct/blob/main/config.json
@@ -1220,8 +1210,8 @@ platypus = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=28672,
     ),
 ]
@@ -1275,8 +1265,8 @@ together_llama2_32k = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         rope_condense_ratio=8,
     )
@@ -1335,9 +1325,9 @@ mistral = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=14336,
     ),
     # https://huggingface.co/mistralai/Mixtral-8x7B-v0.1/blob/main/config.json
@@ -1351,9 +1341,9 @@ mistral = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMoE",
+        mlp_class_str="LLaMAMoE",
         intermediate_size=14336,
         rope_base=1000000,
         n_expert=8,
@@ -1378,9 +1368,9 @@ configs.append(
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
+        norm_class_str="RMSNorm",
         norm_eps=1e-05,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=14336,
     )
 )
@@ -1402,9 +1392,9 @@ tiny_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",  # original TinyLlama uses FusedRMSNorm
+        norm_class_str="RMSNorm",  # original TinyLlama uses FusedRMSNorm
         norm_eps=1e-5,
-        _mlp_class="LLaMAMLP",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=5632,
         n_query_groups=4,
     )
@@ -1430,8 +1420,8 @@ llama_2_function_calling = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        _norm_class="RMSNorm",
-        _mlp_class="LLaMAMLP",
+        norm_class_str="RMSNorm",
+        mlp_class_str="LLaMAMLP",
         intermediate_size=11008,
         norm_eps=1e-6,
         block_size=4096,

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -495,7 +495,7 @@ class Config(BaseConfig):
 
     @property
     def mlp_class(self) -> Type:
-        return getattr(lit_gpt.lora, self._mlp_class)
+        return getattr(lit_gpt.lora, self.mlp_class_str)
 
 
 class GPT(BaseModel):

--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -495,7 +495,7 @@ class Config(BaseConfig):
 
     @property
     def mlp_class(self) -> Type:
-        return getattr(lit_gpt.lora, self.mlp_class_str)
+        return getattr(lit_gpt.lora, self.mlp_class_name)
 
 
 class GPT(BaseModel):

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -135,7 +135,7 @@ def copy_weights_hf_llama(
         "model.norm.bias": "transformer.ln_f.bias",
         "lm_head.weight": "lm_head.weight",
     }
-    if config._mlp_class == "LLaMAMoE":
+    if config.mlp_class_str == "LLaMAMoE":
         weight_map.update(
             {
                 "model.layers.{}.block_sparse_moe.gate.weight": "transformer.h.{l}.mlp.gate.weight",
@@ -144,7 +144,7 @@ def copy_weights_hf_llama(
                 "model.layers.{}.block_sparse_moe.experts.{}.w2.weight": "transformer.h.{l}.mlp.experts.{e}.proj.weight",
             }
         )
-    elif config._mlp_class in ("LLaMAMLP", "GemmaMLP"):
+    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP"):
         weight_map.update(
             {
                 "model.layers.{}.mlp.gate_proj.weight": "transformer.h.{l}.mlp.fc_1.weight",
@@ -311,7 +311,7 @@ def convert_hf_checkpoint(
 
     if "falcon" in model_name:
         copy_fn = partial(copy_weights_falcon, model_name)
-    elif config._mlp_class in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
+    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
         # holder to reconstitute the split q, k, v
         qkv_weights = {}
         copy_fn = partial(copy_weights_hf_llama, config, qkv_weights)

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -135,7 +135,7 @@ def copy_weights_hf_llama(
         "model.norm.bias": "transformer.ln_f.bias",
         "lm_head.weight": "lm_head.weight",
     }
-    if config.mlp_class_str == "LLaMAMoE":
+    if config.mlp_class_name == "LLaMAMoE":
         weight_map.update(
             {
                 "model.layers.{}.block_sparse_moe.gate.weight": "transformer.h.{l}.mlp.gate.weight",
@@ -144,7 +144,7 @@ def copy_weights_hf_llama(
                 "model.layers.{}.block_sparse_moe.experts.{}.w2.weight": "transformer.h.{l}.mlp.experts.{e}.proj.weight",
             }
         )
-    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP"):
+    elif config.mlp_class_name in ("LLaMAMLP", "GemmaMLP"):
         weight_map.update(
             {
                 "model.layers.{}.mlp.gate_proj.weight": "transformer.h.{l}.mlp.fc_1.weight",
@@ -311,7 +311,7 @@ def convert_hf_checkpoint(
 
     if "falcon" in model_name:
         copy_fn = partial(copy_weights_falcon, model_name)
-    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
+    elif config.mlp_class_name in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
         # holder to reconstitute the split q, k, v
         qkv_weights = {}
         copy_fn = partial(copy_weights_hf_llama, config, qkv_weights)

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -120,7 +120,7 @@ def copy_weights_llama(
         "transformer.ln_f.bias": "model.norm.bias",
         "lm_head.weight": "lm_head.weight",
     }
-    if config._mlp_class == "LLaMAMoE":
+    if config.mlp_class_str == "LLaMAMoE":
         weight_map.update(
             {
                 "transformer.h.{}.mlp.gate.weight": "model.layers.{l}.block_sparse_moe.gate.weight",
@@ -129,7 +129,7 @@ def copy_weights_llama(
                 "transformer.h.{}.mlp.experts.{}.proj.weight": "model.layers.{l}.block_sparse_moe.experts.{e}.w2.weight",
             }
         )
-    elif config._mlp_class in ("LLaMAMLP", "GemmaMLP"):
+    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP"):
         weight_map.update(
             {
                 "transformer.h.{}.mlp.fc_1.weight": "model.layers.{l}.mlp.gate_proj.weight",
@@ -249,7 +249,7 @@ def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path
 
     if "falcon" in config.name:
         copy_fn = partial(copy_weights_falcon, config.name)
-    elif config._mlp_class in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
+    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
         untie_weights = "Gemma" in config.name
         copy_fn = partial(copy_weights_llama, config, untie_weights=untie_weights)
     elif "phi" in config.name:

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -120,7 +120,7 @@ def copy_weights_llama(
         "transformer.ln_f.bias": "model.norm.bias",
         "lm_head.weight": "lm_head.weight",
     }
-    if config.mlp_class_str == "LLaMAMoE":
+    if config.mlp_class_name == "LLaMAMoE":
         weight_map.update(
             {
                 "transformer.h.{}.mlp.gate.weight": "model.layers.{l}.block_sparse_moe.gate.weight",
@@ -129,7 +129,7 @@ def copy_weights_llama(
                 "transformer.h.{}.mlp.experts.{}.proj.weight": "model.layers.{l}.block_sparse_moe.experts.{e}.w2.weight",
             }
         )
-    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP"):
+    elif config.mlp_class_name in ("LLaMAMLP", "GemmaMLP"):
         weight_map.update(
             {
                 "transformer.h.{}.mlp.fc_1.weight": "model.layers.{l}.mlp.gate_proj.weight",
@@ -249,7 +249,7 @@ def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path
 
     if "falcon" in config.name:
         copy_fn = partial(copy_weights_falcon, config.name)
-    elif config.mlp_class_str in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
+    elif config.mlp_class_name in ("LLaMAMLP", "GemmaMLP", "LLaMAMoE"):
         untie_weights = "Gemma" in config.name
         copy_fn = partial(copy_weights_llama, config, untie_weights=untie_weights)
     elif "phi" in config.name:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,25 +33,6 @@ def test_config():
     assert config.name == "pythia-14m"
 
 
-def test_legacy_args(tmp_path):
-    from lit_gpt import Config
-
-    config = Config.from_name("pythia-14m", condense_ratio=2)
-    assert not hasattr(config, "condense_ratio")
-    assert config.rope_condense_ratio == 2
-
-    json_path = tmp_path / "config.json"
-    with open(json_path, "w") as fp:
-        json.dump({"condense_ratio": 3}, fp)
-
-    config = Config.from_json(json_path)
-    assert not hasattr(config, "condense_ratio")
-    assert config.rope_condense_ratio == 3
-    config = Config.from_json(json_path, condense_ratio=2)
-    assert not hasattr(config, "condense_ratio")
-    assert config.rope_condense_ratio == 2
-
-
 def test_from_hf_name():
     from lit_gpt import Config
 
@@ -60,23 +41,6 @@ def test_from_hf_name():
     # or by huggingface hub repo name
     config1 = Config.from_name("TinyLlama-1.1B-intermediate-step-1431k-3T")
     assert config0 == config1
-
-
-def test_hf_config_from_json(tmp_path):
-    """Test for backward compatibility with older configs that didn't have the `hf_config` field."""
-    from lit_gpt import Config
-
-    legacy_config = {"name": "falcon-40b", "org": "tiiuae"}
-    with open(tmp_path / "config.json", "w") as file:
-        json.dump(legacy_config, file)
-    new_config = Config.from_json(tmp_path / "config.json")
-    assert new_config.name == "falcon-40b"
-    assert not hasattr(new_config, "org")
-    assert new_config.hf_config["org"] == "tiiuae"
-    assert new_config.hf_config["name"] == "falcon-40b"
-
-    new_config = Config.from_json(tmp_path / "config.json", org="new-org")
-    assert new_config.hf_config["org"] == "new-org"
 
 
 @pytest.mark.parametrize("config", config_module.configs, ids=[c["name"] for c in config_module.configs])

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -265,7 +265,7 @@ def test_lora_linear_utilization(apply_to, target_layer_names, mlp_class_name):
         r=2,
         alpha=8,
         dropout=0.1,
-        _mlp_class=mlp_class_name,
+        mlp_class_str=mlp_class_name,
         intermediate_size=8 * 3,
         **{apply_to: True},
     )

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -265,7 +265,7 @@ def test_lora_linear_utilization(apply_to, target_layer_names, mlp_class_name):
         r=2,
         alpha=8,
         dropout=0.1,
-        mlp_class_str=mlp_class_name,
+        mlp_class_name=mlp_class_name,
         intermediate_size=8 * 3,
         **{apply_to: True},
     )


### PR DESCRIPTION
Fixes #979

This is a breaking change, so I also included removal for some legacy args. Checkpoint configs will need to be regenerated. I believe this is okay since everything has changed anyways