### PR TITLE
Reuse `cos.device` in `reset_parameters`

### DIFF
--- a/lit_gpt/model.py
+++ b/lit_gpt/model.py
@@ -59,7 +59,7 @@ class GPT(nn.Module):
 
     def reset_parameters(self) -> None:
         # Trigger resetting the rope-cache
-        self.cos, self.sin = self.rope_cache()
+        self.cos, self.sin = self.rope_cache(device=self.cos.device)
 
     def _init_weights(self, module: nn.Module) -> None:
         """Meant to be used with `gpt.apply(gpt._init_weights)`."""


### PR DESCRIPTION
If FSDP didn't move the entire module to the device after materializing, this would get created on CPU