### PR TITLE
mkdir in convert_lit_checkpoint

### DIFF
--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -1,7 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import gc
-import os
 import sys
 from functools import partial
 from pathlib import Path

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -247,7 +247,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path: Path) -> None:
     config = Config.from_json(config_path)
 
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     if "falcon" in config.name:
         copy_fn = partial(copy_weights_falcon, config.name)

--- a/scripts/convert_lit_checkpoint.py
+++ b/scripts/convert_lit_checkpoint.py
@@ -1,6 +1,7 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import gc
+import os
 import sys
 from functools import partial
 from pathlib import Path
@@ -246,6 +247,8 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_path: Path, output_path: Path, config_path: Path) -> None:
     config = Config.from_json(config_path)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     if "falcon" in config.name:
         copy_fn = partial(copy_weights_falcon, config.name)

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -123,8 +123,6 @@ python scripts/merge_lora.py \
 5. Convert the finetuning model back into a HF format:
 
 ```bash
-mkdir out/hf-tinyllama
-
 python scripts/convert_lit_checkpoint.py \
    --checkpoint_path $finetuned_dir/merged/lit_model.pth \
    --output_path out/hf-tinyllama/converted_model.pth \

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -123,6 +123,8 @@ python scripts/merge_lora.py \
 5. Convert the finetuning model back into a HF format:
 
 ```bash
+mkdir out/hf-tinyllama
+
 python scripts/convert_lit_checkpoint.py \
    --checkpoint_path $finetuned_dir/merged/lit_model.pth \
    --output_path out/hf-tinyllama/converted_model.pth \


### PR DESCRIPTION
This was missing a `mkdir out/hf-tinyllama` to make the code fully reproducible