### PR TITLE
Save the hyperparameters to the checkpoint

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -33,6 +33,7 @@ from lit_gpt.utils import (
     CycleIterator,
     parse_devices,
     copy_config_files,
+    save_hyperparameters,
 )
 
 
@@ -145,6 +146,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_adapter_checkpoint(fabric, model, save_path)
     # Copy checkpoint files from original checkpoint dir
     copy_config_files(checkpoint_dir, save_path.parent)
+    save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -224,6 +226,7 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_adapter_checkpoint(fabric, model, checkpoint_file)
             copy_config_files(checkpoint_dir, checkpoint_file.parent)
+            save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -144,9 +144,10 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_path = out_dir / "final" / "lit_model.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)
     save_adapter_checkpoint(fabric, model, save_path)
-    # Copy checkpoint files from original checkpoint dir
-    copy_config_files(checkpoint_dir, save_path.parent)
-    save_hyperparameters(setup, save_path.parent)
+    if fabric.global_rank == 0:
+        # Copy checkpoint files from original checkpoint dir
+        copy_config_files(checkpoint_dir, save_path.parent)
+        save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -225,8 +226,9 @@ def fit(
             checkpoint_file = out_dir / f"iter-{iter_num:06d}" / "lit_model.pth"
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_adapter_checkpoint(fabric, model, checkpoint_file)
-            copy_config_files(checkpoint_dir, checkpoint_file.parent)
-            save_hyperparameters(setup, checkpoint_file.parent)
+            if fabric.global_rank == 0:
+                copy_config_files(checkpoint_dir, checkpoint_file.parent)
+                save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -33,6 +33,7 @@ from lit_gpt.utils import (
     CycleIterator,
     parse_devices,
     copy_config_files,
+    save_hyperparameters,
 )
 
 
@@ -145,6 +146,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_adapter_v2_checkpoint(fabric, model, save_path)
     # Copy checkpoint files from original checkpoint dir
     copy_config_files(checkpoint_dir, save_path.parent)
+    save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -224,6 +226,7 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_adapter_v2_checkpoint(fabric, model, checkpoint_file)
             copy_config_files(checkpoint_dir, checkpoint_file.parent)
+            save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -144,9 +144,10 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_path = out_dir / "final" / "lit_model.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)
     save_adapter_v2_checkpoint(fabric, model, save_path)
-    # Copy checkpoint files from original checkpoint dir
-    copy_config_files(checkpoint_dir, save_path.parent)
-    save_hyperparameters(setup, save_path.parent)
+    if fabric.global_rank == 0:
+        # Copy checkpoint files from original checkpoint dir
+        copy_config_files(checkpoint_dir, save_path.parent)
+        save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -225,8 +226,9 @@ def fit(
             checkpoint_file = out_dir / f"iter-{iter_num:06d}" / "lit_model.pth"
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_adapter_v2_checkpoint(fabric, model, checkpoint_file)
-            copy_config_files(checkpoint_dir, checkpoint_file.parent)
-            save_hyperparameters(setup, checkpoint_file.parent)
+            if fabric.global_rank == 0:
+                copy_config_files(checkpoint_dir, checkpoint_file.parent)
+                save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -34,6 +34,7 @@ from lit_gpt.utils import (
     CycleIterator,
     parse_devices,
     copy_config_files,
+    save_hyperparameters,
 )
 
 
@@ -139,6 +140,7 @@ def main(
     fabric.save(save_path, {"model": state["model"]})
     # Copy checkpoint files from original checkpoint dir
     copy_config_files(checkpoint_dir, save_path.parent)
+    save_hyperparameters(setup, checkpoint_dir)
 
 
 def fit(
@@ -243,6 +245,7 @@ def fit(
             fabric.print(f"Saving checkpoint to {str(checkpoint_file.parent)!r}")
             fabric.save(checkpoint_file, state)
             copy_config_files(checkpoint_dir, checkpoint_file.parent)
+            save_hyperparameters(setup, checkpoint_dir)
 
 
 # FSDP has issues with `inference_mode`

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -138,9 +138,10 @@ def main(
     save_path = out_dir / "final" / "lit_model.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)
     fabric.save(save_path, {"model": state["model"]})
-    # Copy checkpoint files from original checkpoint dir
-    copy_config_files(checkpoint_dir, save_path.parent)
-    save_hyperparameters(setup, save_path.parent)
+    if fabric.global_rank == 0:
+        # Copy checkpoint files from original checkpoint dir
+        copy_config_files(checkpoint_dir, save_path.parent)
+        save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -244,8 +245,9 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             fabric.print(f"Saving checkpoint to {str(checkpoint_file.parent)!r}")
             fabric.save(checkpoint_file, state)
-            copy_config_files(checkpoint_dir, checkpoint_file.parent)
-            save_hyperparameters(setup, checkpoint_file.parent)
+            if fabric.global_rank == 0:
+                copy_config_files(checkpoint_dir, checkpoint_file.parent)
+                save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -140,7 +140,7 @@ def main(
     fabric.save(save_path, {"model": state["model"]})
     # Copy checkpoint files from original checkpoint dir
     copy_config_files(checkpoint_dir, save_path.parent)
-    save_hyperparameters(setup, checkpoint_dir)
+    save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -245,7 +245,7 @@ def fit(
             fabric.print(f"Saving checkpoint to {str(checkpoint_file.parent)!r}")
             fabric.save(checkpoint_file, state)
             copy_config_files(checkpoint_dir, checkpoint_file.parent)
-            save_hyperparameters(setup, checkpoint_dir)
+            save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -33,6 +33,7 @@ from lit_gpt.utils import (
     CycleIterator,
     parse_devices,
     copy_config_files,
+    save_hyperparameters,
 )
 
 
@@ -176,6 +177,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_lora_checkpoint(fabric, model, save_path)
     # Copy checkpoint files from original checkpoint dir
     copy_config_files(checkpoint_dir, save_path.parent)
+    save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -255,6 +257,7 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_lora_checkpoint(fabric, model, checkpoint_file)
             copy_config_files(checkpoint_dir, checkpoint_file.parent)
+            save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -175,9 +175,10 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
     save_path = out_dir / "final" / "lit_model.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)
     save_lora_checkpoint(fabric, model, save_path)
-    # Copy checkpoint files from original checkpoint dir
-    copy_config_files(checkpoint_dir, save_path.parent)
-    save_hyperparameters(setup, save_path.parent)
+    if fabric.global_rank == 0:
+        # Copy checkpoint files from original checkpoint dir
+        copy_config_files(checkpoint_dir, save_path.parent)
+        save_hyperparameters(setup, save_path.parent)
 
 
 def fit(
@@ -256,8 +257,9 @@ def fit(
             checkpoint_file = out_dir / f"iter-{iter_num:06d}" / "lit_model.pth"
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             save_lora_checkpoint(fabric, model, checkpoint_file)
-            copy_config_files(checkpoint_dir, checkpoint_file.parent)
-            save_hyperparameters(setup, checkpoint_file.parent)
+            if fabric.global_rank == 0:
+                copy_config_files(checkpoint_dir, checkpoint_file.parent)
+                save_hyperparameters(setup, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/lit_gpt/pretrain.py
+++ b/lit_gpt/pretrain.py
@@ -269,9 +269,10 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             fabric.print(f"Saving checkpoint to {str(checkpoint_file)!r}")
             fabric.save(checkpoint_file, state)
-            save_hyperparameters(setup, checkpoint_file.parent)
-            if tokenizer_dir is not None:
-                copy_config_files(tokenizer_dir, checkpoint_file.parent)
+            if fabric.global_rank == 0:
+                save_hyperparameters(setup, checkpoint_file.parent)
+                if tokenizer_dir is not None:
+                    copy_config_files(tokenizer_dir, checkpoint_file.parent)
 
 
 @torch.no_grad()

--- a/lit_gpt/pretrain.py
+++ b/lit_gpt/pretrain.py
@@ -23,7 +23,7 @@ from lit_gpt import Tokenizer
 from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import LitDataModule, TinyLlama
 from lit_gpt.model import GPT, Block, CausalSelfAttention, Config, LLaMAMLP
-from lit_gpt.utils import CLI, CycleIterator, chunked_cross_entropy, num_parameters, parse_devices, copy_config_files
+from lit_gpt.utils import CLI, CycleIterator, chunked_cross_entropy, num_parameters, parse_devices, copy_config_files, save_hyperparameters
 
 
 def setup(
@@ -269,6 +269,7 @@ def fit(
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
             fabric.print(f"Saving checkpoint to {str(checkpoint_file)!r}")
             fabric.save(checkpoint_file, state)
+            save_hyperparameters(setup, checkpoint_file.parent)
             if tokenizer_dir is not None:
                 copy_config_files(tokenizer_dir, checkpoint_file.parent)
 

--- a/lit_gpt/utils.py
+++ b/lit_gpt/utils.py
@@ -395,6 +395,15 @@ def CLI(*args: Any, **kwargs: Any) -> Any:
     return CLI(*args, **kwargs)
 
 
+def save_hyperparameters(function: callable, checkpoint_dir: Path) -> None:
+    """Captures the CLI parameters passed to `function` without running `function` and saves them to the checkpoint."""
+    from jsonargparse import capture_parser
+
+    parser = capture_parser(lambda: CLI(function))
+    config = parser.parse_args()
+    parser.save(config, checkpoint_dir / "hyperparameters.yaml", overwrite=True)
+
+
 def parse_devices(devices: Union[str, int]) -> int:
     if devices in (-1, "auto"):
         return torch.cuda.device_count() or 1

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -167,7 +167,7 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -68,7 +68,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,
@@ -93,6 +93,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
             "lit_config.json",
             "tokenizer_config.json",
             "tokenizer.json",
+            "hyperparameters.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -91,7 +91,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,
@@ -116,6 +116,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
             "lit_config.json",
             "tokenizer_config.json",
             "tokenizer.json",
+            "hyperparameters.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -256,7 +256,7 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alp
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -40,7 +40,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
         eval=EvalArgs(interval=2, max_iters=2, max_new_tokens=1),
     )
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["full.py"]):
         module.setup(**setup_kwargs)
 
     out_dir_contents = set(os.listdir(out_dir))
@@ -48,7 +48,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     assert checkpoint_dirs.issubset(out_dir_contents)
     assert all((out_dir / p).is_dir() for p in checkpoint_dirs)
     for checkpoint_dir in checkpoint_dirs:
-        assert {os.listdir(out_dir / checkpoint_dir)} == {
+        assert set(os.listdir(out_dir / checkpoint_dir)) == {
             "lit_model.pth",
             "lit_config.json",
             "tokenizer_config.json",
@@ -66,7 +66,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     setup_kwargs["train"].max_steps = 8
     setup_kwargs["resume"] = True
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["full.py"]):
         module.setup(**setup_kwargs)
     logs = stdout.getvalue()
     assert f"Resuming training from {out_dir / 'step-000006' / 'lit_model.pth'}" in logs

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -48,11 +48,12 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     assert checkpoint_dirs.issubset(out_dir_contents)
     assert all((out_dir / p).is_dir() for p in checkpoint_dirs)
     for checkpoint_dir in checkpoint_dirs:
-        assert {p.name for p in (out_dir / checkpoint_dir).iterdir()} == {
+        assert {os.listdir(out_dir / checkpoint_dir)} == {
             "lit_model.pth",
             "lit_config.json",
             "tokenizer_config.json",
             "tokenizer.json",
+            "hyperparameters.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -625,7 +625,7 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["full.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -198,7 +198,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["lora.py"]):
         module.setup(
             data=Alpaca(
                 download_dir=alpaca_path.parent,
@@ -223,6 +223,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
             "lit_config.json",
             "tokenizer_config.json",
             "tokenizer.json",
+            "hyperparameters.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -27,7 +27,7 @@ def test_pretrain(tmp_path, monkeypatch):
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["pretrain.py"]):
         pretrain.setup(
             devices=2,
             model=model_config,
@@ -44,7 +44,7 @@ def test_pretrain(tmp_path, monkeypatch):
         assert all((out_dir / p).is_dir() for p in checkpoint_dirs)
         for checkpoint_dir in checkpoint_dirs:
             # the `tokenizer_dir` is None by default, so only 'lit_model.pth' shows here
-            assert {p.name for p in (out_dir / checkpoint_dir).iterdir()} == {"lit_model.pth"}
+            assert set(os.listdir(out_dir / checkpoint_dir)) == {"lit_model.pth", "hyperparameters.yaml"}
 
         # logs only appear on rank 0
         logs = stdout.getvalue()

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -14,7 +14,11 @@ from torch.utils.data import DataLoader
 @RunIf(min_cuda_gpus=2, standalone=True)
 # Set CUDA_VISIBLE_DEVICES for FSDP hybrid-shard, if fewer GPUs are used than are available
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
-def test_pretrain(tmp_path, monkeypatch):
+# If we were to use `save_hyperparameters()`, we would have to patch `sys.argv` or otherwise
+# the CLI would capture pytest args, but unfortunately patching would mess with subprocess
+# launching, so we need to mock `save_hyperparameters()`
+@mock.patch("lit_gpt.pretrain.save_hyperparameters")
+def test_pretrain(_, tmp_path):
     from lit_gpt import pretrain
     from lit_gpt.args import EvalArgs, TrainArgs
     from lit_gpt.config import Config
@@ -27,7 +31,7 @@ def test_pretrain(tmp_path, monkeypatch):
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["pretrain.py"]):
+    with redirect_stdout(stdout):
         pretrain.setup(
             devices=2,
             model=model_config,
@@ -44,7 +48,7 @@ def test_pretrain(tmp_path, monkeypatch):
         assert all((out_dir / p).is_dir() for p in checkpoint_dirs)
         for checkpoint_dir in checkpoint_dirs:
             # the `tokenizer_dir` is None by default, so only 'lit_model.pth' shows here
-            assert set(os.listdir(out_dir / checkpoint_dir)) == {"lit_model.pth", "hyperparameters.yaml"}
+            assert set(os.listdir(out_dir / checkpoint_dir)) == {"lit_model.pth"}
 
         # logs only appear on rank 0
         logs = stdout.getvalue()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,13 +3,17 @@
 import os
 from contextlib import redirect_stderr
 from io import StringIO
+from pathlib import Path
 from unittest import mock
 
 import pytest
 import torch
 import torch.nn.functional as F
+import yaml
+
 from conftest import RunIf
 from lightning import Fabric
+from lit_gpt.utils import save_hyperparameters, CLI
 
 
 def test_find_multiple():
@@ -222,3 +226,19 @@ def test_copy_config_files(fake_checkpoint_dir, tmp_path):
     }
     contents = set(os.listdir(tmp_path))
     assert expected.issubset(contents)
+
+
+def _test_function(out_dir: Path, foo: bool = False, bar: int = 1):
+    save_hyperparameters(_test_function, out_dir)
+
+
+def test_save_hyperparameters(tmp_path):
+    with mock.patch("sys.argv", ["any.py", "--out_dir", str(tmp_path), "--foo", "True"]):
+        CLI(_test_function)
+
+    with open(tmp_path / "hyperparameters.yaml", "r") as file:
+        hparams = yaml.full_load(file)
+
+    assert hparams["out_dir"] == str(tmp_path)
+    assert hparams["foo"] is True
+    assert hparams["bar"] == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@ import yaml
 
 from conftest import RunIf
 from lightning import Fabric
-from lit_gpt.utils import save_hyperparameters, CLI
 
 
 def test_find_multiple():
@@ -229,10 +228,14 @@ def test_copy_config_files(fake_checkpoint_dir, tmp_path):
 
 
 def _test_function(out_dir: Path, foo: bool = False, bar: int = 1):
+    from lit_gpt.utils import save_hyperparameters
+
     save_hyperparameters(_test_function, out_dir)
 
 
 def test_save_hyperparameters(tmp_path):
+    from lit_gpt.utils import CLI
+
     with mock.patch("sys.argv", ["any.py", "--out_dir", str(tmp_path), "--foo", "True"]):
         CLI(_test_function)
 


### PR DESCRIPTION
Saves a hyperparameters.yaml file to the checkpoint. Feel free to discuss the naming on this PR.

This will also be used to store the prompt template so that it can be dynamically loaded from the checkpoint after finetuning.

Part of #1005
