### PR TITLE
Save and load prompt style automatically

### DIFF
--- a/chat/base.py
+++ b/chat/base.py
@@ -15,6 +15,7 @@ sys.path.append(str(wd))
 
 from generate.base import next_token
 from lit_gpt import GPT, Config, PromptStyle, Tokenizer
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
@@ -157,7 +158,7 @@ def main(
     model = fabric.setup_module(model)
 
     tokenizer = Tokenizer(checkpoint_dir)
-    prompt_style = PromptStyle.from_config(config)
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
     stop_tokens = prompt_style.stop_tokens(tokenizer)
 
     L.seed_everything(1234)

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -22,6 +22,7 @@ from generate.base import generate
 from lit_gpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
 from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import Alpaca, LitDataModule
+from lit_gpt.prompts import save_prompt_style
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
     CLI,
@@ -148,6 +149,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
         # Copy checkpoint files from original checkpoint dir
         copy_config_files(checkpoint_dir, save_path.parent)
         save_hyperparameters(setup, save_path.parent)
+        save_prompt_style(data.prompt_style, save_path.parent)
 
 
 def fit(
@@ -229,6 +231,7 @@ def fit(
             if fabric.global_rank == 0:
                 copy_config_files(checkpoint_dir, checkpoint_file.parent)
                 save_hyperparameters(setup, checkpoint_file.parent)
+                save_prompt_style(data.prompt_style, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -22,6 +22,7 @@ from generate.base import generate
 from lit_gpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_adapter_v2_as_trainable
 from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import Alpaca, LitDataModule
+from lit_gpt.prompts import save_prompt_style
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
     CLI,
@@ -148,6 +149,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
         # Copy checkpoint files from original checkpoint dir
         copy_config_files(checkpoint_dir, save_path.parent)
         save_hyperparameters(setup, save_path.parent)
+        save_prompt_style(data.prompt_style, save_path.parent)
 
 
 def fit(
@@ -229,6 +231,7 @@ def fit(
             if fabric.global_rank == 0:
                 copy_config_files(checkpoint_dir, checkpoint_file.parent)
                 save_hyperparameters(setup, checkpoint_file.parent)
+                save_prompt_style(data.prompt_style, checkpoint_file.parent)
 
 
 # the adapter "kv cache" cannot be initialized under `inference_mode`

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -24,6 +24,7 @@ from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.model import GPT, Block, Config
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.data import Alpaca, LitDataModule
+from lit_gpt.prompts import save_prompt_style
 from lit_gpt.utils import (
     CLI,
     check_valid_checkpoint_dir,
@@ -142,6 +143,7 @@ def main(
         # Copy checkpoint files from original checkpoint dir
         copy_config_files(checkpoint_dir, save_path.parent)
         save_hyperparameters(setup, save_path.parent)
+        save_prompt_style(data.prompt_style, save_path.parent)
 
 
 def fit(
@@ -248,6 +250,7 @@ def fit(
             if fabric.global_rank == 0:
                 copy_config_files(checkpoint_dir, checkpoint_file.parent)
                 save_hyperparameters(setup, checkpoint_file.parent)
+                save_prompt_style(data.prompt_style, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -22,6 +22,7 @@ from generate.base import generate
 from lit_gpt.args import EvalArgs, TrainArgs
 from lit_gpt.data import LitDataModule, Alpaca
 from lit_gpt.lora import GPT, Block, Config, lora_filter, mark_only_lora_as_trainable
+from lit_gpt.prompts import save_prompt_style
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import (
     CLI,
@@ -179,6 +180,7 @@ def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDat
         # Copy checkpoint files from original checkpoint dir
         copy_config_files(checkpoint_dir, save_path.parent)
         save_hyperparameters(setup, save_path.parent)
+        save_prompt_style(data.prompt_style, save_path.parent)
 
 
 def fit(
@@ -260,6 +262,7 @@ def fit(
             if fabric.global_rank == 0:
                 copy_config_files(checkpoint_dir, checkpoint_file.parent)
                 save_hyperparameters(setup, checkpoint_file.parent)
+                save_prompt_style(data.prompt_style, checkpoint_file.parent)
 
 
 # FSDP has issues with `inference_mode`

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -14,10 +14,11 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt import Tokenizer
+from lit_gpt import Tokenizer, PromptStyle
 from lit_gpt.adapter import GPT, Config
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
-from lit_gpt.prompts import Alpaca
+
 
 
 def main(
@@ -71,9 +72,8 @@ def main(
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 
     tokenizer = Tokenizer(checkpoint_dir)
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
 
-    # TODO: Load prompt style from checkpoint and apply it here
-    prompt_style = Alpaca()
     prompt = prompt_style.apply(prompt, input=input)
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -14,9 +14,9 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt import Tokenizer
+from lit_gpt import Tokenizer, PromptStyle
 from lit_gpt.adapter_v2 import GPT, Config
-from lit_gpt.prompts import Alpaca
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 
 
@@ -71,8 +71,8 @@ def main(
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 
     tokenizer = Tokenizer(checkpoint_dir)
-    # TODO: Load prompt style from checkpoint and apply it here
-    prompt_style = Alpaca()
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
+
     prompt = prompt_style.apply(prompt, input=input)
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)

--- a/generate/base.py
+++ b/generate/base.py
@@ -15,7 +15,8 @@ from lightning.fabric.plugins import BitsandbytesPrecision
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from lit_gpt import GPT, Config, Tokenizer
+from lit_gpt import GPT, Config, Tokenizer, PromptStyle
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
@@ -142,7 +143,8 @@ def main(
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 
     tokenizer = Tokenizer(checkpoint_dir)
-    # TODO: Load prompt style from checkpoint and apply it here
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
+
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)
     max_returned_tokens = prompt_length + max_new_tokens

--- a/generate/full.py
+++ b/generate/full.py
@@ -14,8 +14,8 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt import GPT, Config, Tokenizer
-from lit_gpt.prompts import Alpaca
+from lit_gpt import GPT, Config, Tokenizer, PromptStyle
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 
 
@@ -71,8 +71,8 @@ def main(
     checkpoint_path = finetuned_path
 
     tokenizer = Tokenizer(checkpoint_dir)
-    # TODO: Load prompt style from checkpoint and apply it here
-    prompt_style = Alpaca()
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
+
     prompt = prompt_style.apply(prompt, input=input)
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -14,9 +14,9 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from generate.base import generate
-from lit_gpt import Tokenizer
+from lit_gpt import Tokenizer, PromptStyle
 from lit_gpt.lora import GPT, Config, merge_lora_weights
-from lit_gpt.prompts import Alpaca
+from lit_gpt.prompts import load_prompt_style, has_prompt_style
 from lit_gpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
 
 
@@ -91,8 +91,8 @@ def main(
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 
     tokenizer = Tokenizer(checkpoint_dir)
-    # TODO: Load prompt style from checkpoint and apply it here
-    prompt_style = Alpaca()
+    prompt_style = load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
+
     prompt = prompt_style.apply(prompt, input=input)
     encoded = tokenizer.encode(prompt, device=fabric.device)
     prompt_length = encoded.size(0)

--- a/lit_gpt/prompts.py
+++ b/lit_gpt/prompts.py
@@ -350,3 +350,7 @@ def load_prompt_style(checkpoint_dir: Path) -> PromptStyle:
     module = importlib.import_module(full_module_path)
     cls = getattr(module, cls_name)
     return cls()
+
+
+def has_prompt_style(checkpoint_dir: Path) -> bool:
+    return (checkpoint_dir / "prompt_style.json").is_file()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -94,6 +94,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
+            "prompt_style.json",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -117,6 +117,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
+            "prompt_style.json",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -54,6 +54,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
+            "prompt_style.json",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -224,6 +224,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
+            "prompt_style.json",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -90,12 +90,14 @@ class CustomPromptStyle(PromptStyle):
 
 
 def test_save_load_prompt_style(tmp_path):
-    from lit_gpt.prompts import Alpaca, save_prompt_style, load_prompt_style
+    from lit_gpt.prompts import Alpaca, save_prompt_style, load_prompt_style, has_prompt_style
 
     # Save and load a built-in style
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
+    assert not has_prompt_style(checkpoint_dir)
     save_prompt_style("alpaca", checkpoint_dir)
+    assert has_prompt_style(checkpoint_dir)
     with open(checkpoint_dir / "prompt_style.json", "r") as file:
         contents = json.load(file)
     assert contents == {"class_path": "lit_gpt.prompts.Alpaca"}


### PR DESCRIPTION
Fixes #969
Fixes #954
Fixes #825

After this PR, you will be able to finetune

```
python finetune/full.py --config ...
```

and directly use the checkpoint:

```
python chat/base.py --checkpoint_dir out/finetune/full/final
```

Now you actually get the correct prompt style that you used for finetuning (e.g. Alpaca). On main, it does not apply the prompt style, you had to hard code it into chat.py, generate.py etc. if you wanted to use your checkpoint in Lit-GPT.